### PR TITLE
Completion reports

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -10,7 +10,7 @@ from werkzeug.datastructures import MultiDict
 import cubedash
 import datacube
 from datacube.scripts.dataset import build_dataset_info
-from . import _filters, _dataset, _product, _platform, _api, _model
+from . import _filters, _dataset, _product, _platform, _api, _model, _reports
 from . import _utils as utils
 from ._utils import as_json
 
@@ -20,6 +20,7 @@ app.register_blueprint(_api.bp)
 app.register_blueprint(_dataset.bp)
 app.register_blueprint(_product.bp)
 app.register_blueprint(_platform.bp)
+app.register_blueprint(_reports.bp)
 
 _LOG = structlog.getLogger()
 

--- a/cubedash/_reports.py
+++ b/cubedash/_reports.py
@@ -40,7 +40,7 @@ def report_products_page(product_name_list: str = None,
     )
 
 
-# @app.route(/reports/time
+# @app.route('/reports/time')
 @bp.route('/time')
 @bp.route('/time/<int:year>')
 @bp.route('/time/<int:year>/<int:month>')
@@ -48,8 +48,55 @@ def reports_time_page(year: int = None,
                       month: int = None):
     return flask.render_template(
         'reports-time.html',
+        report_type='',
         year=year,
         month=month
+    )
+
+
+# @app.route('/reports/time')
+@bp.route('differences/time')
+@bp.route('differences/time/<int:year>')
+@bp.route('differences/time/<int:year>/<int:month>')
+def differences_time_page(year: int = None,
+                          month: int = None):
+    return flask.render_template(
+        'reports-time.html',
+        report_type='Differences',
+        year=year,
+        month=month
+    )
+
+
+# @app.route('/reports/differences')
+@bp.route('/differences/<product_name_list>')
+@bp.route('/differences/<product_name_list>/<int:year>')
+@bp.route('/differences/<product_name_list>/<int:year>/<int:month>')
+@bp.route('/differences/<product_name_list>/<int:year>/<int:month>/<int:day>')
+def differences(product_name_list: str = None,
+                year: int = None,
+                month: int = None,
+                day: int = None):
+    product_names = re.split('\+', product_name_list)
+    product_1, product_summary_1, selected_summary_1 = _load_product(product_names[0], year, month, day)
+    product_2, product_summary_2, selected_summary_2 = _load_product(product_names[1], year, month, day)
+    product = lambda: None
+    product.name = product_names[0] + '-' + product_names[1]
+    diff_counts = (selected_summary_1.dataset_counts - selected_summary_2.dataset_counts) + \
+                  (selected_summary_2.dataset_counts - selected_summary_1.dataset_counts)
+    selected_summary = lambda: None
+    selected_summary.dataset_counts = diff_counts
+    selected_summary.dataset_count = sum(diff_counts.values())
+    selected_summary.period = selected_summary_1.period
+    products = []
+    product_summary = None
+    products.append({'product': product, 'product_summary': product_summary, 'selected_summary': selected_summary})
+    return flask.render_template(
+        'product_summary.html',
+        year=year,
+        month=month,
+        day=day,
+        products=products,
     )
 
 

--- a/cubedash/_reports.py
+++ b/cubedash/_reports.py
@@ -40,31 +40,21 @@ def report_products_page(product_name_list: str = None,
     )
 
 
-# @app.route('/reports/time')
-@bp.route('/time')
-@bp.route('/time/<int:year>')
-@bp.route('/time/<int:year>/<int:month>')
-def reports_time_page(year: int = None,
-                      month: int = None):
+# @app.route('/reports/time/report_type')
+@bp.route('time/<report_type>')
+@bp.route('time/<report_type>/<int:year>')
+@bp.route('time/<report_type>/<int:year>/<int:month>')
+@bp.route('time/<report_type>/<int:year>/<int:month>/<int:day>')
+def reports_time_page(report_type='',
+                      year: int = None,
+                      month: int = None,
+                      day: int = None):
     return flask.render_template(
         'reports-time.html',
-        report_type='',
+        report_type=report_type,
         year=year,
-        month=month
-    )
-
-
-# @app.route('/reports/time')
-@bp.route('differences/time')
-@bp.route('differences/time/<int:year>')
-@bp.route('differences/time/<int:year>/<int:month>')
-def differences_time_page(year: int = None,
-                          month: int = None):
-    return flask.render_template(
-        'reports-time.html',
-        report_type='Differences',
-        year=year,
-        month=month
+        month=month,
+        day=day
     )
 
 

--- a/cubedash/_reports.py
+++ b/cubedash/_reports.py
@@ -1,0 +1,67 @@
+import logging
+import flask
+from flask import Blueprint, abort
+import re
+from . import _model
+
+_LOG = logging.getLogger(__name__)
+bp = Blueprint('reports', __name__, url_prefix='/reports')
+
+
+# @app.route('/reports')
+@bp.route('/')
+def reports_page():
+    return flask.render_template(
+        'reports.html'
+    )
+
+
+# @app.route('/reports')
+@bp.route('/<product_name_list>')
+@bp.route('/<product_name_list>/<int:year>')
+@bp.route('/<product_name_list>/<int:year>/<int:month>')
+@bp.route('/<product_name_list>/<int:year>/<int:month>/<int:day>')
+def report_products_page(product_name_list: str = None,
+                         year: int = None,
+                         month: int = None,
+                         day: int = None):
+    product_names = re.split('\+', product_name_list)
+    products = []
+    for product_name in product_names:
+        product, product_summary, selected_summary = _load_product(product_name, year, month, day)
+        products.append({'product': product, 'product_summary': product_summary, 'selected_summary': selected_summary})
+
+    return flask.render_template(
+        'product_summary.html',
+        year=year,
+        month=month,
+        day=day,
+        products=products,
+    )
+
+
+# @app.route(/reports/time
+@bp.route('/time')
+@bp.route('/time/<int:year>')
+@bp.route('/time/<int:year>/<int:month>')
+def reports_time_page(year: int = None,
+                      month: int = None):
+    return flask.render_template(
+        'reports-time.html',
+        year=year,
+        month=month
+    )
+
+
+def _load_product(product_name, year, month, day):
+    product = None
+    if product_name:
+        product = _model.index.products.get_by_name(product_name)
+        if not product:
+            abort(404, "Unknown product %r" % product_name)
+
+    # Entire summary for the product.
+    product_summary = _model.get_summary(product_name)
+    selected_summary = _model.get_summary(product_name, year, month, day)
+
+    return product, product_summary, selected_summary

--- a/cubedash/_reports.py
+++ b/cubedash/_reports.py
@@ -25,7 +25,7 @@ def report_products_page(product_name_list: str = None,
                          year: int = None,
                          month: int = None,
                          day: int = None):
-    product_names = re.split('\+', product_name_list)
+    product_names = re.split(r'\+', product_name_list)
     products = []
     for product_name in product_names:
         product, product_summary, selected_summary = _load_product(product_name, year, month, day)
@@ -77,7 +77,7 @@ def differences(product_name_list: str = None,
                 year: int = None,
                 month: int = None,
                 day: int = None):
-    product_names = re.split('\+', product_name_list)
+    product_names = re.split(r'\+', product_name_list)
     product_1, product_summary_1, selected_summary_1 = _load_product(product_names[0], year, month, day)
     product_2, product_summary_2, selected_summary_2 = _load_product(product_names[1], year, month, day)
     product = lambda: None

--- a/cubedash/templates/layout/base-reports.html
+++ b/cubedash/templates/layout/base-reports.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>{% block title %}{% endblock %}</title>
+
+    <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}">
+    <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
+    {% block head %}{% endblock %}
+</head>
+<body>
+<!--[if IE]>
+<div class='message-box'>
+    <p>
+        Your version of Internet Explorer is unsupported (requires 11+).
+    </p>
+    <p>
+        <a href="http://www.mozilla.com/firefox">Firefox</a> or Chrome are recommended.
+    </p>
+</div>
+<![endif]-->
+
+<div class="content-wrapper">
+    <div id="logo">
+        <a href="/">
+            <img src="{{ url_for('static', filename='dea-icon.svg') }}"
+                 height="26px" alt=""/>
+            <span class="logo-text"><strong>Digital Earth</strong> Australia</span>
+        </a>
+    </div>
+    <h3> Product Summaries </h3>
+    <div class="header-wrapper">
+        {% block header %}{% endblock %}
+    </div>
+    <div id="summary-content">
+        {% block summary_content %}{% endblock %}
+    </div>
+    <h3> Product differences </h3>
+    <div class="header-wrapper">
+        {% block diff_header %}{% endblock %}
+    </div>
+    <div id="diff-content">
+        {% block diff_content %}{% endblock %}
+    </div>
+</div>
+<footer>
+    Open Data Cube v{{ datacube_version }},
+    Dash v{{ app_version }}, <span id="map-attribution-text"></span><br/>
+    {% if last_updated_time %}
+        Updated {{ last_updated_time | timesince }}
+    {% endif %}
+    {% block footer %}{% endblock %}
+</footer>
+
+<script src="{{ url_for('static', filename='leaflet-1.3.1/leaflet.js') }}"></script>
+<script src="{{ url_for('static', filename='leaflet-groupedlayercontrol/leaflet.groupedlayercontrol.js') }}"></script>
+
+{% block body_footer %}{% endblock %}
+<script>
+    // If there's a map on the page, add layer attribution in the footer.
+    (function () {
+        var map = window.MAP;
+        if (map) {
+            var attributionEl = document.getElementById('map-attribution-text');
+
+            function updateAttribution(e) {
+                var attributions = Object.keys(map._layers).map(function (name) {
+                    var layer = map._layers[name];
+                    if (layer.getAttribution) {
+                        return layer.getAttribution();
+                    }
+                    return null;
+                });
+                var isDefined = function (a) {
+                    return a !== null;
+                };
+                var attributionText = new DOMParser().parseFromString(
+                    attributions.filter(isDefined).join(', '),
+                    'text/html'
+                ).body.textContent;
+                attributionEl.innerHTML = attributionText || "";
+            }
+
+            map.on("layeradd", updateAttribution);
+            map.on("layerremove", updateAttribution);
+            updateAttribution();
+        }
+    })();
+</script>
+</body>
+</html>

--- a/cubedash/templates/product_summary.html
+++ b/cubedash/templates/product_summary.html
@@ -1,0 +1,18 @@
+{% for p in products %}
+<div class="panel info-panel">
+    <div>
+        {{ p.product.name }}
+    </div>
+    <div>
+        {{ p.selected_summary.dataset_count }} datasets
+    </div>
+
+
+    {% from "layout/macros.html" import chart_timeline %}
+    {% if p.selected_summary.dataset_counts and (p.selected_summary.dataset_counts | length > 1) %}
+    <div>
+        {{ chart_timeline(p.selected_summary.dataset_counts, p.product, period=p.selected_summary.period) }}
+    </div>
+    {% endif %}
+</div>
+{% endfor %}

--- a/cubedash/templates/product_summary.html
+++ b/cubedash/templates/product_summary.html
@@ -1,18 +1,20 @@
-{% for p in products %}
-<div class="panel info-panel">
-    <div>
-        {{ p.product.name }}
-    </div>
-    <div>
-        {{ p.selected_summary.dataset_count }} datasets
-    </div>
+<div style="display: inline-flex">
+    {% for p in products %}
+    <div class="panel info-panel">
+        <div>
+            {{ p.product.name }}
+        </div>
+        <div>
+            {{ p.selected_summary.dataset_count }} datasets
+        </div>
 
 
-    {% from "layout/macros.html" import chart_timeline %}
-    {% if p.selected_summary.dataset_counts and (p.selected_summary.dataset_counts | length > 1) %}
-    <div>
-        {{ chart_timeline(p.selected_summary.dataset_counts, p.product, period=p.selected_summary.period) }}
+        {% from "layout/macros.html" import chart_timeline %}
+        {% if p.selected_summary.dataset_counts and (p.selected_summary.dataset_counts | length > 1) %}
+        <div>
+            {{ chart_timeline(p.selected_summary.dataset_counts, p.product, period=p.selected_summary.period) }}
+        </div>
+        {% endif %}
     </div>
-    {% endif %}
+    {% endfor %}
 </div>
-{% endfor %}

--- a/cubedash/templates/reports-time.html
+++ b/cubedash/templates/reports-time.html
@@ -1,5 +1,5 @@
 <div class="header-option" onclick="" style="max-width: 100%">
-    <h2 id="year-menu" class="option-title">
+    <h2 id="{{ report_type }}-year-menu" class="option-title">
         {{ year or 'All years' }}
     </h2>
     <div class="option-menu">
@@ -14,7 +14,7 @@
             <ul>
                 {% for year_opt in row %}
                     <li>
-                        <button onclick="setYear( {{ year_opt }} )">
+                        <button onclick="set{{ report_type }}Date('year', {{ year_opt }})">
                             {{ year_opt }}
                         </button>
                     </li>
@@ -30,7 +30,7 @@
 </div>
 {% if year %}
     <div class="header-option" onclick="">
-        <h2 id="month-menu" class="option-title">
+        <h2 id="{{ report_type }}-month-menu" class="option-title">
             {% if month %}
                 {{ month | month_name }}
             {% else %}
@@ -42,7 +42,7 @@
                 <ul>
                     {% for month_opt in row %}
                         <li>
-                            <button onclick="setMonth( {{ month_opt }} )">
+                            <button onclick="set{{ report_type}}Date('month', {{ month_opt }})">
                                 {{ month_opt | month_name }}
                             </button>
                         </li>
@@ -60,7 +60,7 @@
 
 {% if month %}
     <div class="header-option" onclick="">
-        <h2 id="day-menu" class="option-title">
+        <h2 id="{{ report_type }}-day-menu" class="option-title">
             {% if day %}
                 {{ day | day_ordinal }}
             {% else %}
@@ -72,7 +72,7 @@
                 <ul>
                     {% for day_opt in row %}
                         <li>
-                            <button onclick="setDay( {{ day_opt }} )">
+                            <button onclick="set{{ report_type }}Date('day', {{ day_opt }})">
                                 {{ day_opt | day_ordinal }}
                             </button>
                         </li>

--- a/cubedash/templates/reports-time.html
+++ b/cubedash/templates/reports-time.html
@@ -14,7 +14,7 @@
             <ul>
                 {% for year_opt in row %}
                     <li>
-                        <button onclick="set{{ report_type }}Date('year', {{ year_opt }})">
+                        <button onclick="{{ report_type }}Date('year', {{ year_opt }})">
                             {{ year_opt }}
                         </button>
                     </li>
@@ -22,7 +22,7 @@
             </ul>
         {% endfor %}
         <ul>
-            <li class="wildcard">
+            <li class="wildcard" onclick="{{ report_type }}Date('year', 'All')">
                 <strong>All</strong>
             </li>
         </ul>
@@ -42,7 +42,7 @@
                 <ul>
                     {% for month_opt in row %}
                         <li>
-                            <button onclick="set{{ report_type}}Date('month', {{ month_opt }})">
+                            <button onclick="{{ report_type}}Date('month', {{ month_opt }})">
                                 {{ month_opt | month_name }}
                             </button>
                         </li>
@@ -50,7 +50,7 @@
                 </ul>
             {% endfor %}
             <ul>
-                <li class="wildcard">
+                <li class="wildcard" onclick="{{ report_type }}Date('month', 'All')">
                     <strong>All</strong>
                 </li>
             </ul>
@@ -72,7 +72,7 @@
                 <ul>
                     {% for day_opt in row %}
                         <li>
-                            <button onclick="set{{ report_type }}Date('day', {{ day_opt }})">
+                            <button onclick="{{ report_type }}Date('day', {{ day_opt }})">
                                 {{ day_opt | day_ordinal }}
                             </button>
                         </li>
@@ -80,7 +80,7 @@
                 </ul>
             {% endfor %}
             <ul>
-                <li class="wildcard">
+                <li class="wildcard" onclick="{{ report_type }}Date('day', 'All')">
                     <strong>
                         All
                     </strong>

--- a/cubedash/templates/reports-time.html
+++ b/cubedash/templates/reports-time.html
@@ -1,0 +1,89 @@
+<div class="header-option" onclick="">
+    <h2 id="year-menu" class="option-title">{{ year or 'All years' }}</h2>
+    <div class="option-menu">
+
+        {% set year_range=(range(
+            product_summary.time_range.end.year,
+            product_summary.time_range.begin.year - 1,
+            -1
+        ) if (product_summary and product_summary.time_range) else range(current_time.year, 1985, -1)) %}
+
+        {% for row in year_range | batch(3) %}
+            <ul>
+                {% for year_opt in row %}
+                    <li>
+                        <button onclick="setYear( {{ year_opt }} )">
+                            {{ year_opt }}
+                        </button>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endfor %}
+        <ul>
+            <li class="wildcard">
+                <strong>All</strong>
+            </li>
+        </ul>
+    </div>
+</div>
+{% if year %}
+    <div class="header-option" onclick="">
+        <h2 id="month-menu" class="option-title">
+            {% if month %}
+                {{ month | month_name }}
+            {% else %}
+                All months
+            {% endif %}
+        </h2>
+        <div class="option-menu left">
+            {% for row in range(1, 13) | batch(3) %}
+                <ul>
+                    {% for month_opt in row %}
+                        <li>
+                            <button onclick="setMonth( {{ month_opt }} )">
+                                {{ month_opt | month_name }}
+                            </button>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endfor %}
+            <ul>
+                <li class="wildcard">
+                    <strong>All</strong>
+                </li>
+            </ul>
+        </div>
+    </div>
+{% endif %}
+
+{% if month %}
+    <div class="header-option" onclick="">
+        <h2 id="day-menu" class="option-title">
+            {% if day %}
+                {{ day | day_ordinal }}
+            {% else %}
+                All days
+            {% endif %}
+        </h2>
+        <div class="option-menu left">
+            {% for row in (year, month) | days_in_month | batch(3) %}
+                <ul>
+                    {% for day_opt in row %}
+                        <li>
+                            <button onclick="setDay( {{ day_opt }} )">
+                                {{ day_opt | day_ordinal }}
+                            </button>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endfor %}
+            <ul>
+                <li class="wildcard">
+                    <strong>
+                        All
+                    </strong>
+                </li>
+            </ul>
+        </div>
+    </div>
+{% endif %}

--- a/cubedash/templates/reports-time.html
+++ b/cubedash/templates/reports-time.html
@@ -1,5 +1,7 @@
-<div class="header-option" onclick="">
-    <h2 id="year-menu" class="option-title">{{ year or 'All years' }}</h2>
+<div class="header-option" onclick="" style="max-width: 100%">
+    <h2 id="year-menu" class="option-title">
+        {{ year or 'All years' }}
+    </h2>
     <div class="option-menu">
 
         {% set year_range=(range(

--- a/cubedash/templates/reports.html
+++ b/cubedash/templates/reports.html
@@ -1,8 +1,8 @@
-{% extends "layout/base.html" %}
+{% extends "layout/base-reports.html" %}
 
 {% block header %}
     <header>
-        <div class="header-option primary">
+        <div class="header-option primary" style="display: inline-flex">
             <h2 class="option-title" onclick="">
                 <strong> products </strong>
             </h2>
@@ -28,6 +28,67 @@
             </div>
         </div>
         <div id="time-picker" style="display: inline-flex">
+            {% set report_type = '' %}
+            {% include "reports-time.html" %}
+        </div>
+    </header>
+{% endblock %}
+
+{% block diff_header %}
+    <header>
+        <div class="header-option" onclick="" style="max-width: 100%">
+            <h2 class="option-title" onclick="">
+                <strong id="product-one" > product one </strong>
+            </h2>
+            <div class="option-menu">
+                {% for row in grouped_products | batch(3) %}
+                    <ul>
+                        {% for group_name, product_summaries in row %}
+                            <li>
+                                <h3 class="group-name">{{ group_name }}</h3>
+                                <ul class="items">
+                                    {% for product_opt, summary in product_summaries if summary %}
+                                        <li class="{% if summary.dataset_count == 0 %}empty{% endif %}">
+                                            <button onclick="addDiffsProduct('first', '{{ product_opt.name }}')">
+                                                {{ product_opt.name }}
+                                            </button>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endfor %}
+            </div>
+        </div>
+
+        <div class="header-option" onclick="" style="max-width: 100%">
+            <h2 class="option-title" onclick="">
+                <strong id="product-two"> product two </strong>
+            </h2>
+            <div class="option-menu">
+                {% for row in grouped_products | batch(3) %}
+                    <ul>
+                        {% for group_name, product_summaries in row %}
+                            <li>
+                                <h3 class="group-name">{{ group_name }}</h3>
+                                <ul class="items">
+                                    {% for product_opt, summary in product_summaries if summary %}
+                                        <li class="{% if summary.dataset_count == 0 %}empty{% endif %}">
+                                            <button onclick="addDiffsProduct('second', '{{ product_opt.name }}')">
+                                                {{ product_opt.name }}
+                                            </button>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endfor %}
+            </div>
+        </div>
+        <div id="diff-time-picker" style="display: inline-flex">
+            {% set report_type = 'Differences' %}
             {% include "reports-time.html" %}
         </div>
     </header>
@@ -40,6 +101,13 @@
         var year = null;
         var month = null;
         var day = null;
+
+        // Product differences
+        var product_1 = null;
+        var product_2 = null;
+        var diffs_year = null;
+        var diffs_month = null;
+        var diffs_day = null;
 
         function getProductUrl() {
             url = "/reports";
@@ -85,22 +153,33 @@
                 url = getProductUrl();
                 console.log(url);
                 $.get(url, function(data, status) {
-                    document.getElementById("content").innerHTML = data;
+                    document.getElementById("summary-content").innerHTML = data;
                 });
             }
         }
 
+        function setDate(date_type, value) {
+            if (date_type == 'year') {
+                year = value;
+                menu_id = '-year-menu';
+            } else if (date_type == 'month') {
+                month = value;
+                menu_id = '-month-menu';
+            } else if (date_type == 'day') {
+                day = value;
+                menu_id = '-day-menu';
+            } else {
+                return
+            }
 
-        function setYear(_year) {
-            year = _year;
             if (products.length > 0) {
                 url = getProductUrl();
-                console.log(url)
                 $.get(url, function(data, status) {
-                    document.getElementById("content").innerHTML = data;
+                    document.getElementById("summary-content").innerHTML = data;
                 });
-                document.getElementById("year-menu").innerText = year;
             }
+
+            document.getElementById(menu_id).innerText = value;
             menuUrl = getMenuUrl()
             $.get(menuUrl, function(data, status) {
                 document.getElementById("time-picker").innerHTML = data;
@@ -108,36 +187,60 @@
         }
 
 
-        function setMonth(_month) {
-            month = _month;
-            if (products.length > 0) {
-                url = getProductUrl()
-                console.log(url)
-                $.get(url, function(data, status) {
-                    document.getElementById("content").innerHTML = data;
-                });
-                document.getElementById("month-menu").innerText = month;
+        function addDiffsProduct(rank, name) {
+            if (rank == 'first') {
+                product_1 = name;
+                document.getElementById("product-one").innerText = name;
+            } else if (rank == 'second') {
+                product_2 = name;
+                document.getElementById("product-two").innerText = name;
             }
-            menuUrl = getMenuUrl()
-            $.get(menuUrl, function(data, status) {
-                document.getElementById("time-picker").innerHTML = data;
-            });
+            if (product_1 && product_2) {
+                $.get('/reports/differences/' + product_1 + '+' + product_2, function(data, status) {
+                        document.getElementById("diff-content").innerHTML = data;
+                });
+            }
         }
 
-
-        function setDay(_day) {
-            day = _day;
-            if (products.length > 0) {
-                url = getProductUrl()
-                console.log(url)
-                $.get(url, function(data, status) {
-                    document.getElementById("content").innerHTML = data;
-                });
-                document.getElementById("day-menu").innerText = day;
+        function getDiffsMenuUrl() {
+            url = "/reports/differences/time";
+            if (diffs_year) {
+                url += "/" + diffs_year;
             }
-            menuUrl = getMenuUrl()
+            if (diffs_month) {
+                url += "/" + diffs_month;
+            }
+            if (diffs_day) {
+                url += "/" + diffs_day;
+            }
+            return url;
+        }
+
+        function setDifferencesDate(date_type, value) {
+            if (date_type == 'year') {
+                diffs_year = value;
+                menu_id = 'Differences-year-menu';
+            } else if (date_type == 'month') {
+                diffs_month = value;
+                menu_id = 'Differences-month-menu';
+            } else if (date_type == 'day') {
+                diffs_day = value;
+                menu_id = 'Differences-day-menu';
+            } else {
+                return;
+            }
+
+            if (product_1 && product_2) {
+                url = '/reports/differences/' + product_1 + '+' + product_2;
+                $.get(url, function(data, status) {
+                    document.getElementById("diff-content").innerHTML = data;
+                });
+            }
+
+            document.getElementById(menu_id).innerText = value;
+            menuUrl = getDiffsMenuUrl();
             $.get(menuUrl, function(data, status) {
-                document.getElementById("time-picker").innerHTML = data;
+                document.getElementById("diff-time-picker").innerHTML = data;
             });
         }
     </script>

--- a/cubedash/templates/reports.html
+++ b/cubedash/templates/reports.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Reports</title>
+
+    <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}">
+    <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
+</head>
+<body>
+    <div class="content-wrapper">
+        <div id="logo">
+            <a href="/">
+                <img src="{{ url_for('static', filename='dea-icon.svg') }}"
+                     height="26px" alt=""/>
+                <span class="logo-text"><strong>Digital Earth</strong> Australia</span>
+            </a>
+        </div>
+        <div class="header-wrapper">
+            <header>
+                <div class="header-option primary">
+                    <h2 class="option-title" onclick="">
+                        <strong> products </strong>
+                    </h2>
+                    <div class="option-menu">
+                        {% for row in grouped_products | batch(3) %}
+                            <ul>
+                                {% for group_name, product_summaries in row %}
+                                    <li>
+                                        <h3 class="group-name">{{ group_name }}</h3>
+                                        <ul class="items">
+                                            {% for product_opt, summary in product_summaries if summary %}
+                                                <li class="{% if summary.dataset_count == 0 %}empty{% endif %}">
+                                                    <button onclick="addProduct( '{{ product_opt.name }}' )">
+                                                        {{ product_opt.name }}
+                                                    </button>
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div id="time-picker" style="display: inline-flex">
+                    {% include "reports-time.html" %}
+                </div>
+            </header>
+        </div>
+        <div id="product-overviews">
+        </div>
+    </div>
+    <script src="{{ url_for('static', filename='jquery-3.3.1.min.js') }}"></script>
+    <script>
+        var products = [];
+        var year = null;
+        var month = null;
+        var day = null;
+
+        function getProductUrl() {
+            url = "/reports";
+            if (products.length > 0) {
+                product_list = products[0];
+                for (i = 1; i < products.length; i++) {
+                    product_list += "+" + products[i];
+                }
+                url += "/" + product_list;
+                if (year) {
+                    url += "/" + year;
+                }
+                if (month) {
+                    url += "/" + month;
+                }
+                if (day) {
+                    url += "/" + day;
+                }
+                return url;
+            }
+            return url;
+        }
+
+
+        function getMenuUrl() {
+            url = "/reports/time";
+            if (year) {
+                url += "/" + year;
+            }
+            if (month) {
+                url += "/" + month;
+            }
+            if (day) {
+                url += "/" + day;
+            }
+            return url;
+        }
+
+
+        function addProduct(product_name) {
+            if (!products.includes(product_name)) {
+                products.push(product_name);
+                url = getProductUrl();
+                console.log(url);
+                $.get(url, function(data, status) {
+                    document.getElementById("product-overviews").innerHTML = data;
+                });
+            }
+        }
+
+
+        function setYear(_year) {
+            year = _year;
+            if (products.length > 0) {
+                url = getProductUrl();
+                console.log(url)
+                $.get(url, function(data, status) {
+                    document.getElementById("product-overviews").innerHTML = data;
+                });
+                document.getElementById("year-menu").innerText = year;
+            }
+            menuUrl = getMenuUrl()
+            $.get(menuUrl, function(data, status) {
+                document.getElementById("time-picker").innerHTML = data;
+            });
+        }
+
+
+        function setMonth(_month) {
+            month = _month;
+            if (products.length > 0) {
+                url = getProductUrl()
+                console.log(url)
+                $.get(url, function(data, status) {
+                    document.getElementById("product-overviews").innerHTML = data;
+                });
+                document.getElementById("month-menu").innerText = month;
+            }
+            menuUrl = getMenuUrl()
+            $.get(menuUrl, function(data, status) {
+                document.getElementById("time-picker").innerHTML = data;
+            });
+        }
+
+
+        function setDay(_day) {
+            day = _day;
+            if (products.length > 0) {
+                url = getProductUrl()
+                console.log(url)
+                $.get(url, function(data, status) {
+                    document.getElementById("product-overviews").innerHTML = data;
+                });
+                document.getElementById("day-menu").innerText = day;
+            }
+            menuUrl = getMenuUrl()
+            $.get(menuUrl, function(data, status) {
+                document.getElementById("time-picker").innerHTML = data;
+            });
+        }
+    </script>
+</body>
+</html>

--- a/cubedash/templates/reports.html
+++ b/cubedash/templates/reports.html
@@ -1,57 +1,39 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Reports</title>
+{% extends "layout/base.html" %}
 
-    <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}">
-    <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
-</head>
-<body>
-    <div class="content-wrapper">
-        <div id="logo">
-            <a href="/">
-                <img src="{{ url_for('static', filename='dea-icon.svg') }}"
-                     height="26px" alt=""/>
-                <span class="logo-text"><strong>Digital Earth</strong> Australia</span>
-            </a>
-        </div>
-        <div class="header-wrapper">
-            <header>
-                <div class="header-option primary">
-                    <h2 class="option-title" onclick="">
-                        <strong> products </strong>
-                    </h2>
-                    <div class="option-menu">
-                        {% for row in grouped_products | batch(3) %}
-                            <ul>
-                                {% for group_name, product_summaries in row %}
-                                    <li>
-                                        <h3 class="group-name">{{ group_name }}</h3>
-                                        <ul class="items">
-                                            {% for product_opt, summary in product_summaries if summary %}
-                                                <li class="{% if summary.dataset_count == 0 %}empty{% endif %}">
-                                                    <button onclick="addProduct( '{{ product_opt.name }}' )">
-                                                        {{ product_opt.name }}
-                                                    </button>
-                                                </li>
-                                            {% endfor %}
-                                        </ul>
-                                    </li>
-                                {% endfor %}
-                            </ul>
+{% block header %}
+    <header>
+        <div class="header-option primary">
+            <h2 class="option-title" onclick="">
+                <strong> products </strong>
+            </h2>
+            <div class="option-menu">
+                {% for row in grouped_products | batch(3) %}
+                    <ul>
+                        {% for group_name, product_summaries in row %}
+                            <li>
+                                <h3 class="group-name">{{ group_name }}</h3>
+                                <ul class="items">
+                                    {% for product_opt, summary in product_summaries if summary %}
+                                        <li class="{% if summary.dataset_count == 0 %}empty{% endif %}">
+                                            <button onclick="addProduct( '{{ product_opt.name }}' )">
+                                                {{ product_opt.name }}
+                                            </button>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            </li>
                         {% endfor %}
-                    </div>
-                </div>
-                <div id="time-picker" style="display: inline-flex">
-                    {% include "reports-time.html" %}
-                </div>
-            </header>
+                    </ul>
+                {% endfor %}
+            </div>
         </div>
-        <div id="product-overviews">
+        <div id="time-picker" style="display: inline-flex">
+            {% include "reports-time.html" %}
         </div>
-    </div>
+    </header>
+{% endblock %}
+
+{% block body_footer %}
     <script src="{{ url_for('static', filename='jquery-3.3.1.min.js') }}"></script>
     <script>
         var products = [];
@@ -103,7 +85,7 @@
                 url = getProductUrl();
                 console.log(url);
                 $.get(url, function(data, status) {
-                    document.getElementById("product-overviews").innerHTML = data;
+                    document.getElementById("content").innerHTML = data;
                 });
             }
         }
@@ -115,7 +97,7 @@
                 url = getProductUrl();
                 console.log(url)
                 $.get(url, function(data, status) {
-                    document.getElementById("product-overviews").innerHTML = data;
+                    document.getElementById("content").innerHTML = data;
                 });
                 document.getElementById("year-menu").innerText = year;
             }
@@ -132,7 +114,7 @@
                 url = getProductUrl()
                 console.log(url)
                 $.get(url, function(data, status) {
-                    document.getElementById("product-overviews").innerHTML = data;
+                    document.getElementById("content").innerHTML = data;
                 });
                 document.getElementById("month-menu").innerText = month;
             }
@@ -149,7 +131,7 @@
                 url = getProductUrl()
                 console.log(url)
                 $.get(url, function(data, status) {
-                    document.getElementById("product-overviews").innerHTML = data;
+                    document.getElementById("content").innerHTML = data;
                 });
                 document.getElementById("day-menu").innerText = day;
             }
@@ -159,5 +141,4 @@
             });
         }
     </script>
-</body>
-</html>
+{% endblock %}

--- a/cubedash/templates/reports.html
+++ b/cubedash/templates/reports.html
@@ -28,7 +28,7 @@
             </div>
         </div>
         <div id="time-picker" style="display: inline-flex">
-            {% set report_type = '' %}
+            {% set report_type = 'summaries' %}
             {% include "reports-time.html" %}
         </div>
     </header>
@@ -88,7 +88,7 @@
             </div>
         </div>
         <div id="diff-time-picker" style="display: inline-flex">
-            {% set report_type = 'Differences' %}
+            {% set report_type = 'differences' %}
             {% include "reports-time.html" %}
         </div>
     </header>
@@ -109,7 +109,7 @@
         var diffs_month = null;
         var diffs_day = null;
 
-        function getProductUrl() {
+        function getProductsUrl() {
             url = "/reports";
             if (products.length > 0) {
                 product_list = products[0];
@@ -133,7 +133,7 @@
 
 
         function getMenuUrl() {
-            url = "/reports/time";
+            url = "/reports/time/summaries";
             if (year) {
                 url += "/" + year;
             }
@@ -150,37 +150,50 @@
         function addProduct(product_name) {
             if (!products.includes(product_name)) {
                 products.push(product_name);
-                url = getProductUrl();
-                console.log(url);
+                url = getProductsUrl();
                 $.get(url, function(data, status) {
                     document.getElementById("summary-content").innerHTML = data;
                 });
             }
         }
 
-        function setDate(date_type, value) {
+        function summariesDate(date_type, value) {
             if (date_type == 'year') {
-                year = value;
-                menu_id = '-year-menu';
+                if (value == 'All') {
+                    year = null;
+                    month = null;
+                    day = null;
+                } else {
+                    year = value;
+                }
+                menu_id = 'summaries-year-menu';
             } else if (date_type == 'month') {
-                month = value;
-                menu_id = '-month-menu';
+                if (value == 'All') {
+                    month = null;
+                    day = null;
+                } else {
+                    month = value;
+                }
+                menu_id = 'summaries-month-menu';
             } else if (date_type == 'day') {
-                day = value;
-                menu_id = '-day-menu';
+                if (value == 'All') {
+                    day = null;
+                } else {
+                    day = value;
+                }
+                menu_id = 'summaries-day-menu';
             } else {
-                return
+                return;
             }
 
             if (products.length > 0) {
-                url = getProductUrl();
-                $.get(url, function(data, status) {
+                summaryUrl = getProductsUrl();
+                $.get(summaryUrl, function(data, status) {
                     document.getElementById("summary-content").innerHTML = data;
                 });
             }
 
-            document.getElementById(menu_id).innerText = value;
-            menuUrl = getMenuUrl()
+            menuUrl = getMenuUrl();
             $.get(menuUrl, function(data, status) {
                 document.getElementById("time-picker").innerHTML = data;
             });
@@ -203,7 +216,7 @@
         }
 
         function getDiffsMenuUrl() {
-            url = "/reports/differences/time";
+            url = "/reports/time/differences";
             if (diffs_year) {
                 url += "/" + diffs_year;
             }
@@ -216,16 +229,31 @@
             return url;
         }
 
-        function setDifferencesDate(date_type, value) {
+        function differencesDate(date_type, value) {
             if (date_type == 'year') {
-                diffs_year = value;
-                menu_id = 'Differences-year-menu';
+                if (value == 'All') {
+                    diffs_year = null;
+                    diffs_month = null;
+                    diffs_day = null;
+                } else {
+                    diffs_year = value;
+                }
+                menu_id = 'differences-year-menu';
             } else if (date_type == 'month') {
-                diffs_month = value;
-                menu_id = 'Differences-month-menu';
+                if (value == 'All') {
+                    diffs_month = null;
+                    diffs_day = null;
+                } else {
+                    diffs_month = value;
+                }
+                menu_id = 'differences-month-menu';
             } else if (date_type == 'day') {
-                diffs_day = value;
-                menu_id = 'Differences-day-menu';
+                if (value == 'All') {
+                    diffs_day = null;
+                } else {
+                    diffs_day = value;
+                }
+                menu_id = 'differences-day-menu';
             } else {
                 return;
             }
@@ -237,7 +265,6 @@
                 });
             }
 
-            document.getElementById(menu_id).innerText = value;
             menuUrl = getDiffsMenuUrl();
             $.get(menuUrl, function(data, status) {
                 document.getElementById("diff-time-picker").innerHTML = data;


### PR DESCRIPTION
**Completion reports: comparative summaries and differences**
It's currently really tedious to compare products in cubedash and we would like to be able to do it to get a clear picture of how much of different types of products have been processed, and where we might have gaps or double ups. In particular, for each month there should be the same number of products for PQ, PQ-Legacy, and WOfS. And there should be the same number of products for NBART and FC.

This feature runs on a separate page on the client side while on the server it utilises existing infrastructure, architecture, and styles. However, some client state management is implemented with `javascript` and `jquery`. The `url` of the feature is `<cubedash-url>/reports`. The server side routing is implemented as a `flask` blueprint `reports`.

This feature refer to the item `DEADM-20` in JIRA.

Integration tests are passed. 