### PR TITLE
Add display limits for huge provenance graphs

### DIFF
--- a/cubedash/_dataset.py
+++ b/cubedash/_dataset.py
@@ -4,26 +4,43 @@ import logging
 
 import flask
 from flask import Blueprint
+from jinja2 import Markup
 
+from datacube.model import Dataset
 from . import _utils as utils
 from . import _model
 
 _LOG = logging.getLogger(__name__)
 bp = Blueprint('dataset', __name__, url_prefix='/dataset')
 
+PROVENANCE_DISPLAY_LIMIT = 50
+
 
 @bp.route('/<uuid:id_>')
 def dataset_page(id_):
+    derived_dataset_overflow = source_dataset_overflow = 0
+
     index = _model.STORE.index
     dataset = index.datasets.get(id_, include_sources=True)
 
+    source_list = list(dataset.metadata.sources.items())
+    if len(source_list) > PROVENANCE_DISPLAY_LIMIT:
+        source_dataset_overflow = len(source_list) - PROVENANCE_DISPLAY_LIMIT
+        source_list = source_list[:PROVENANCE_DISPLAY_LIMIT]
+
     source_datasets = {type_: index.datasets.get(dataset_d['id'])
-                       for type_, dataset_d in dataset.metadata.sources.items()}
+                       for type_, dataset_d in source_list}
 
     archived_location_times = index.datasets.get_archived_location_times(id_)
+
+    # simple_sources = {classifier: dataset_link(d) for classifier, d in dataset.sources.items()}
+    dataset.metadata.sources = {}
     ordered_metadata = utils.get_ordered_metadata(dataset.metadata_doc)
 
     derived_datasets = sorted(index.datasets.get_derived(id_), key=utils.dataset_label)
+    if len(derived_datasets) > PROVENANCE_DISPLAY_LIMIT:
+        derived_dataset_overflow = len(derived_datasets) - PROVENANCE_DISPLAY_LIMIT
+        derived_datasets = derived_datasets[:PROVENANCE_DISPLAY_LIMIT]
 
     return flask.render_template(
         'dataset.html',
@@ -31,5 +48,12 @@ def dataset_page(id_):
         dataset_metadata=ordered_metadata,
         derived_datasets=derived_datasets,
         source_datasets=source_datasets,
-        archive_location_times=archived_location_times
+        archive_location_times=archived_location_times,
+
+        derived_dataset_overflow=derived_dataset_overflow,
+        source_dataset_overflow=source_dataset_overflow,
     )
+
+
+def dataset_link(d: Dataset):
+    return Markup(f'<a href="{flask.url_for("dataset.dataset_page", id_=d.id)}">{d.id}</a>')

--- a/cubedash/templates/dataset.html
+++ b/cubedash/templates/dataset.html
@@ -64,6 +64,9 @@
                 </span>
             </div>
         {% endfor %}
+        {% if source_dataset_overflow %}
+            <span title="Too many to display">... {{ source_dataset_overflow }} more</span>
+        {% endif %}
         <div class="tree-node">
             → <strong>{{ dataset | printable_dataset }}</strong>
             {% for d_dataset in derived_datasets %}
@@ -75,6 +78,9 @@
                     </span>
                 </div>
             {% endfor %}
+            {% if derived_dataset_overflow %}
+                <span title="Too many to display">... {{ derived_dataset_overflow}} more</span>
+            {% endif %}
         </div>
 
     </div>


### PR DESCRIPTION
Issue #11

This will still fetch large amounts from the DB, but will not display all of it.

This make most of the affected products (eg. `item_v2`) usable, but a real solution will need to expand the upstream API to support limits.