### PR TITLE
Minor fix to page titles: make them more specific

### DIFF
--- a/cubedash/_audit.py
+++ b/cubedash/_audit.py
@@ -7,7 +7,7 @@ from typing import Iterable
 
 import flask
 from dataclasses import dataclass
-from flask import Blueprint
+from flask import Blueprint, Response
 
 from datacube.model import Range
 from . import _model
@@ -82,3 +82,13 @@ def product_audit_page():
         spatial_quality_stats=list(store.get_quality_stats()),
         **extra,
     )
+
+
+@bp.route('/day-times.txt')
+def get_timings():
+    def respond():
+        yield "product\tcount\ttime_ms\n"
+        for f in product_timings():
+            yield f'"{f.name}"\t{f.dataset_count}\t{int(f.time_seconds*1000)}\n'
+
+    return Response(respond(), mimetype='text/plain')

--- a/cubedash/_audit.py
+++ b/cubedash/_audit.py
@@ -89,6 +89,7 @@ def get_timings():
     def respond():
         yield "product\tcount\ttime_ms\n"
         for f in product_timings():
-            yield f'"{f.name}"\t{f.dataset_count}\t{int(f.time_seconds*1000)}\n'
+            time_ms = int(f.time_seconds*1000) if f.time_seconds else ''
+            yield f'"{f.name}"\t{f.dataset_count}\t{time_ms}\n'
 
     return Response(respond(), mimetype='text/plain')

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 import flask
 import structlog
-from flask import abort, redirect, url_for
+from flask import abort, redirect, url_for, Response
 from flask import request
 from werkzeug.datastructures import MultiDict
 
@@ -280,4 +280,13 @@ def default_redirect():
             'overview_page',
             product_name=default_product
         )
+    )
+
+
+@app.route('/products.txt')
+def product_list_text():
+    # This is useful for bash scripts when we want to loop products :)
+    return Response(
+        '\n'.join(_model.STORE.list_complete_products()),
+        content_type="text/plain"
     )

--- a/cubedash/templates/layout/product-section.html
+++ b/cubedash/templates/layout/product-section.html
@@ -31,7 +31,13 @@
     </div>
 {% endset %}
 
-{% block title %}{{ product.name }} {{ product_args_label }}{% endblock %}
+{% block title -%}
+    {{ product.name }} {% if year -%}
+        for {% if month -%}
+            {%- if day -%}{{ day }} {% endif -%}
+            {{ month | month_name }} {% endif -%}
+    {{ year }} {% endif -%}
+{% endblock %}
 
 {% block header %}
     <header>

--- a/cubedash/templates/layout/product-section.html
+++ b/cubedash/templates/layout/product-section.html
@@ -31,7 +31,7 @@
     </div>
 {% endset %}
 
-{% block title %}{{ product.name }}{% endblock %}
+{% block title %}{{ product.name }} {{ product_args_label }}{% endblock %}
 
 {% block header %}
     <header>

--- a/cubedash/templates/overview.html
+++ b/cubedash/templates/overview.html
@@ -1,6 +1,5 @@
 {% extends "layout/product-section.html" %}
 {% set active_page = "overview" %}
-{% block title %}{{ product.name }}{% endblock %}
 
 {% set have_data = selected_summary and selected_summary.dataset_count > 0 %}
 {% set have_displayable_data = selected_summary and selected_summary.footprint_count > 0 %}

--- a/cubedash/templates/product-audit.html
+++ b/cubedash/templates/product-audit.html
@@ -35,7 +35,7 @@
             </ul>
         {% endif %}
     </div>
-    <div class="panel">
+    <div class="panel" id="missing-metadata">
         {% if spatial_quality_stats %}
             <table class="data-table unavailable-metadata">
                 <thead>
@@ -74,7 +74,7 @@
             <span class="primary-error">Spatial quality view not populated</span>
         {% endif %}
     </div>
-    <div class="panel">
+    <div class="panel" id="largest-footprint-size">
         {% if spatial_quality_stats %}
             <h2>Largest footprint size</h2>
             Measured from binary storage. JSON/Metadata representation is much larger.
@@ -123,7 +123,7 @@
     {% else %}
         <div class="panel odd">
             <a href="{{ url_for('audit.product_audit_page', timings=True) }}#query-timings">
-                Measure query timings (very slow)
+                View query timings (very slow)
             </a>
         </div>
     {% endif %}

--- a/cubedash/templates/product.html
+++ b/cubedash/templates/product.html
@@ -1,6 +1,6 @@
 {% extends "layout/base.html" %}
 
-{% block title %}{{ product.name }}{% endblock %}
+{% block title %}{{ product.name }} definition{% endblock %}
 
 
 {% block head %}

--- a/cubedash/templates/search.html
+++ b/cubedash/templates/search.html
@@ -1,7 +1,7 @@
 {% extends "layout/product-section.html" %}
 {% set active_page = "datasets" %}
 
-{% block title %}{{ super() }} search{% endblock %}
+{% block title %}Search {{ super() }}{% endblock %}
 
 {% block content %}
     <div class="panel relative">

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -33,13 +33,13 @@ def populate_index(dataset_loader, module_dea_index):
         TEST_DATA_DIR / 'wofs-albers-sample.yaml.gz'
     )
     assert loaded == 11
-    
+
     loaded = dataset_loader(
         'high_tide_comp_20p',
         TEST_DATA_DIR / 'high_tide_comp_20p.yaml.gz'
     )
     assert loaded == 306
-    
+
     return module_dea_index
 
 
@@ -279,7 +279,6 @@ def test_api_returns_limited_tile_regions(client: FlaskClient):
     assert geojson is None, "Unexpected wofs albers region count"
 
 
-
 def test_undisplayable_product(client: FlaskClient):
     """
     Telemetry products have no footprint available at all.
@@ -359,3 +358,8 @@ def test_with_timings(client: FlaskClient):
     # app;dur=1034.12,odcquery;dur=103.03;desc="ODC query time",odcquerycount_6;desc="6 ODC queries"
     _, val = count_header[0].split(';')[0].split('_')
     assert int(val) > 0, "At least one query was run, presumably?"
+
+
+def test_plain_product_list(client: FlaskClient):
+    rv: Response = client.get('/products.txt')
+    assert 'ls7_nbar_scene\n' in rv.data.decode('utf-8')

--- a/integration_tests/test_wagl_data.py
+++ b/integration_tests/test_wagl_data.py
@@ -87,5 +87,5 @@ def test_product_audit(unpopulated_client: FlaskClient, run_generate):
 
     res: Response = client.get('/product-audit/day-times.txt')
     plain_timing_results = res.data.decode('utf-8')
-    assert 's2_ard_granule' in plain_timing_results
-    assert len(plain_timing_results.splitlines(keepends=False)) == 2
+    print(plain_timing_results)
+    assert '"s2a_ard_granule"\t8\t' in plain_timing_results

--- a/integration_tests/test_wagl_data.py
+++ b/integration_tests/test_wagl_data.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from dateutil.tz import tzutc
+from flask import Response
 from flask.testing import FlaskClient
 
 from cubedash.summary import SummaryStore
@@ -83,3 +84,8 @@ def test_product_audit(unpopulated_client: FlaskClient, run_generate):
     assert largest_val == '181.6B'
 
     assert len(res.find('.unavailable-metadata .search-result')) == 2
+
+    res: Response = client.get('/product-audit/day-times.txt')
+    plain_timing_results = res.data.decode('utf-8')
+    assert 's2_ard_granule' in plain_timing_results
+    assert len(plain_timing_results.splitlines(keepends=False)) == 2


### PR DESCRIPTION
The "May 2014" page for a product should include "May 2014" in the title, etc. This shows up on Google results.

(plus a few plain-text pages useful for administration)