### PR TITLE
Rename proposal: dea-dashboard → datacube-explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# DEA Operations Dashboard [![Build Status](https://travis-ci.org/opendatacube/dea-dashboard.svg?branch=develop)](https://travis-ci.org/opendatacube/dea-dashboard) [![Coverage Status](https://coveralls.io/repos/github/opendatacube/dea-dashboard/badge.svg?branch=develop)](https://coveralls.io/github/opendatacube/dea-dashboard?branch=develop)
+# Data Cube Explorer [![Build Status](https://travis-ci.org/opendatacube/datacube-explorer.svg?branch=develop)](https://travis-ci.org/opendatacube/datacube-explorer) [![Coverage Status](https://coveralls.io/repos/github/opendatacube/datacube-explorer/badge.svg?branch=develop)](https://coveralls.io/github/opendatacube/datacube-explorer?branch=develop)
 
-![Dashboard Screenshot](deployment/screenshot.png)
+![Explorer Screenshot](deployment/screenshot.png)
 
 ## Developer Setup
 
@@ -14,7 +14,7 @@ to the correct instance.
 
 ### Dependencies
 
-Now install the dashboard dependencies:
+Now install the explorer dependencies:
 
     # These two should come from conda if you're using it, not pypi
     conda install fiona shapely

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     python_requires='>=3.6',
 
-    url='https://github.com/data-cube/dea-dashboard',
+    url='https://github.com/opendatacube/datacube-explorer',
     author='Geoscience Australia',
 
     packages=find_packages(),


### PR DESCRIPTION
As suggested by @omad in #40, now that the branding has been changed (#12)

(I'm happy to modify this if we want to further discuss other name ideas)

If accepted, we'll rename the repo to match.