### PR TITLE
Basic Stac support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,11 @@ addons:
   services:
     - postgresql
   apt:
+      sources:
+      - sourceline: ppa:nextgis/ppa
       packages:
+          - gdal-bin
+          - gdal-data
           - libhdf5-serial-dev
           - libnetcdf-dev
           - libproj-dev
@@ -35,6 +39,13 @@ before_install:
 
 - export CPLUS_INCLUDE_PATH="/usr/include/gdal"
 - export C_INCLUDE_PATH="/usr/include/gdal"
+
+# The following is a temporary fix for broken gdal shared libraries due to upgrade of GDAL to 2.4.0.
+# This may require removing if more recent versions fixes this issue or alternative isolation
+# approaches between postgis and GDAL could be implemented instead
+- sudo ln -s /usr/lib/x86_64-linux-gnu/libgdal.so /usr/lib/x86_64-linux-gnu/libgdal.so.1
+- sudo /sbin/ldconfig
+
 - travis_retry pip install --upgrade pip
 - travis_retry pip install --progress-bar off coveralls codecov
 - travis_retry pip install --progress-bar off --requirement requirements-test.txt

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -16,7 +16,7 @@ from cubedash.summary import RegionInfo, TimePeriodOverview
 from cubedash.summary._stores import ProductSummary
 from datacube.model import DatasetType, Range
 from datacube.scripts.dataset import build_dataset_info
-from . import _filters, _dataset, _product, _platform, _api, _model, _reports
+from . import _filters, _dataset, _product, _platform, _api, _model, _reports, _stac
 from . import _utils as utils
 from ._utils import as_rich_json
 
@@ -28,6 +28,7 @@ app.register_blueprint(_product.bp)
 app.register_blueprint(_platform.bp)
 app.register_blueprint(_reports.bp)
 app.register_blueprint(_audit.bp)
+app.register_blueprint(_stac.bp)
 
 _LOG = structlog.getLogger()
 

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -1,0 +1,254 @@
+import logging
+
+from collections import OrderedDict
+import flask
+from flask import Blueprint, request, abort, url_for
+
+from datacube.model import Range
+from datacube.utils import parse_time
+from datacube.utils.geometry import CRS, Geometry
+from cubedash import _utils
+
+from urllib.parse import urlparse
+import datetime
+import json
+import itertools
+from functools import reduce
+
+from . import _utils as utils
+from . import _model
+
+_LOG = logging.getLogger(__name__)
+bp = Blueprint('stac', __name__, url_prefix='/stac')
+
+MAX_DATASETS = 100
+DATASETS_PER_REQUEST = 20
+
+
+@bp.route('/')
+def root():
+    return abort(404, "Only /stac/search is currently supported")
+
+
+@bp.route('/search', methods=['GET', 'POST'])
+def stac_search():
+    if request.method == 'GET':
+        bbox = request.args.get('bbox')
+        time_ = request.args.get('time')
+        product = request.args.get('product')
+        limit = request.args.get('limit')
+        from_dts = request.args.get('from')
+    else:
+        req_data = request.get_json()
+        bbox = req_data.get('bbox')
+        time_ = req_data.get('time')
+        product = req_data.get('product')
+        limit = req_data.get('limit')
+        from_dts = req_data.get('from')
+
+    # bbox and time are compulsory
+    if not bbox:
+        abort(400, "bbox must be specified")
+    if not time_:
+        abort(400, "time must be specified")
+
+    # Verify and cast data types of request data
+    bbox = json.loads(bbox) if isinstance(bbox, str) else bbox
+    time_ = time_ if isinstance(time_, str) else json.dumps(time_)
+    limit = int(limit) if isinstance(limit, str) else limit
+    if from_dts and isinstance(from_dts, str):
+        from_dts = int(from_dts)
+
+    # from_dts must be lower than limit
+    limit = DATASETS_PER_REQUEST if not limit else min(limit, DATASETS_PER_REQUEST)
+
+    if from_dts and from_dts >= MAX_DATASETS:
+        abort(400, "The parameter from must be lower than (MAX) {}".format(MAX_DATASETS))
+
+    return utils.as_json(search_datasets_stac(product, bbox, time_, limit, from_dts))
+
+
+def search_datasets_stac(product, bbox, time, limit, from_dts):
+    """
+    Returns a GeoJson FeatureCollection corresponding to given parameters for
+    a set of datasets returned by datacube.
+    """
+
+    stac_datasets = stac_datasets_validated(load_datasets(bbox, product, time))
+
+    from_dts_ = from_dts or 0
+    to_dts = min(MAX_DATASETS, from_dts_ + limit)
+    stac_datasets_ = list(itertools.islice(stac_datasets, from_dts_, to_dts))
+
+    result = dict()
+    result["type"] = "FeatureCollection"
+    res_bbox = _compute_bbox(stac_datasets_)
+    if res_bbox:
+        result["bbox"] = res_bbox
+
+    result["features"] = stac_datasets_
+
+    # Check whether stac_datasets has more datasets and we don't want to process
+    # more than MAX_DATASETS
+    if _generator_not_empty(stac_datasets) and to_dts < MAX_DATASETS:
+        url_next = url_for('.stac_search') + '?'
+        if product:
+            url_next += 'product=' + product
+        url_next += '&bbox=' + '[{},{},{},{}]'.format(*bbox) + '&time=' + time
+        url_next += '&limit=' + str(limit)
+        url_next += '&from=' + str(to_dts)
+        result['links'] = [{'href': url_next, 'rel': 'next'}]
+    return result
+
+
+def _generator_not_empty(items):
+    """
+    Check whether the given generator is not empty. Note: this function can remove upto
+    one item from the generator
+    """
+
+    return len(list(itertools.islice(items, 1))) == 1
+
+
+def load_datasets(bbox, product, time):
+    """
+    Parse the query parameters and load and return the matching datasets. bbox is assumed to be
+    [minimum longitude, minimum latitude, maximum longitude, maximum latitude]
+    """
+
+    query = dict()
+    if product:
+        query['product'] = product
+
+    # Need to further parse time, we assume date as a range anf if time is present its a timestamp
+    time_period = time.split('/')
+    if len(time_period) == 2:
+        query['time'] = Range(parse_time(time_period[0]), parse_time(time_period[1]))
+    elif len(time_period) == 1:
+        t = parse_time(time_period[0])
+        if t.time() == datetime.time():
+            query['time'] = Range(t, t + datetime.timedelta(days=1))
+        else:
+            query['time'] = t
+    else:
+        return []
+
+    # bbox is in GeoJSON CRS (WGS84)
+    query['lon'] = Range(bbox[0], bbox[2])
+    query['lat'] = Range(bbox[1], bbox[3])
+
+    return _model.STORE.index.datasets.search(**query)
+
+
+def stac_datasets_validated(datasets):
+    """
+    Generates an extent validated stream of stac items
+    """
+
+    for dataset in datasets:
+        stac_item = stac_dataset(dataset)
+        if stac_item:
+            yield stac_item
+
+
+def stac_dataset(dataset):
+    """
+    Returns a dict corresponding to a stac item
+    """
+
+    # Parse extent first return None if fails
+    shape, is_valid_extent = _utils.dataset_shape(dataset)
+    if not (shape and is_valid_extent):
+        _LOG.warning('Invalid extent or None extent in dataset %s', dataset.id)
+        return None
+
+    bbox = list(shape.bounds)
+    metadata_doc = dataset.metadata_doc
+
+    # Parse uri (and prefer remote uri s3)
+    uris = dataset.uris
+    remote_uris = [uri for uri in uris if urlparse(uri).scheme == 's3']
+    if remote_uris:
+        uri = remote_uris[0]
+    else:
+        other_uris = [uri for uri in uris if urlparse(uri).scheme != 's3']
+        uri = other_uris[0] if other_uris else ''
+
+    if metadata_doc['grid_spatial']['projection'].get('valid_data', None):
+        geodata = valid_coord_to_geojson(metadata_doc['grid_spatial']['projection']['valid_data'],
+                                         dataset.crs)
+    else:
+        # Compute geometry from geo_ref_points
+        points = [[list(point.values()) for point in
+                   metadata_doc['grid_spatial']['projection']['geo_ref_points'].values()]]
+
+        # last point and first point should be same
+        points[0].append(points[0][0])
+
+        geodata = valid_coord_to_geojson({'type': 'Polygon', 'coordinates': points}, dataset.crs)
+
+    # Convert the date to add time zone.
+    center_dt = dataset.center_time
+    center_dt = center_dt.replace(microsecond=0)
+    time_zone = center_dt.tzinfo
+    if not time_zone:
+        center_dt = center_dt.replace(tzinfo=datetime.timezone.utc).isoformat()
+    else:
+        center_dt = center_dt.isoformat()
+
+    # parent? We will have an empty parent for now
+    stac_item = OrderedDict([
+        ('id', metadata_doc['id']),
+        ('type', 'Feature'),
+        ('bbox', bbox),
+        ('geometry', geodata),
+        ('properties', {
+            'datetime': center_dt,
+            'product_type': metadata_doc['product_type']
+        }),
+        ('links', [
+            {'href': uri, 'rel': 'self'},
+        ]),
+        ('assets', {
+            band_name: {
+                # "type"? "GeoTIFF" or image/vnd.stac.geotiff; cloud-optimized=true
+                'href': band_data['path']
+            }
+            for band_name, band_data in metadata_doc['image']['bands'].items()
+        })
+    ])
+
+    cfg = flask.current_app.config.get('STAC_SETTINGS')
+    if cfg:
+        if cfg.get('contact') and cfg['contact'].get('name'):
+            stac_item['properties']['provider'] = cfg['contact']['name']
+        if cfg.get('license') and cfg['license'].get('name'):
+            stac_item['properties']['license'] = cfg['license']['name']
+        if cfg.get('license') and cfg['license'].get('copyright'):
+            stac_item['properties']['copyright'] = cfg['license']['copyright']
+
+    return stac_item
+
+
+def valid_coord_to_geojson(valid_coord, crs):
+    """
+        The polygon coordinates come in Albers' format, which must be converted to
+        lat/lon as in universal format in EPSG:4326
+    """
+
+    geo = Geometry(valid_coord, crs)
+    return geo.to_crs(CRS('epsg:4326')).__geo_interface__
+
+
+def _compute_bbox(stac_items):
+    """
+    Given extent validated stac items, compute the bounding box
+    """
+
+    if stac_items:
+        return reduce(lambda x, y: dict(bbox=[min(x['bbox'][0], y['bbox'][0]),
+                                              min(x['bbox'][1], y['bbox'][1]),
+                                              max(x['bbox'][2], y['bbox'][2]),
+                                              max(x['bbox'][3], y['bbox'][3])]),
+                      stac_items)['bbox']
+    return None

--- a/integration_tests/schemas/stac_item.json
+++ b/integration_tests/schemas/stac_item.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "id": "item.json#",
+  "title": "STAC Item",
+  "type": "object",
+  "description": "This object represents the metadata for an item in a SpatioTemporal Asset Catalog.",
+  "additionalProperties": true,
+  "allOf": [
+    {
+      "$ref": "#/definitions/core"
+    }
+  ],
+  "definitions": {
+    "core": {
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/master/item-spec/json-schema/geojson.json#/definitions/feature"
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "id",
+            "type",
+            "links",
+            "assets"
+          ],
+          "properties": {
+            "id": {
+              "title": "Provider ID",
+              "description": "Provider item ID",
+              "type": "string"
+            },
+            "links": {
+              "title": "Item links",
+              "description": "Links to item relations",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/link"
+              }
+            },
+            "assets": {
+              "title": "Asset links",
+              "description": "Links to assets",
+              "type": "object",
+              "patternProperties": {
+                ".+": {
+                  "$ref": "#/definitions/asset"
+                }
+              },
+              "additionalProperties": false
+            },
+            "properties": {
+              "type": "object",
+              "required": [
+                "datetime"
+              ],
+              "properties": {
+                "datetime": {
+                  "title": "Date and Time",
+                  "description": "The searchable date/time of the assets, in UTC (Formatted in RFC 3339) ",
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "link": {
+      "type": "object",
+      "required": [
+        "rel",
+        "href"
+      ],
+      "properties": {
+        "href": {
+          "title": "Link reference",
+          "type": "string"
+        },
+        "rel": {
+          "title": "Link relation type",
+          "type": "string"
+        },
+        "type": {
+          "title": "Link type",
+          "type": "string"
+        },
+        "title": {
+          "title": "Link title",
+          "type": "string"
+        }
+      }
+    },
+    "asset": {
+      "type": "object",
+      "required": [
+        "href"
+      ],
+      "properties": {
+        "href": {
+          "title": "Asset reference",
+          "type": "string"
+        },
+        "title": {
+          "title": "Asset title",
+          "type": "string"
+        },
+        "type": {
+          "title": "Asset type",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -2,6 +2,7 @@
 Tests that load pages and check the contained text.
 """
 import json
+import jsonschema
 from pathlib import Path
 from pprint import pprint
 
@@ -19,8 +20,8 @@ from integration_tests.asserts import get_html, check_dataset_count, check_last_
 
 TEST_DATA_DIR = Path(__file__).parent / 'data'
 
-DEFAULT_TZ = tz.gettz('Australia/Darwin')
 
+DEFAULT_TZ = tz.gettz('Australia/Darwin')
 
 @pytest.fixture(scope='module', autouse=True)
 def populate_index(dataset_loader, module_dea_index):
@@ -383,3 +384,95 @@ def test_with_timings(client: FlaskClient):
 def test_plain_product_list(client: FlaskClient):
     rv: Response = client.get('/products.txt')
     assert 'ls7_nbar_scene\n' in rv.data.decode('utf-8')
+
+
+@pytest.fixture
+def stac_settings():
+    """
+    Set STAC blueprint global attributes
+    """
+    import cubedash._stac
+
+    cubedash._stac.MAX_DATASETS = 20
+    cubedash._stac.DATASETS_PER_REQUEST = 4
+
+
+def test_stac_search(client: FlaskClient, stac_settings):
+    from cubedash._stac import MAX_DATASETS, DATASETS_PER_REQUEST
+
+    # Test with GET and without product
+    limit = DATASETS_PER_REQUEST // 2
+    get_url = '/stac/search?' + '&bbox=' + '[114, -33, 153, -10]'
+    get_url += '&time=' + '2017-04-16T01:12:16/2017-05-10T00:24:21' + '&limit=' + str(limit)
+    geojson = get_geojson(client, get_url)
+    assert len(geojson.get('features')) == limit
+    dataset_count = limit
+
+    # Test the links and paging and when paging stop
+    next_links = [link['href'] for link in geojson.get('links', []) if link['rel'] == 'next']
+    while next_links:
+        geojson = get_geojson(client, next_links[0])
+        assert len(geojson.get('features')) == limit
+        dataset_count += limit
+        next_links = [link['href'] for link in geojson.get('links', []) if link['rel'] == 'next']
+    assert dataset_count == MAX_DATASETS
+
+    # Test limit with value greater than DATASETS_PER_REQUEST
+    get_url = '/stac/search?' + '&bbox=' + '[114, -33, 153, -10]'
+    get_url += '&time=' + '2017-04-16T01:12:16/2017-05-10T00:24:21'
+    get_url += '&limit=' + str(DATASETS_PER_REQUEST + 2)
+    geojson = get_geojson(client, get_url)
+    assert len(geojson.get('features')) == DATASETS_PER_REQUEST
+
+    # Test without limit
+    get_url = '/stac/search?' + '&bbox=' + '[114, -33, 153, -10]'
+    get_url += '&time=' + '2017-04-16T01:12:16/2017-05-10T00:24:21'
+    geojson = get_geojson(client, get_url)
+    assert len(geojson.get('features')) == DATASETS_PER_REQUEST
+
+    # Test outside the box
+    get_url = '/stac/search?' + '&bbox=' + '[20,-5,25,10]'
+    get_url += '&time=' + '2017-04-16T01:12:16/2017-05-10T00:24:21'
+    geojson = get_geojson(client, get_url)
+    assert len(geojson.get('features')) == 0
+
+    # Test a query that return one dataset
+    get_url = '/stac/search?' + 'product=' + 'ls7_nbar_scene' + '&bbox=' + '[114, -33, 153, -10]'
+    get_url += '&time=' + '2017-04-20'
+    geojson = get_geojson(client, get_url)
+    assert len(geojson.get('features')) == 1
+
+    # Test a query that return no datasets
+    get_url = '/stac/search?' + 'product=' + 'ls7_nbar_scene' + '&bbox=' + '[114, -33, 153, -10]'
+    get_url += '&time=' + '2017-04-22'
+    geojson = get_geojson(client, get_url)
+    assert len(geojson.get('features')) == 0
+
+    # Test POST, product, and assets
+    rv: Response = client.post('/stac/search',
+                               data=json.dumps({'product': 'wofs_albers',
+                                                'bbox': [114, -33, 153, -10],
+                                                'time': '2017-04-16T01:12:16/2017-05-10T00:24:21',
+                                                'limit': DATASETS_PER_REQUEST}),
+                               headers={'Content-Type': 'application/json', 'Accept': 'application/json'})
+    geodata = json.loads(rv.data)
+    assert len(geodata.get('features')) == DATASETS_PER_REQUEST
+    assert 'water' in geodata['features'][0]['assets']
+    assert len(geodata['features'][0]['assets']) == 1
+
+    # Test high_tide_comp_20p with POST and assets
+    rv: Response = client.post('/stac/search',
+                               data=json.dumps({'product': 'high_tide_comp_20p',
+                                                'bbox': [114, -40, 147, -32],
+                                                'time': '2000-01-01T00:00:00/2016-10-31T00:00:00',
+                                                'limit': 5}),
+                               headers={'Content-Type': 'application/json', 'Accept': 'application/json'})
+    geodata = json.loads(rv.data)
+    bands = ['blue', 'green', 'nir', 'red', 'swir1', 'swir2']
+    for band in bands:
+        assert band in geodata['features'][0]['assets']
+
+    # Validate stac items with jsonschema
+    with open(Path(__file__).parent / 'schemas' / 'stac_item.json', 'r') as fp:
+        schema = json.load(fp)
+    jsonschema.validate(geodata['features'][0], schema)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -34,7 +34,7 @@ fake-useragent==0.1.11
 Fiona==1.8.2
 Flask==1.0.2
 Flask-Caching==1.4.0
-GDAL==1.10.0
+GDAL==2.4.0
 GeoAlchemy2==0.5.0
 geographiclib==1.49
 idna==2.7


### PR DESCRIPTION
## `STAC-API` for `datacube-explorer`
This is a minimalist implementation of `STAC-API` spec for `datacube-explorer`.  The `STAC-API` spec could be found [here](https://github.com/radiantearth/stac-spec/tree/master/api-spec). This basic implementation has implemented the single endpoint `/stac/search`  where `HTTP POST` is a required implementation while `HTTP GET` is an equivalent optional implementation. The optional `stac` endpoint will be released in a future release. Currently The search fields `bbox` (bounding box) and `time` are required fields though these two fields are optional in the `STAC API schema` (Please refer to the API spec of the STAC spec). The `stac/search` endpoint returns a list of `STAC items` that matches the query parameters, in a `GeoJson FeatureCollection` format. `paging` is supported via a `link` in the `links` field of `GeoJson FeatureCollection` up to an implementation determined constant number of datasets.

There are no changes done to `datacube-explorer` front-end rendering aspects. The `API` is implemented as a `Flask blueprint` in `_stac.py`. The implementation rely on improved parsing of `Index.datasets.search`  function of the `datacube api` to properly interpret, for example `extents`. It further uses `cubedash._utils` to filter out datasets with invalid extents, and no `stac items` are generated for such datasets. `pytests` are added in the `integration_tests` module (The fixture `stac_settings` and the test function `test_stac_search`). 

The `GDAL` libray required updating to a recent version (2.4.0) due to parsing of certain datasets resulting in `exceptions`. However, this update appear to break `shared GDL libraries` in `travis CI`. As a temporary fix, a `linux symbolic link` needed to be created between  `libgdal.so` and `libgdal.so.1`.

This `PR` addresses the issues raised in the PR #50 .  