### PR TITLE
Use a flask-themes that we control

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -4,7 +4,6 @@ from typing import List, Tuple
 
 import flask
 import structlog
-import werkzeug
 from flask import Response, abort, redirect, request, url_for
 from werkzeug.datastructures import MultiDict
 
@@ -20,8 +19,6 @@ from datacube.scripts.dataset import build_dataset_info
 from . import _api, _dataset, _filters, _model, _platform, _product, _reports, _stac
 from . import _utils as utils
 from ._utils import as_rich_json
-
-werkzeug.cached_property = werkzeug.utils.cached_property
 
 
 app = _model.app

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "fiona",
         "flask",
         "Flask-Caching",
-        "flask_themes @ git+https://git@github.com/maxcountryman/flask-themes@master",
+        "flask_themes @ git+https://git@github.com/opendatacube/flask-themes@master",
         "geoalchemy2",
         "geographiclib",
         "jinja2",


### PR DESCRIPTION
Supercedes #85, as discussed with @whatnick  on slack.

We forked flask-themes into a version we control, and patched it so that we no longer need the werkzeug fix. The original is maintained very sporadically, so this seemed worth it.