### PR TITLE
Add a simple metadata type page

### DIFF
--- a/cubedash/_product.py
+++ b/cubedash/_product.py
@@ -8,16 +8,37 @@ from cubedash import _model
 from cubedash import _utils as utils
 
 _LOG = logging.getLogger(__name__)
-bp = Blueprint("product", __name__, url_prefix="/product")
+bp = Blueprint("product", __name__)
 
 
-@bp.route("/<name>")
+@bp.route("/product/<name>")
 def product_page(name):
     product = _model.STORE.index.products.get_by_name(name)
     if not product:
         abort(404, "Unknown product %r" % name)
     ordered_metadata = utils.get_ordered_metadata(product.definition)
 
+    return utils.render("product.html", product=product, metadata_doc=ordered_metadata)
+
+
+@bp.route("/metadata-type/<name>")
+def metadata_type_page(name):
+    metadata_type = _model.STORE.index.metadata_types.get_by_name(name)
+    if not metadata_type:
+        abort(404, "Unknown metadata type %r" % name)
+    ordered_metadata = utils.get_ordered_metadata(metadata_type.definition)
+
+    products_using_it = sorted(
+        (
+            p
+            for p in _model.STORE.index.products.get_all()
+            if p.metadata_type.name == name
+        ),
+        key=lambda p: p.name,
+    )
     return utils.render(
-        "product.html", product=product, product_metadata=ordered_metadata
+        "metadata_type.html",
+        metadata_type=metadata_type,
+        metadata_doc=ordered_metadata,
+        products_using_it=products_using_it,
     )

--- a/cubedash/templates/metadata_type.html
+++ b/cubedash/templates/metadata_type.html
@@ -1,0 +1,39 @@
+{% extends "layout/base.html" %}
+
+{% block title %}{{ metadata_type.name }} definition{% endblock %}
+
+
+{% block head %}
+    {{ super() }}
+    <style type="text/css">
+        .metadata-type-name {
+            text-transform: uppercase;
+        }
+    </style>
+{% endblock %}
+{% block panel %}
+
+{% endblock %}
+{% block content %}
+    {% from "layout/macros.html" import query_param_list, show_raw_document %}
+
+    <div class="panel odd">
+        <h2><span class="metadata-type-name">{{ metadata_type.name }}</span> Metadata Type</h2>
+        {{ show_raw_document(metadata_doc) }}
+    </div>
+
+    <div class="panel">
+        <h2>Usage</h2>
+        {% if products_using_it %}
+            <ul class="type-usage-list">
+            {% for product in products_using_it %}
+                <li class="type-usage-item">{{ product.name | product_link }}</li>
+            {% endfor %}
+            </ul>
+        {% else %}
+            <em>None</em>
+        {% endif %}
+    </div>
+
+
+{% endblock %}

--- a/cubedash/templates/overview.html
+++ b/cubedash/templates/overview.html
@@ -138,7 +138,11 @@
                         </ul>
                     {% endif %}
 
-                    <h4>Fields ({{ product.metadata_type.name }})</h4>
+                    <h4>
+                        <a href="{{ url_for('product.metadata_type_page', name=product.metadata_type.name) }}">
+                            {{ product.metadata_type.name }}</a>
+                        fields
+                    </h4>
 
                     {{ query_param_list(product.fields, descriptions=product.metadata_type.dataset_fields) }}
 

--- a/cubedash/templates/product.html
+++ b/cubedash/templates/product.html
@@ -11,29 +11,13 @@
 {% endblock %}
 {% block content %}
     {% from "layout/macros.html" import query_param_list, show_raw_document %}
-    
-{#    <div class="panel highlight">#}
-{#        <h2>{{ product.name }}</h2>#}
-{#        <div class="sub-header">#}
-{#            {{ dataset.indexed_time | timesince }}#}
-{#            {% if dataset.archived_time %}#}
-{#                <div>#}
-{#                    Archived#}
-{#                    <span title="{{ dataset.archived_time }}">#}
-{#                    {{ dataset.archived_time | timesince }}#}
-{#                    </span>#}
-{#                </div>#}
-{#            {% endif %}#}
-{#        </div>#}
+
     <div class="panel odd">
-        {{ show_raw_document(product_metadata) }}
+        {{ show_raw_document(metadata_doc) }}
     </div>
-    
+
     <div class="panel">
         Return to <a href="{{ url_for('overview_page', product_name=product.name) }}">overview</a>
-
     </div>
-
-
 
 {% endblock %}

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -8,6 +8,7 @@ from click.testing import Result
 from dateutil import tz
 from flask import Response
 from flask.testing import FlaskClient
+from requests_html import HTML
 
 from cubedash import _model, _monitoring
 from cubedash.summary import SummaryStore, _extents, show
@@ -168,12 +169,26 @@ def test_view_dataset(client: FlaskClient):
 
 
 def _h1_text(html):
-    return html.find("h1", first=True).text
+    return _text(html, "h1")
+
+
+def _text(html, tag):
+    return html.find(tag, first=True).text
 
 
 def test_view_product(client: FlaskClient):
     rv: Response = client.get("/product/ls7_nbar_scene")
     assert b"Landsat 7 NBAR 25 metre" in rv.data
+
+
+def test_view_metadata_type(client: FlaskClient):
+    # Does it load without error?
+    html: HTML = get_html(client, "/metadata-type/eo")
+    assert "eo Metadata Type" in _text(html, "h2")
+
+    # Does the page list products using the type?
+    products_using_it = [t.text for t in html.find(".type-usage-item")]
+    assert "ls8_nbar_albers" in products_using_it
 
 
 def test_about_page(client: FlaskClient):


### PR DESCRIPTION
Since it's sometimes useful when figuring out product issues.

Example url: https://explorer.dea.ga.gov.au/metadata-type/eo

It can also be found by clicking the name in the map page (eg, the "eo fields" header).

(the tests all pass, but the build fails because of the current versioning switchover in-progress in develop)