### PR TITLE
#96 add sentry imports in optional dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ extras_require = {
         "setproctitle",
         "meinheld",
         "gevent",
+        # Monitoring
+        "raven",
+        "blinker",
     ],
 }
 


### PR DESCRIPTION
Add raven and blinker to surface errors via Sentry.