### PR TITLE
Enable esri crses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM opendatacube/geobase:wheels as env_builder
+
 COPY requirements-docker.txt /
 RUN env-build-tool new /requirements-docker.txt /env
 
@@ -32,8 +33,6 @@ RUN mkdir -p /code
 WORKDIR /code
 
 ADD . /code
-
-RUN ls -lah /code
 
 # These ENVIRONMENT flags make this a bit complex, but basically, if we are in dev
 # then we want to link the source (with the -e flag) and if we're in prod, we

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -131,7 +131,7 @@ def get_dataset_srid_alchemy_expression(md: MetadataType, default_crs: str = Non
     # When datasets have no CRS, optionally use this as default.
     default_crs_expression = None
     if default_crs:
-        if not default_crs.lower().startswith("epsg:"):
+        if not default_crs.lower().startswith("epsg:") and not default_crs.lower().startswith("esri:"):
             raise NotImplementedError(
                 "CRS expected in form of 'EPSG:1234'. Got: %r" % default_crs
             )

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -131,7 +131,9 @@ def get_dataset_srid_alchemy_expression(md: MetadataType, default_crs: str = Non
     # When datasets have no CRS, optionally use this as default.
     default_crs_expression = None
     if default_crs:
-        if not default_crs.lower().startswith("epsg:") and not default_crs.lower().startswith("esri:"):
+        if not default_crs.lower().startswith(
+            "epsg:"
+        ) and not default_crs.lower().startswith("esri:"):
             raise NotImplementedError(
                 "CRS expected in form of 'EPSG:1234'. Got: %r" % default_crs
             )

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,6 +5,8 @@ services:
       context: .
       args:
         ENVIRONMENT: test
+    environment:
+      - PROJ_LIB=/usr/share/proj  # This is to fix an odd issue with PyProj
     volumes:
       - ./:/code
       - ./.docker/.datacube_integration.conf:/root/.datacube_integration.conf


### PR DESCRIPTION
Fixes a single line of code that tests for an `epsg` string to make it include `esri` strings too, which it turns out are valid in Proj 6.