### PR TITLE
'generate' command should default to --no-init-db

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Now install the explorer dependencies:
 
 ### Summary generation
 
-Cache some product summaries:
+Initialise and create product summaries:
 
-    nohup cubedash-gen --all &>> summary-gen.log &
+    nohup cubedash-gen --init --all &>> summary-gen.log &
 
 (This can take a while the first time, depending on your datacube size. 
 We're using `nohup .. &` to run in the background.)

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -171,7 +171,17 @@ SPATIAL_QUALITY_STATS = Table(
 )
 
 
+def has_schema(engine: Engine) -> bool:
+    """
+    Does the cubedash schema already exist?
+    """
+    return engine.dialect.has_schema(engine, CUBEDASH_SCHEMA)
+
+
 def create_schema(engine: Engine):
+    """
+    Create any missing parts of the cubedash schema
+    """
     engine.execute(DDL(f"create schema if not exists {CUBEDASH_SCHEMA}"))
     engine.execute(DDL(f"create extension if not exists postgis"))
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -28,9 +28,10 @@ TEST_DATA_DIR = Path(__file__).parent / "data"
 
 @pytest.fixture(scope="function")
 def summary_store(module_dea_index: Index) -> SummaryStore:
-    SummaryStore.create(module_dea_index, init_schema=False).drop_all()
+    store = SummaryStore.create(module_dea_index)
+    store.drop_all()
     module_dea_index.close()
-    store = SummaryStore.create(module_dea_index, init_schema=True)
+    store.init()
     return store
 
 


### PR DESCRIPTION
As suggested by @alexgleith on Slack.

The new prod instances are always passing `--no-init-db` so that they can run with tighter user permissions (presumably only `insert`/`update`, not `create`). 

We could have fixed this accidental requirement of `create` permission, but it's probably better to be consistent with datacube-core/ows and separate `init` as an explicit action.

It will print a 'friendly' red error message if you have not initialised:

```
 $ cubedash-gen 
No cubedash schema exists. Please rerun with --init to create one
```

--- 
I've also included a second commit to clean up some inconsistent stderr/stdout usage in the user messages of the command.
