### PR TITLE
#153 Use git to get unstable semver

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,32 +34,28 @@ jobs:
       - name: Log the unstable tag
         run: echo $UNSTABLE_TAG
 
-      - name: Build and Push latest Docker image
+      - name: Build and Push unstable + latest Docker image tag
+        if: github.event_name != 'release'
         uses: whoan/docker-build-with-cache-action@v4
         with:
           image_name: ${{ env.IMAGE_NAME }}
           username: gadockersvc
+          image_tag: ${{ env.UNSTABLE_TAG }},latest
           password: "${{ secrets.DockerPassword }}"
           build_extra_args: "--build-arg=ENVIRONMENT=deployment"
 
-      - name: Build and Push unstable Docker image tag
-        uses: whoan/docker-build-with-cache-action@v4
-        with:
-          image_name: ${{ env.IMAGE_NAME }}
-          username: gadockersvc
-          image_tag: ${{ env.UNSTABLE_TAG }}
-          password: "${{ secrets.DockerPassword }}"
-          build_extra_args: "--build-arg=ENVIRONMENT=deployment"
-
-      - name: Build and Push latest Docker image (old name)
+      - name: Build and Push unstable + latest Docker image (old name)
+        if: github.event_name != 'release'
         uses: whoan/docker-build-with-cache-action@v4
         with:
           image_name: ${{ env.OLD_IMAGE_NAME }}
+          image_tag: ${{ env.UNSTABLE_TAG }},latest
           username: gadockersvc
           password: "${{ secrets.DockerPassword }}"
           build_extra_args: "--build-arg=ENVIRONMENT=deployment"
 
       - name: Run vulnerability scanner
+        if: github.event_name != 'release'
         uses: aquasecurity/trivy-action@0.0.6
         with:
           image-ref: "${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}"
@@ -95,6 +91,15 @@ jobs:
           username: gadockersvc
           password: "${{ secrets.DockerPassword }}"
           build_extra_args: "--build-arg=ENVIRONMENT=deployment"
+
+      - name: Run vulnerability scanner for Release
+        if: github.event_name == 'release'
+        uses: aquasecurity/trivy-action@0.0.6
+        with:
+          image-ref: "${{ env.IMAGE_NAME }}: ${{ env.RELEASE }}"
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
 
       - name: Notify Slack for Failures
         uses: rtCamp/action-slack-notify@v2.0.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,11 +27,27 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get unstable git tag
+        run: >
+          echo ::set-env name=UNSTABLE_TAG::$(git describe --tags)
+
+      - name: Log the unstable tag
+        run: echo $UNSTABLE_TAG
+
       - name: Build and Push latest Docker image
         uses: whoan/docker-build-with-cache-action@v4
         with:
           image_name: ${{ env.IMAGE_NAME }}
           username: gadockersvc
+          password: "${{ secrets.DockerPassword }}"
+          build_extra_args: "--build-arg=ENVIRONMENT=deployment"
+
+      - name: Build and Push unstable Docker image tag
+        uses: whoan/docker-build-with-cache-action@v4
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          username: gadockersvc
+          image_tag: ${{ env.UNSTABLE_TAG }}
           password: "${{ secrets.DockerPassword }}"
           build_extra_args: "--build-arg=ENVIRONMENT=deployment"
 
@@ -46,7 +62,7 @@ jobs:
       - name: Run vulnerability scanner
         uses: aquasecurity/trivy-action@0.0.6
         with:
-          image-ref: "${{ env.IMAGE_NAME }}:latest"
+          image-ref: "${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}"
           format: "table"
           exit-code: "1"
           severity: "CRITICAL,HIGH"


### PR DESCRIPTION
Closes #153 
- Use git to fetch unstable semver
- Push unstable Semver to dockerhub
- Scan the latest unstable semver with Trivy instead of latest
- Scan release semver with Trivy ( more scanning more security ? )