### PR TITLE
Remove isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,3 @@ repos:
     rev: v0.2.0
     hooks:
       - id: flake8-markdown
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
-    hooks:
-      - id: isort


### PR DESCRIPTION
It disagrees with Black and seems to cause more problems than it fixes.

Somehow we still end up with imports changing between developers.
I don't think it's worth the hassle.