### PR TITLE
Fix/futurewarning

### DIFF
--- a/cubedash/summary/_model.py
+++ b/cubedash/summary/_model.py
@@ -155,8 +155,8 @@ class TimePeriodOverview:
             warnings.warn(f"Geometry without a crs for {self}")
             return None
 
-        origin = pyproj.Proj(init=self.footprint_crs)
-        dest = pyproj.Proj(init="epsg:4326")
+        origin = pyproj.Proj(self.footprint_crs)
+        dest = pyproj.Proj("epsg:4326")
 
         tranform_wrs84 = partial(pyproj.transform, origin, dest)
         new_geometry = transform(tranform_wrs84, self.footprint_geometry)


### PR DESCRIPTION
Fix `/usr/local/lib/python3.6/dist-packages/pyproj/crs.py:77: FutureWarning: '+init=:' syntax is deprecated. ':' is the preferred initialization method. return _prepare_from_string(" ".join(pjargs))`

