### PR TITLE
Add an option to recreate existing dataset extents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,28 @@ help: ## Display this help text
 .PHONY: install
 install: ## Install all requirements and explorer
 	pip install -U setuptools pip
-	pip install -U -r requirements-test.txt
 	pip install -e .[test]
+
+.PHONY: install-flake8
+install-flake8:
+	pipx install flake8
+	# Add the same plugins as the .pre-commit-config.yaml
+	pipx inject flake8 \
+		   dlint \
+		   flake8-broken-line \
+		   flake8-bugbear \
+		   flake8-builtins \
+		   flake8-coding \
+		   flake8-debugger \
+		   flake8-executable \
+		   flake8-logging-format \
+		   flake8-pep3101 \
+		   flake8-pytest-style \
+		   flake8-pytest \
+		   flake8-rst-docstrings
 
 .PHONY: format
 format: ## Reformat all Python code
-	isort -rc cubedash integration_tests
 	black cubedash integration_tests ./*.py
 
 .PHONY: lint

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Initialise and create product summaries:
 
 (This can take a long time the first time, depending on your datacube size.)
 
+Other available options can be seen by running `cubedash-gen --help`.
+
 ### Run
 
 Explorer can be run using any typical python wsgi server, for example:

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -51,7 +51,7 @@ def generate_report(
         log.info("generate.product.refresh.done")
 
         log.info("generate.product")
-        updated = store.get_or_update(product.name, None, None, None, force_refresh)
+        updated = store.get_or_update(product.name, force_refresh=force_refresh)
         log.info("generate.product.done")
 
         return product_name, updated

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -169,7 +169,7 @@ def _load_products(index: Index, product_names) -> List[DatasetType]:
     default=False,
     help=dedent(
         """\
-        Overwrite Explorer's dataset extents rather than appending only the new datasets.
+        Rebuild Explorer's existing dataset extents rather than appending new datasets.
 
         This is useful if you've patched datasets or products in-place with new geometry
         or regions.

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -4,6 +4,7 @@ import multiprocessing
 import sys
 from datetime import timedelta
 from functools import partial
+from textwrap import dedent
 from typing import List, Sequence, Tuple, Optional
 
 import click
@@ -163,9 +164,17 @@ def _load_products(index: Index, product_names) -> List[DatasetType]:
 @click.option("--refresh-stats/--no-refresh-stats", is_flag=True, default=True)
 @click.option("--force-refresh/--no-force-refresh", is_flag=True, default=False)
 @click.option(
-    "--recreate-dataset-extents/--no-recreate-dataset-extents",
+    "--recreate-dataset-extents/--append-dataset-extents",
     is_flag=True,
     default=False,
+    help=dedent(
+        """\
+        Overwrite Explorer's dataset extents rather than appending only the new datasets.
+
+        This is useful if you've patched datasets or products in-place with new geometry
+        or regions.
+        """
+    ),
 )
 @click.option("--force-concurrently", is_flag=True, default=False)
 @click.option(

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -351,7 +351,7 @@ def _populate_missing_dataset_extents(
             )
             .on_conflict_do_nothing(index_elements=["id"])
         )
-    print(as_sql(query))
+    # print(as_sql(query))
 
     _LOG.debug(
         "spatial_insert_query.start",

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -334,7 +334,7 @@ def _populate_missing_dataset_extents(
                 DATASET.c.dataset_type_ref
                 == bindparam("product_ref", product.id, type_=SmallInteger)
             )
-            .where(DATASET.c.archived == None),
+            .where(DATASET.c.archived == None)
         )
     else:
         query = (

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from typing import Set
+from enum import Enum
 import structlog
 from geoalchemy2 import Geometry
 from sqlalchemy import (
@@ -9,7 +11,7 @@ from sqlalchemy import (
     Column,
     Date,
     DateTime,
-    Enum,
+    Enum as SqlEnum,
     ForeignKey,
     Index,
     Integer,
@@ -111,7 +113,9 @@ TIME_OVERVIEW = Table(
     METADATA,
     # Uniquely identified by three values:
     Column("product_ref", None, ForeignKey(PRODUCT.c.id)),
-    Column("period_type", Enum("all", "year", "month", "day", name="overviewperiod")),
+    Column(
+        "period_type", SqlEnum("all", "year", "month", "day", name="overviewperiod")
+    ),
     Column("start_day", Date),
     Column("dataset_count", Integer, nullable=False),
     # Time range (if there's at least one dataset)
@@ -119,7 +123,7 @@ TIME_OVERVIEW = Table(
     Column("time_latest", DateTime(timezone=True)),
     Column(
         "timeline_period",
-        Enum("year", "month", "week", "day", name="timelineperiod"),
+        SqlEnum("year", "month", "week", "day", name="timelineperiod"),
         nullable=False,
     ),
     Column(
@@ -206,8 +210,24 @@ def is_compatible_schema(engine: Engine) -> bool:
     return is_latest
 
 
-def update_schema(engine: Engine):
-    """Update the schema if needed."""
+class PleaseRefresh(Enum):
+    """
+    What data should be refreshed/recomputed?
+    """
+
+    # Refresh dataset extents for EO3 datasets
+    EO3_DATASET_EXTENTS = 1
+
+
+def update_schema(engine: Engine) -> Set[PleaseRefresh]:
+    """
+    Update the schema if needed.
+
+    Returns what data should be resummarised.
+    """
+
+    refresh = set()
+
     if not pg_column_exists(engine, f"{CUBEDASH_SCHEMA}.product", "fixed_metadata"):
         _LOG.info("schema.applying_update.add_fixed_metadata")
         engine.execute(
@@ -215,6 +235,9 @@ def update_schema(engine: Engine):
         alter table {CUBEDASH_SCHEMA}.product add column fixed_metadata jsonb
         """
         )
+        refresh.add(PleaseRefresh.EO3_DATASET_EXTENTS)
+
+    return refresh
 
 
 def pg_exists(conn, name: str) -> bool:

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -215,8 +215,8 @@ class PleaseRefresh(Enum):
     What data should be refreshed/recomputed?
     """
 
-    # Refresh dataset extents for EO3 datasets
-    EO3_DATASET_EXTENTS = 1
+    # Refresh all calculated extents/geometry for datasets
+    DATASET_EXTENTS = 1
 
 
 def update_schema(engine: Engine) -> Set[PleaseRefresh]:
@@ -235,7 +235,7 @@ def update_schema(engine: Engine) -> Set[PleaseRefresh]:
         alter table {CUBEDASH_SCHEMA}.product add column fixed_metadata jsonb
         """
         )
-        refresh.add(PleaseRefresh.EO3_DATASET_EXTENTS)
+        refresh.add(PleaseRefresh.DATASET_EXTENTS)
 
     return refresh
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -709,7 +709,7 @@ class SummaryStore:
         month: Optional[int] = None,
         day: Optional[int] = None,
         force_refresh: Optional[bool] = False,
-    ):
+    ) -> TimePeriodOverview:
         """
         Get a cached summary if exists, otherwise generate one
 
@@ -738,7 +738,7 @@ class SummaryStore:
         day: Optional[int] = None,
         generate_missing_children: Optional[bool] = True,
         force_refresh: Optional[bool] = False,
-    ):
+    ) -> TimePeriodOverview:
         """Update the given summary and return the new one"""
         product = self._product(product_name)
         get_child = self.get_or_update if generate_missing_children else self.get

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -23,7 +23,6 @@ from sqlalchemy.sql import Select
 from cubedash import _utils
 from cubedash._utils import ODC_DATASET, ODC_DATASET_TYPE
 from cubedash.summary import RegionInfo, TimePeriodOverview, _extents, _schema
-from cubedash.summary._extents import expects_eo3_metadata_type
 from cubedash.summary._schema import (
     DATASET_SPATIAL,
     PRODUCT,
@@ -898,16 +897,13 @@ def _refresh_data(item: PleaseRefresh, store: SummaryStore):
     """
     Refresh the given kind of data.
     """
-    if item == PleaseRefresh.EO3_DATASET_EXTENTS:
-        # Refresh dataset extents for EO3 datasets
-
+    if item == PleaseRefresh.DATASET_EXTENTS:
         for dt in store.all_dataset_types():
             # Skip product if it's never been summarised at all.
             if store.get_product_summary(dt.name) is None:
                 continue
 
-            if expects_eo3_metadata_type(dt.metadata_type):
-                store.refresh_product(dt, force_dataset_extent_recompute=True)
+            store.refresh_product(dt, force_dataset_extent_recompute=True)
     else:
         raise NotImplementedError(f"Unknown data type to refresh_data: {item}")
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -162,7 +162,11 @@ class SummaryStore:
         refresh_older_than: timedelta = _DEFAULT_REFRESH_OLDER_THAN,
         dataset_sample_size: int = 1000,
         force_dataset_extent_recompute=False,
-    ):
+    ) -> Optional[int]:
+        """
+        Update Explorer's computed extents for the given product, and record any new
+        datasets into the spatial table.
+        """
         our_product = self.get_product_summary(product.name)
 
         if (
@@ -221,11 +225,16 @@ class SummaryStore:
         return added_count
 
     def refresh_stats(self, concurrently=False):
+        """
+        Refresh general statistics tables that cover all products.
+
+        This is ideally done once after all needed products have been refreshed.
+        """
         refresh_supporting_views(self._engine, concurrently=concurrently)
 
     def _find_product_fixed_metadata(
         self, product: DatasetType, sample_percentage=0.05
-    ):
+    ) -> Dict[str, any]:
         """
         Find metadata fields that have an identical value in every dataset of the product.
 
@@ -322,7 +331,7 @@ class SummaryStore:
 
     def _get_linked_products(
         self, product: DatasetType, kind="source", sample_percentage=0.05
-    ):
+    ) -> List[str]:
         """
         Find products with upstream or downstream datasets from this product.
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from textwrap import indent
 from typing import Tuple
 
 import pytest
@@ -59,17 +60,21 @@ def clirunner(global_integration_cli_args):
         runner = CliRunner()
         result = runner.invoke(cli_method, exe_opts, catch_exceptions=catch_exceptions)
         if expect_success:
-            assert 0 == result.exit_code, f"Error for {opts}. output: {result.output!r}"
+            assert (
+                0 == result.exit_code
+            ), f"Error for {opts}. Out:\n{indent(result.output, ' '*4)}"
         return result
 
     return _run_cli
 
 
 @pytest.fixture()
-def run_generate(clirunner, summary_store):
-    def do(*only_products, expect_success=True):
-        products = only_products or ["--all"]
-        res = clirunner(generate.cli, products, expect_success=expect_success)
+def run_generate(clirunner, summary_store, multi_processed=False):
+    def do(*args, expect_success=True):
+        args = args or ["--all"]
+        if not multi_processed:
+            args = ("-j", "1") + args
+        res = clirunner(generate.cli, args, expect_success=expect_success)
         return res
 
     return do

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -71,9 +71,9 @@ def clirunner(global_integration_cli_args):
 @pytest.fixture()
 def run_generate(clirunner, summary_store, multi_processed=False):
     def do(*args, expect_success=True):
-        args = args or ["--all"]
+        args = args or ("--all",)
         if not multi_processed:
-            args = ("-j", "1") + args
+            args = ("-j", "1") + tuple(args)
         res = clirunner(generate.cli, args, expect_success=expect_success)
         return res
 

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -279,12 +279,17 @@ def test_view_product(client: FlaskClient):
     assert b"Landsat 7 NBAR 25 metre" in rv.data
 
 
-def test_view_metadata_type(client: FlaskClient):
+def test_view_metadata_type(client: FlaskClient, populated_index: Index):
     # Does it load without error?
     html: HTML = get_html(client, "/metadata-type/eo")
     assert html.find("h2", first=True).text == "eo"
+
+    how_many_are_eo = len(
+        [p for p in populated_index.products.get_all() if p.metadata_type.name == "eo"]
+    )
     assert (
-        html.find(".header-follow", first=True).text == "metadata type of 44 products"
+        html.find(".header-follow", first=True).text
+        == f"metadata type of {how_many_are_eo} products"
     )
 
     # Does the page list products using the type?

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -353,7 +353,7 @@ def test_force_dataset_regeneration(
     assert footprint != original_footprint, "Test data didn't successfully override"
 
     # Now force-recreate dataset extents
-    run_generate("ls8_nbar_albers", "--recreate-dataset-extents")
+    run_generate("-v", "ls8_nbar_albers", "--recreate-dataset-extents")
 
     # ... and they should be correct again
     footprint = summary_store.get_dataset_footprint_region(example_dataset.id)

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -13,6 +13,7 @@ from dateutil.tz import tzutc
 from cubedash._utils import alchemy_engine
 from cubedash.summary import SummaryStore
 from cubedash.summary._schema import CUBEDASH_SCHEMA
+from datacube.index import Index
 from datacube.index.hl import Doc2Dataset
 from datacube.model import Range
 from datacube.utils import read_documents
@@ -318,6 +319,47 @@ def test_generate_day(run_generate, summary_store: SummaryStore):
     )
 
 
+def test_force_dataset_regeneration(
+    run_generate, summary_store: SummaryStore, module_index: Index
+):
+    """
+    We should be able to force-replace dataset extents with the "--recreate-dataset-extents" option
+    """
+    run_generate("ls8_nbar_albers")
+    [example_dataset] = summary_store.index.datasets.search_eager(
+        product="ls8_nbar_albers", limit=1
+    )
+
+    original_footprint = summary_store.get_dataset_footprint_region(example_dataset.id)
+    assert original_footprint is not None
+
+    # Now let's break the footprint!
+    alchemy_engine(module_index).execute(
+        f"update {CUBEDASH_SCHEMA}.dataset_spatial "
+        "    set footprint="
+        "        ST_SetSRID("
+        "            ST_GeomFromText("
+        "                'POLYGON((-71.1776585052917 42.3902909739571,-71.1776820268866 42.3903701743239,"
+        "                          -71.1776063012595 42.3903825660754,-71.1775826583081 42.3903033653531,"
+        "                          -71.1776585052917 42.3902909739571))'"
+        "            ),"
+        "            4326"
+        "        )"
+        "    where id=%s",
+        example_dataset.id,
+    )
+    # Make sure it worked
+    footprint = summary_store.get_dataset_footprint_region(example_dataset.id)
+    assert footprint != original_footprint, "Test data didn't successfully override"
+
+    # Now force-recreate dataset extents
+    run_generate("ls8_nbar_albers", "--recreate-dataset-extents")
+
+    # ... and they should be correct again
+    footprint = summary_store.get_dataset_footprint_region(example_dataset.id)
+    assert footprint == original_footprint, "Dataset extent was not regenerated"
+
+
 def test_calc_albers_summary_with_storage(summary_store: SummaryStore):
     summary_store.refresh_all_products()
 
@@ -360,7 +402,7 @@ def test_calc_albers_summary_with_storage(summary_store: SummaryStore):
     assert cached_s.dataset_count == summary.dataset_count
 
 
-def test_cubedash_gen_refresh(run_generate, module_index):
+def test_cubedash_gen_refresh(run_generate, module_index: Index):
     """
     cubedash-gen shouldn't increment the product sequence when run normally
     """

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ tests_require = [
     "boltons",
     "digitalearthau",
     "flake8",
-    "isort[requirements]",
     "jsonschema > 3",
     "pytest",
     "pytest-benchmark",


### PR DESCRIPTION
...and do it automatically as part of the schema update, so that the newer, better extents will show up.

Option:
```bash
$ cubedash-gen --recreate-dataset-extents <products...>
```

I've also changed `generate` so that it doesn't spawn any subprocesses at all when workers==1. This makes debugging a little nicer.