### PR TITLE
Assorted minor web, rendering, refresh fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ Add a `.datacube_integration.conf` file to your home directory in the same forma
 Then run pytest: `pytest integration_tests`
 
 __Warning__ All data in this database will be dropped while running tests. Use a separate one from your normal development db.
-#### Roles for production deployments
+
+## Roles for production deployments
 
 The [roles](cubedash/summary/roles) directory contains sql files for creating
 Postgres roles for Explorer. These are suitable for running each Explorer 

--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division
 import calendar
 import logging
 from datetime import datetime
+from typing import Mapping
 
 import flask
 import rapidjson
@@ -104,6 +105,11 @@ def _product_link(product_name):
 @bp.app_template_filter("dataset_created")
 def _dataset_created(dataset: Dataset):
     return utils.dataset_created(dataset)
+
+
+@bp.app_template_filter("all_values_none")
+def _all_values_none(d: Mapping):
+    return all(v is None for v in d.values())
 
 
 @bp.app_template_filter("dataset_day_link")

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -1,5 +1,5 @@
-import time
 import os
+import time
 from pathlib import Path
 from typing import Counter, Dict, Iterable, Optional, Tuple
 
@@ -147,7 +147,6 @@ def get_regions_geojson(
     month: Optional[int] = None,
     day: Optional[int] = None,
 ) -> Optional[Dict]:
-
     product = STORE.get_dataset_type(product_name)
 
     region_info = STORE.get_product_region_info(product_name)
@@ -278,3 +277,11 @@ def enable_prometheus():
 
         metrics = GunicornInternalPrometheusMetrics(app)
         _LOG.info(f"Prometheus metrics enabled : {metrics}")
+
+
+@app.before_first_request
+def check_schema_compatibility():
+    if not STORE.is_schema_compatible():
+        raise RuntimeError(
+            "Cubedash schema is out of date. Please rerun `cubedash-gen --init` to apply updates."
+        )

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -283,5 +283,6 @@ def enable_prometheus():
 def check_schema_compatibility():
     if not STORE.is_schema_compatible():
         raise RuntimeError(
-            "Cubedash schema is out of date. Please rerun `cubedash-gen --init` to apply updates."
+            "Cubedash schema is out of date. "
+            "Please rerun `cubedash-gen -v --init` to apply updates."
         )

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -696,7 +696,6 @@ class SummaryStore:
         )
 
         for r in self._engine.execute(query):
-
             yield DatasetItem(
                 dataset_id=r.id,
                 bbox=_box2d_to_bbox(r.bbox) if r.bbox else None,
@@ -1009,7 +1008,7 @@ def _summary_to_row(summary: TimePeriodOverview) -> dict:
     )
 
 
-def _counter_key_vals(counts: Counter) -> Tuple[Tuple, Tuple]:
+def _counter_key_vals(counts: Counter, null_sort_key="ø") -> Tuple[Tuple, Tuple]:
     """
     Split counter into a keys sequence and a values sequence.
 
@@ -1019,11 +1018,17 @@ def _counter_key_vals(counts: Counter) -> Tuple[Tuple, Tuple]:
     (('a', 'b'), (2, 1))
     >>> tuple(_counter_key_vals(Counter(['a'])))
     (('a',), (1,))
+    >>> tuple(_counter_key_vals(Counter(['a', None])))
+    (('a', None), (1, 1))
     >>> # Important! zip(*) doesn't do this.
     >>> tuple(_counter_key_vals(Counter()))
     ((), ())
     """
-    items = sorted(counts.items())
+    items = sorted(
+        counts.items(),
+        # Swap nulls if needed.
+        key=lambda t: (null_sort_key, t[1]) if t[0] is None else t,
+    )
     return tuple(k for k, v in items), tuple(v for k, v in items)
 
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -910,11 +910,13 @@ def _refresh_data(item: PleaseRefresh, store: SummaryStore):
     """
     if item == PleaseRefresh.DATASET_EXTENTS:
         for dt in store.all_dataset_types():
+            _LOG.info("data.refreshing_extents", product=dt.name)
             # Skip product if it's never been summarised at all.
             if store.get_product_summary(dt.name) is None:
                 continue
 
             store.refresh_product(dt, force_dataset_extent_recompute=True)
+        _LOG.info("data.refreshing_extents.complete")
     else:
         raise NotImplementedError(f"Unknown data type to refresh_data: {item}")
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1055,7 +1055,7 @@ def _dataset_to_feature(dataset: Dataset):
 
 
 _BOX2D_PATTERN = re.compile(
-    r"BOX\(([-0-9.]+)\s+([-0-9.]+)\s*,\s*([-0-9.]+)\s+([-0-9.]+)\)"
+    r"BOX\(([-0-9.e]+)\s+([-0-9.e]+)\s*,\s*([-0-9.e]+)\s+([-0-9.e]+)\)"
 )
 
 
@@ -1067,8 +1067,16 @@ def _box2d_to_bbox(pg_box2d: str) -> Tuple[float, float, float, float]:
     ...     "BOX(134.806923200497 -17.7694714883835,135.769692610214 -16.8412669214876)"
     ... )
     (134.806923200497, -17.7694714883835, 135.769692610214, -16.8412669214876)
+    >>> # Scientific notation in numbers is sometimes given
+    >>> _box2d_to_bbox(
+    ...     "BOX(35.6948526641442 -0.992278901187827,36.3518945675102 -9.03173177994956e-06)"
+    ... )
+    (35.6948526641442, -0.992278901187827, 36.3518945675102, -9.03173177994956e-06)
     """
     m = _BOX2D_PATTERN.match(pg_box2d)
+    if m is None:
+        raise RuntimeError(f"Unexpected postgis box syntax {pg_box2d!r}")
+
     # We know there's exactly four groups, but type checker doesn't...
     # noinspection PyTypeChecker
     return tuple(float(m) for m in m.groups())

--- a/cubedash/templates/dataset.html
+++ b/cubedash/templates/dataset.html
@@ -31,10 +31,12 @@
 {% block content %}
     {% from "layout/macros.html" import query_param_list, show_raw_document %}
     <div class="panel highlight">
-        <h1><strong>{{ dataset | printable_dataset }}</strong></h1>
+        <h2 class="followed"><strong>{{ dataset | printable_dataset }}</strong></h2>
+        <div class="header-follow">
+                dataset of product {{ dataset.type.name | product_link }}
+        </div>
         <div class="sub-header">
             <span>
-                {% if dataset_region_code %}Region <strong>{{ dataset_region_code }}</strong>, {% endif %}
                 Indexed by <strong>{{ dataset.indexed_by }}</strong>
                 {{ dataset.indexed_time | timesince }},
                 created {{ dataset | dataset_created | timesince }}
@@ -49,8 +51,14 @@
             </span>
         </div>
         <div class="sub-header">
-            {{ dataset.type.name | product_link }} of {{ dataset | dataset_day_link(grouping_timezone) }}
-            ({{ dataset.type.metadata_type.name }})
+            {% if dataset_region_code %}
+                    Region
+                    <a href="{{ url_for('region_page', region_code=dataset_region_code, product_name=dataset.type.name)}}">
+                        {{- dataset_region_code -}}
+                    </a>
+                {% endif %}
+            for
+            {{ dataset | dataset_day_link(grouping_timezone) }}
         </div>
     </div>
 

--- a/cubedash/templates/metadata-type.html
+++ b/cubedash/templates/metadata-type.html
@@ -8,7 +8,7 @@
 {% block content %}
     {% from "layout/macros.html" import query_param_list, show_raw_document %}
 
-    <div class="panel odd">
+    <div class="panel highlight">
         <h2 class="followed"><span class="metadata-type-name">{{ metadata_type.name }}</span></h2>
         <div class="header-follow">metadata type of {{ products_using_it | length }} products</div>
 

--- a/cubedash/templates/metadata-type.html
+++ b/cubedash/templates/metadata-type.html
@@ -9,7 +9,12 @@
     {% from "layout/macros.html" import query_param_list, show_raw_document %}
 
     <div class="panel highlight">
-        <h2 class="followed"><span class="metadata-type-name">{{ metadata_type.name }}</span></h2>
+        <h2 class="followed">
+            <span class="metadata-type-name">
+                <i class="fa fa-hdd-o" aria-hidden="true"></i>
+                {{ metadata_type.name }}
+            </span>
+        </h2>
         <div class="header-follow">metadata type of {{ products_using_it | length }} products</div>
 
         <div><em>

--- a/cubedash/templates/overview.html
+++ b/cubedash/templates/overview.html
@@ -73,7 +73,11 @@
                     </a>
 
                     {% if selected_summary.dataset_count != selected_summary.footprint_count %}
-                        ({{ selected_summary.footprint_count or 'None' }} displayable)
+                        {%- if selected_summary.footprint_count -%}
+                            ({{ '{:,d}'.format(selected_summary.footprint_count) }} displayable)
+                        {%- else -%}
+                            (None displayable)
+                        {%- endif -%}
                     {% endif %}
 
                     <ul>

--- a/cubedash/templates/overview.html
+++ b/cubedash/templates/overview.html
@@ -144,11 +144,19 @@
                         metadata:
                     </h4>
 
-                    {{ query_param_list(product.fields,
+                    {% if (product.fields | all_values_none) and (product_summary.fixed_metadata == {}) %}
+                        <em>No common values</em>
+                    {% else %}
+                        {{ query_param_list(product.fields,
                                         show_nulls=false,
                                         descriptions=product.metadata_type.dataset_fields,
                                         fallback_dict=product_summary.fixed_metadata or {}) }}
-
+                        {% if product_summary.fixed_metadata is none %}
+                            <em class="muted" title="Generated summaries are out of date">
+                                Unknown (needs refresh)
+                            </em>
+                        {% endif %}
+                    {% endif %}
 
                     {% if product_summary.derived_products %}
                         <h4>Derived</h4>

--- a/cubedash/templates/product-audit.html
+++ b/cubedash/templates/product-audit.html
@@ -19,11 +19,11 @@
 {% endblock %}
 {% block content %}
     {% from "layout/macros.html" import query_param_list, show_raw_document %}
-    <div class="panel highlight">
-        <h1 class="followed">Product Audit
+    <div class="panel">
+        <h2 class="followed">Product Audit
             {%- if sentry_public_dsn and sentry_public_args.environment %} ({{ sentry_public_args.environment }})
             {%- endif -%}
-        </h1>
+        </h2>
         <div class="header-follow">{{ products_summarised|length }} products with summaries.
             {{ (products_missing | length) or 'None' }} without{% if products_missing %}:{% else %}.{% endif %}
             {% for name in products_missing %}

--- a/cubedash/templates/product.html
+++ b/cubedash/templates/product.html
@@ -18,31 +18,40 @@
         </div>
         <div>
             <em>{{ product.definition['description'] }}</em>
-
         </div>
         <p>
-
-            <a href="{{ url_for('overview_page', product_name=product.name) }}">
-                {%- if product_summary.time_earliest -%}
-                    {{ product_summary.time_earliest.strftime('%B %Y') }} to
-                    {{ product_summary.time_latest.strftime('%B %Y') }}
-                {%- endif -%}
-            </a>,
-            <a href="{{ url_for('search_page', product_name=product.name) }}">
-                {{ product_summary.dataset_count or '0' }} datasets
-            </a>
+                <i class="fa fa-globe" aria-hidden="true"></i>
+                <a href="{{ url_for('overview_page', product_name=product.name) }}">
+                    {% if product_summary.time_earliest -%}
+                        {{ product_summary.time_earliest.strftime('%B %Y') }} to
+                        {{ product_summary.time_latest.strftime('%B %Y') }}
+                    {%- endif -%}
+                </a><br/>
+                <i class="fa fa-list" aria-hidden="true"></i>
+                <a href="{{ url_for('search_page', product_name=product.name) }}">
+                    {{ product_summary.dataset_count or '0' }} datasets
+                </a>
         </p>
     </div>
     <div class="panel">
 
         <h3>Metadata</h3>
-        {{ query_param_list(
-                    product.fields,
-                    wide=true,
-                    show_nulls=false,
-                    descriptions=product.metadata_type.dataset_fields,
-                    fallback_dict=fixed_metadata)
-                }}
+
+        {% if (product.fields | all_values_none) and (product_summary.fixed_metadata == {}) %}
+            <em>No common values</em>
+        {% else %}
+            {{ query_param_list(product.fields,
+                            show_nulls=false,
+                            wide=true,
+                            descriptions=product.metadata_type.dataset_fields,
+                            fallback_dict=product_summary.fixed_metadata or {}) }}
+            {% if product_summary.fixed_metadata is none %}
+                <em title="Generated summaries are out of date">
+                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                    Unknown fixed fields
+                </em>
+            {% endif %}
+        {% endif %}
     </div>
     <div class="panel odd">
         <h3>Searchable fields</h3>
@@ -50,8 +59,13 @@
             <div>
                 {% set field = product.metadata_type.dataset_fields[key] %}
                 {{ key }}
-                {% if field.indexed is true %}<span title="indexed">•</span>{% endif %}
-                <span class="badge">{{ field.type_name }}</span>
+
+                <span class="badge">
+                    {{- field.type_name -}}
+                    {%- if field.indexed is true %}
+                        <span title="indexed"><i class="fa fa-square" aria-hidden="true"></i></span>
+                    {%- endif -%}
+                </span>
                 {% if field.description and ('TODO' not in field.description) %}
                     <span class="muted">{{ field.description }}</span>
                 {% endif %}

--- a/cubedash/templates/product.html
+++ b/cubedash/templates/product.html
@@ -29,7 +29,7 @@
                 </a><br/>
                 <i class="fa fa-list" aria-hidden="true"></i>
                 <a href="{{ url_for('search_page', product_name=product.name) }}">
-                    {{ product_summary.dataset_count or '0' }} datasets
+                    {{ '{:,d}'.format(product_summary.dataset_count) if product_summary.dataset_count else '0' }} datasets
                 </a>
         </p>
     </div>

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -257,7 +257,10 @@ def test_view_dataset(client: FlaskClient):
     html = get_html(client, "/dataset/57848615-2421-4d25-bfef-73f57de0574d")
 
     # Label of dataset is header
-    assert "LS7_ETM_OTH_P51_GALPGS01-002_105_074_20170501" in _h1_text(html)
+    assert (
+        "LS7_ETM_OTH_P51_GALPGS01-002_105_074_20170501"
+        in html.find("h2", first=True).text
+    )
 
     # wofs_albers dataset (has no label or location)
     rv: Response = client.get("/dataset/20c024b5-6623-4b06-b00c-6b5789f81eeb")


### PR DESCRIPTION
- Check that the schema is compatible on web boot-up, and print an error message telling the user how to fix it (Addressing some confusion on Slack)
- Put a time-limit on memoised functions (to address #131 and other minor cases where people currently have to reboot the web view to see changes). Default 10 seconds.
- Fix `generate` failure when a product has a mix of null and non-null region codes (Seen in Africa db)
- Improve informational logging during schema migration (so it doesn't look like it has stalled when dataset-extents are regenerated from #176).
- More consistent, readable document page headers (product, metadata-type, dataset...). Include extra information and links.
- Improve the display of missing data when the newer `cubedash-gen` hasn't been run yet on an existing system.
- Fix exception when Postgis gives us scientific number notation in footprint points