### PR TITLE
Convert the Regions materialised-view to a table

### DIFF
--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -260,7 +260,7 @@ class SummaryStore:
             select srid_groups.dataset_type_ref,
                    coalesce(srid_groups.region_code, '')                          as region_code,
                    ST_SimplifyPreserveTopology(
-                           ST_Union(srid_groups.footprint), 0.0001) as footprint,
+                           ST_Union(ST_MakeValid(srid_groups.footprint)), 0.0001) as footprint,
                    sum(srid_groups.count)                                         as count
             from srid_groups
             group by srid_groups.dataset_type_ref, srid_groups.region_code

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -260,7 +260,7 @@ class SummaryStore:
             select srid_groups.dataset_type_ref,
                    coalesce(srid_groups.region_code, '')                          as region_code,
                    ST_SimplifyPreserveTopology(
-                           ST_Union(ST_MakeValid(srid_groups.footprint)), 0.0001) as footprint,
+                           ST_Union(ST_Buffer(srid_groups.footprint, 0)), 0.0001) as footprint,
                    sum(srid_groups.count)                                         as count
             from srid_groups
             group by srid_groups.dataset_type_ref, srid_groups.region_code

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -74,7 +74,7 @@ class Summariser:
                     func.array_agg(select_by_srid.c.srid).label("srids"),
                     func.sum(select_by_srid.c.size_bytes).label("size_bytes"),
                     func.ST_Union(
-                        func.ST_MakeValid(select_by_srid.c.footprint_geometry),
+                        func.ST_Buffer(select_by_srid.c.footprint_geometry, 0),
                         type_=Geometry(srid=self._target_srid()),
                     ).label("footprint_geometry"),
                     func.max(select_by_srid.c.newest_dataset_creation_time).label(

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -74,7 +74,7 @@ class Summariser:
                     func.array_agg(select_by_srid.c.srid).label("srids"),
                     func.sum(select_by_srid.c.size_bytes).label("size_bytes"),
                     func.ST_Union(
-                        select_by_srid.c.footprint_geometry,
+                        func.ST_MakeValid(select_by_srid.c.footprint_geometry),
                         type_=Geometry(srid=self._target_srid()),
                     ).label("footprint_geometry"),
                     func.max(select_by_srid.c.newest_dataset_creation_time).label(

--- a/cubedash/summary/roles/40-ensure-permissions.sql
+++ b/cubedash/summary/roles/40-ensure-permissions.sql
@@ -21,7 +21,6 @@ grant insert, update, delete on all tables in schema cubedash to explorer_genera
 
 -- Must be owner of materialised views to refresh them.
 alter materialized view cubedash.mv_dataset_spatial_quality owner to explorer_generator;
-alter materialized view cubedash.mv_region owner to explorer_generator;
 alter materialized view cubedash.mv_spatial_ref_sys owner to explorer_generator;
 grant usage on sequence cubedash.product_id_seq to explorer_generator;
 
@@ -35,6 +34,7 @@ grant all privileges on all tables in schema cubedash to explorer_owner;
 -- Double-check that tables are owned by them (they should be if it created them)
 alter table cubedash.dataset_spatial owner to explorer_owner;
 alter table cubedash.product owner to explorer_owner;
+alter table cubedash.region owner to explorer_owner;
 alter table cubedash.time_overview owner to explorer_owner;
 alter sequence cubedash.product_id_seq owner to explorer_owner;
 


### PR DESCRIPTION
It gives us a lot more flexibility. Such as handling errors and incremental updating.

Users who were running previous unstable/dev versions of Explorer will need to `--init` again.

(we should probably merge #179 before this, so users are properly notified about the needed schema update.)

Planned before merging:

- [x] Improve the handling of broken geometries (the MV suffered from this too)
- [x] Run another full init/upgrade test of Africa DB with this new code on my laptop.
