### PR TITLE
Pin datacube version to latest stable release

### DIFF
--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://packages.dea.ga.gov.au/ --pre
 digitalearthau
-datacube>=1.8.0
+datacube==1.8.3


### PR DESCRIPTION
Use stable release of datacube-core explicitly.