### PR TITLE
Make product audit page header sticky

### DIFF
--- a/cubedash/templates/product-audit.html
+++ b/cubedash/templates/product-audit.html
@@ -12,6 +12,18 @@
         .data-table tr:hover {
             background-color: #f0f0f0;
         }
+
+        thead tr {
+            display: block;
+        }
+        tbody {
+            display: block;
+            height: 700px;
+            overflow: auto;
+        }
+        .data-table td, .data-table th {
+            width: 160px;
+        }
     </style>
 {% endblock %}
 {% block panel %}
@@ -125,4 +137,3 @@
     {% endif %}
 
 {% endblock %}
-


### PR DESCRIPTION
make product-audit page table header always on top

![image](https://user-images.githubusercontent.com/24644475/93834833-96137780-fcc0-11ea-9f78-087115129049.png)
