### PR TITLE
Add a page with behaviour like the cloud-team's product audit table

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -266,7 +266,7 @@ def dashboard_page():
             uri = uri_list
         item = {
             "product_name": product.name,
-            "dataset_count": _.dataset_count,
+            "dataset_count": summary.dataset_count,
             "metadata_type": product.definition["metadata_type"],
             "product_metadata": product.definition["metadata"],
             "uri": uri,

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -255,7 +255,7 @@ def dashboard_page():
         uri_list = [
             uri
             for [uri] in dc.index.datasets.search_returning(
-                ["uri"], product=p.name, limit=100
+                ["uri"], product=product.name, limit=100
             )
         ]
 
@@ -265,10 +265,10 @@ def dashboard_page():
         else:
             uri = uri_list
         item = {
-            "product_name": p.name,
+            "product_name": product.name,
             "dataset_count": _.dataset_count,
-            "metadata_type": p.definition["metadata_type"],
-            "product_metadata": p.definition["metadata"],
+            "metadata_type": product.definition["metadata_type"],
+            "product_metadata": product.definition["metadata"],
             "uri": uri,
         }
         dashboard.append(item)

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -258,11 +258,18 @@ def dashboard_page():
         for dl in dataset_list:
             for uri in dl.uris:
                 uri_list.append(uri)
+
+        common_uri = os.path.commonprefix(uri_list)
+        if common_uri:
+            uri = common_uri
+        else:
+            uri = uri_list
         item = {
             "product_name": p.name,
-            "description": p.definition["description"],
             "dataset_count": _.dataset_count,
-            "uri": os.path.commonprefix(uri_list),
+            "metadata_type": p.definition["metadata_type"],
+            "product_metadata": p.definition["metadata"],
+            "uri": uri,
         }
         dashboard.append(item)
 

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -246,7 +246,7 @@ def about_page():
 
 @app.route("/dashboard")
 def dashboard_page():
-    dc = datacube.Datacube()
+    dc = datacube.Datacube(index=_model.STORE.index)
     dashboard = []
     import os
 

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -250,7 +250,7 @@ def dashboard_page():
     dashboard = []
     import os
 
-    for p, _ in _model.get_products_with_summaries():
+    for product, summary in _model.get_products_with_summaries():
         dataset_list = dc.find_datasets(
             product=p.name, limit=100
         )  # sample max 100 datasets

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -251,13 +251,18 @@ def dashboard_page():
     import os
 
     for p, _ in _model.get_products_with_summaries():
-        dataset_list = dc.find_datasets(product=p.name, limit=1)
-        uri = dataset_list[0].uris
+        dataset_list = dc.find_datasets(
+            product=p.name, limit=100
+        )  # sample max 100 datasets
+        uri_list = []
+        for dl in dataset_list:
+            for uri in dl.uris:
+                uri_list.append(uri)
         item = {
             "product_name": p.name,
             "description": p.definition["description"],
             "dataset_count": _.dataset_count,
-            "uri": os.path.commonprefix(uri),
+            "uri": os.path.commonprefix(uri_list),
         }
         dashboard.append(item)
 

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -248,14 +248,16 @@ def about_page():
 def dashboard_page():
     dc = datacube.Datacube()
     dashboard = []
+    import os
+
     for p, _ in _model.get_products_with_summaries():
         dataset_list = dc.find_datasets(product=p.name, limit=1)
-        uri = dataset_list[0].uris[0]
+        uri = dataset_list[0].uris
         item = {
             "product_name": p.name,
             "description": p.definition["description"],
             "dataset_count": _.dataset_count,
-            "uri": uri,
+            "uri": os.path.commonprefix(uri),
         }
         dashboard.append(item)
 

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -244,6 +244,24 @@ def about_page():
     return utils.render("about.html")
 
 
+@app.route("/dashboard")
+def dashboard_page():
+    dc = datacube.Datacube()
+    dashboard = []
+    for p, _ in _model.get_products_with_summaries():
+        dataset_list = dc.find_datasets(product=p.name, limit=1)
+        uri = dataset_list[0].uris[0]
+        item = {
+            "product_name": p.name,
+            "description": p.definition["description"],
+            "dataset_count": _.dataset_count,
+            "uri": uri,
+        }
+        dashboard.append(item)
+
+    return utils.render("dashboard.html", dashboard=dashboard)
+
+
 @app.context_processor
 def inject_globals():
     last_updated = _model.get_last_updated()

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -251,13 +251,13 @@ def dashboard_page():
     import os
 
     for product, summary in _model.get_products_with_summaries():
-        dataset_list = dc.find_datasets(
-            product=p.name, limit=100
-        )  # sample max 100 datasets
-        uri_list = []
-        for dl in dataset_list:
-            for uri in dl.uris:
-                uri_list.append(uri)
+        # Sample 100 dataset uris
+        uri_list = [
+            uri
+            for [uri] in dc.index.datasets.search_returning(
+                ["uri"], product=p.name, limit=100
+            )
+        ]
 
         common_uri = os.path.commonprefix(uri_list)
         if common_uri:

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -261,7 +261,7 @@ def dashboard_page():
 
         common_uri = os.path.commonprefix(uri_list)
         if common_uri:
-            uri = common_uri
+            uri = os.path.dirname(common_uri)
         else:
             uri = uri_list
         item = {

--- a/cubedash/templates/dashboard.html
+++ b/cubedash/templates/dashboard.html
@@ -22,6 +22,18 @@
             width: 100%;
             max-width: 100%;
         }
+        thead tr {
+            display: block;
+        }
+        tbody {
+            display: block;
+            height: 700px;
+            overflow: auto;
+        }
+        table th {
+            width: 220px;
+            text-align: left;
+        }
     </style>
 {% endblock %}
 {% block panel %}
@@ -44,14 +56,14 @@
             <thead>
                 <tr>
                     <th>Product Name</th>
-                    <th>Product metadata type</th>
-                    <th>Product definition doc</th>
+                    <th>metadata type</th>
+                    <th>definition doc</th>
                     <th>Product type</th>
                     <th>Dataset count</th>
                     <th>URI</th>
                 </tr>
             </thead>
-            <tbocdy>
+            <tbody>
                 {% for product in dashboard %}
                 <tr>
                     <td>{{ product.product_name }}</td>

--- a/cubedash/templates/dashboard.html
+++ b/cubedash/templates/dashboard.html
@@ -66,7 +66,7 @@
             <tbody>
                 {% for product in dashboard %}
                 <tr>
-                    <td>{{ product.product_name }}</td>
+                    <td>{{ product.product_name | product_link }}</td>
                     <td>{{ product.metadata_type }}</td>
                     <td><a href="{{url_for('product.raw_product_doc', name=product.product_name, _external=True)}}">{{url_for('product.raw_product_doc', name=product.product_name)}}</a></td>
                     <td>{{ product.product_metadata.product_type }}</td>

--- a/cubedash/templates/dashboard.html
+++ b/cubedash/templates/dashboard.html
@@ -45,6 +45,7 @@
                 <tr>
                     <th>Product Name</th>
                     <th>Product metadata type</th>
+                    <th>Product definition doc</th>
                     <th>Product type</th>
                     <th>Dataset count</th>
                     <th>URI</th>
@@ -55,6 +56,7 @@
                 <tr>
                     <td>{{ product.product_name }}</td>
                     <td>{{ product.metadata_type }}</td>
+                    <td><a href="{{url_for('product.raw_product_doc', name=product.product_name, _external=True)}}">{{url_for('product.raw_product_doc', name=product.product_name)}}</a></td>
                     <td>{{ product.product_metadata.product_type }}</td>
                     <td>{{ product.dataset_count }}</td>
                     <td>{{ product.uri }}</td>

--- a/cubedash/templates/dashboard.html
+++ b/cubedash/templates/dashboard.html
@@ -74,7 +74,7 @@
                     <td>{{ product.uri }}</td>
                 </tr>
               {% endfor %}
-            </tbocdy>
+            </tbody>
         </table>
 
 

--- a/cubedash/templates/dashboard.html
+++ b/cubedash/templates/dashboard.html
@@ -1,0 +1,66 @@
+{% extends "layout/base.html" %}
+
+{% block title %}Audit Dashboard{% endblock %}
+{% block head %}
+    {{ super() }}
+    <style type="text/css">
+        .sub-header {
+            line-height: 1.4em;
+        }
+
+        a {
+            font-weight: bold;
+        }
+
+        .panel {
+            line-height: 1.5em;
+        }
+        th, td{
+            padding: 5px 10px;
+        }
+        body {
+            width: 100%;
+            max-width: 100%;
+        }
+    </style>
+{% endblock %}
+{% block panel %}
+
+{% endblock %}
+{% block content %}
+    <div class="panel highlight">
+        <h2>Dataset Audit</h2>
+        <div class="sub-header">
+            Open Data Cube {{ datacube_version }}
+        </div>
+    </div>
+    <div class="panel">
+        Products available on this Open Data Cube instance
+        {# TODO: Links to Website, CMI Metadata, DEA, ODC, help? #}
+    </div>
+    {% from "layout/macros.html" import chart_timeline %}
+    <div class="panel odd">
+        <table>
+            <thead>
+                <tr>
+                    <th>Product Name</th>
+                    <!-- <th>Product Description</th> -->
+                    <th>Dataset count</th>
+                    <th>URI</th>
+                </tr>
+            </thead>
+            <tbocdy>
+                {% for product in dashboard %}
+                <tr>
+                    <td>{{ product.product_name }}</td>
+                    <!-- <td>{{ product.description }}</td> -->
+                    <td>{{ product.dataset_count }}</td>
+                    <td>{{ product.uri }}</td>
+                </tr>
+              {% endfor %}
+            </tbocdy>
+        </table>
+
+
+    </div>
+{% endblock %}

--- a/cubedash/templates/dashboard.html
+++ b/cubedash/templates/dashboard.html
@@ -44,7 +44,8 @@
             <thead>
                 <tr>
                     <th>Product Name</th>
-                    <!-- <th>Product Description</th> -->
+                    <th>Product metadata type</th>
+                    <th>Product type</th>
                     <th>Dataset count</th>
                     <th>URI</th>
                 </tr>
@@ -53,7 +54,8 @@
                 {% for product in dashboard %}
                 <tr>
                     <td>{{ product.product_name }}</td>
-                    <!-- <td>{{ product.description }}</td> -->
+                    <td>{{ product.metadata_type }}</td>
+                    <td>{{ product.product_metadata.product_type }}</td>
                     <td>{{ product.dataset_count }}</td>
                     <td>{{ product.uri }}</td>
                 </tr>

--- a/cubedash/templates/dashboard.html
+++ b/cubedash/templates/dashboard.html
@@ -55,12 +55,12 @@
         <table>
             <thead>
                 <tr>
-                    <th>Product Name</th>
-                    <th>metadata type</th>
-                    <th>definition doc</th>
-                    <th>Product type</th>
-                    <th>Dataset count</th>
-                    <th>URI</th>
+                    <th>Product</th>
+                    <th>Metadata Type</th>
+                    <th>Definition</th>
+                    <th>Family</th>
+                    <th>Dataset Count</th>
+                    <th>Location</th>
                 </tr>
             </thead>
             <tbody>

--- a/cubedash/templates/product-audit.html
+++ b/cubedash/templates/product-audit.html
@@ -12,6 +12,18 @@
         .data-table tr:hover {
             background-color: #f0f0f0;
         }
+
+        thead tr {
+            display: block;
+        }
+        tbody {
+            display: block;
+            height: 700px;
+            overflow: auto;
+        }
+        .data-table td, .data-table th {
+            width: 160px;
+        }
     </style>
 {% endblock %}
 {% block panel %}
@@ -125,4 +137,3 @@
     {% endif %}
 
 {% endblock %}
-

--- a/cubedash/templates/product-audit.html
+++ b/cubedash/templates/product-audit.html
@@ -12,18 +12,6 @@
         .data-table tr:hover {
             background-color: #f0f0f0;
         }
-
-        thead tr {
-            display: block;
-        }
-        tbody {
-            display: block;
-            height: 700px;
-            overflow: auto;
-        }
-        .data-table td, .data-table th {
-            width: 160px;
-        }
     </style>
 {% endblock %}
 {% block panel %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       args:
         ENVIRONMENT: deployment
     ports:
-      - 8000:8080
+      - 80:8080
     environment:
       # - DB_HOSTNAME=host.docker.internal
       - DB_HOSTNAME=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       args:
         ENVIRONMENT: deployment
     ports:
-      - 80:8080
+      - 8000:8080
     environment:
       # - DB_HOSTNAME=host.docker.internal
       - DB_HOSTNAME=postgres

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -306,6 +306,11 @@ def test_about_page(client: FlaskClient):
     assert b"11 total datasets" in rv.data
 
 
+def test_dashboard_page(client: FlaskClient):
+    rv: Response = client.get("/dashboard")
+    assert b"wofs_albers" in rv.data
+
+
 @pytest.mark.skip(reason="TODO: fix out-of-date range return value")
 def test_out_of_date_range(client: FlaskClient):
     """


### PR DESCRIPTION
The cloud team is looking to build a dataset audit page to ensure dataset integrity across clusters. Building it on existing explorer to leverage existing functions.

- [x] Add audit page

![image](https://user-images.githubusercontent.com/24644475/93842280-a421c200-fcd9-11ea-927c-50f51acdba6b.png)
