### PR TITLE
Add EO3 geometry fallback, support dataset archival & make creation-time optional

### DIFF
--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -256,18 +256,50 @@ def _gis_point(doc, doc_offset):
     )
 
 
-def refresh_product(index: Index, product: DatasetType, recompute_all_extents=False):
+# noinspection PyComparisonWithNone
+def refresh_product(
+    index: Index,
+    product: DatasetType,
+    recompute_all_extents=False,
+    remove_archived_datasets=True,
+    after_date: datetime = None,
+):
     """
     Record the spatial extents for each dataset in a product.
 
-    By default, it will only add datasets that are currently missing.
+    By default, it will only add datasets that are currently missing, and remove
+    archived datasets.
 
-    :param recompute_all_extents: replace all extents, even if already recorded
+    :param after_date: Only scan datasets that have changed after the given (db server) time.
+    :param recompute_all_extents: replace/update all extents, even if already present.
     """
     engine: Engine = alchemy_engine(index)
+    change_count = 0
+
+    log = _LOG.bind(product_name=product.name, after_date=after_date)
+
+    if remove_archived_datasets:
+        # Remove any archived datasets from our spatial table.
+        datasets_to_delete = (
+            select([DATASET.c.id])
+            .where(DATASET.c.archived != None)
+            .where(DATASET.c.dataset_type_ref == product.id)
+        )
+        if after_date is not None:
+            datasets_to_delete = datasets_to_delete.where(
+                DATASET.c.archived > after_date
+            )
+        log.debug(
+            "extent_removal.start",
+        )
+        change_count += engine.execute(
+            DATASET_SPATIAL.delete().where(DATASET_SPATIAL.c.id.in_(datasets_to_delete))
+        ).rowcount
+
     insert_count = _populate_missing_dataset_extents(
-        engine, product, force_update_all=recompute_all_extents
+        engine, product, force_update_all=recompute_all_extents, after_date=after_date
     )
+    change_count += insert_count
 
     # If we inserted data...
     if insert_count:
@@ -277,9 +309,8 @@ def refresh_product(index: Index, product: DatasetType, recompute_all_extents=Fa
             if "sat_path" in product.metadata_type.dataset_fields:
 
                 # We can synthesize the polygons!
-                _LOG.debug(
+                log.debug(
                     "spatial_synthesizing.start",
-                    product_name=product.name,
                 )
                 shapes = _get_path_row_shapes()
                 rows = [
@@ -314,16 +345,18 @@ def refresh_product(index: Index, product: DatasetType, recompute_all_extents=Fa
                             for id_, sat_path, sat_row in rows
                         ],
                     )
-            _LOG.debug(
+            log.debug(
                 "spatial_synthesizing.done",
-                product_name=product.name,
             )
 
-    return insert_count
+    return change_count
 
 
 def _populate_missing_dataset_extents(
-    engine: Engine, product: DatasetType, force_update_all=False
+    engine: Engine,
+    product: DatasetType,
+    force_update_all=False,
+    after_date: datetime = None,
 ):
     columns = {c.name: c for c in _select_dataset_extent_columns(product)}
 
@@ -338,18 +371,26 @@ def _populate_missing_dataset_extents(
             )
             .where(DATASET.c.archived == None)
         )
+        # TODO: We could use the `updated` date for smarter updating,
+        #       but it's optional on ODC at the moment!
+        if after_date is not None:
+            query = query.where(DATASET.c.added > after_date)
     else:
+        extent_selection = (
+            select(columns.values())
+            .where(
+                DATASET.c.dataset_type_ref
+                == bindparam("product_ref", product.id, type_=SmallInteger)
+            )
+            .where(DATASET.c.archived == None)
+        )
+        if after_date is not None:
+            extent_selection = extent_selection.where(DATASET.c.added > after_date)
         query = (
             postgres.insert(DATASET_SPATIAL)
             .from_select(
                 columns.keys(),
-                select(columns.values())
-                .where(
-                    DATASET.c.dataset_type_ref
-                    == bindparam("product_ref", product.id, type_=SmallInteger)
-                )
-                .where(DATASET.c.archived == None)
-                .order_by(columns["center_time"]),
+                extent_selection.order_by(columns["center_time"]),
             )
             .on_conflict_do_nothing(index_elements=["id"])
         )
@@ -358,6 +399,7 @@ def _populate_missing_dataset_extents(
     _LOG.debug(
         "spatial_insert_query.start",
         product_name=product.name,
+        after_date=after_date,
         force_update_all=force_update_all,
     )
     changed = engine.execute(query).rowcount

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -305,6 +305,10 @@ def refresh_product(
         change_count += engine.execute(
             DATASET_SPATIAL.delete().where(DATASET_SPATIAL.c.id.in_(datasets_to_delete))
         ).rowcount
+        log.debug(
+            "extent_removal.end",
+            deleted_count=change_count,
+        )
 
     insert_count = _populate_missing_dataset_extents(
         engine, product, force_update_all=recompute_all_extents, after_date=after_date


### PR DESCRIPTION
- Add a fallback for eo3 datasets without geometry (#188)
- Scan for archived datasets, and remove them from Explorer's extents (one component of #68)
- Make creation-date optional. It will fall back to the datacube indexed time. #45