### PR TITLE
Add condition for gha

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
       - "**"
 
   release:
-    types: [created, published]
+    types: [created, edited, published]
 
 env:
   OLD_IMAGE_NAME: opendatacube/dashboard

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,11 +62,11 @@ jobs:
           exit-code: "1"
           severity: "CRITICAL,HIGH"
 
+      # This section is for releases
       - name: Get tag for this build if it exists
         if: github.event_name == 'release'
         run: >
-          echo ::set-env name=RELEASE::$(docker run --rm -e DATACUBE_DB_URL=postgresql://username:password@hostname:5432/database
-          ${{ env.IMAGE_NAME }}:latest python3 -c 'import cubedash; print(cubedash.__version__)')
+          echo ::set-env name=RELEASE::$(git describe --abbrev=0 --tags)
 
       - name: Log the tag
         run: echo $RELEASE

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,8 +9,7 @@ on:
       - "**"
 
   release:
-    types:
-      - created
+    types: [created, published]
 
 env:
   OLD_IMAGE_NAME: opendatacube/dashboard


### PR DESCRIPTION
release `2.2.0` was created initially as a draft and triggered `created` condition for Github action, but it didn't contain a release tag, which meant the docker build didn't trigger.

- Adding second condition `published` for docker build
- `release tag` is faulty

https://github.com/opendatacube/datacube-explorer/runs/1186441298?check_suite_focus=true
```
Run echo $RELEASE
  echo $RELEASE
  shell: /bin/bash -e {0}
  env:
    OLD_IMAGE_NAME: opendatacube/dashboard
    IMAGE_NAME: opendatacube/explorer
    UNSTABLE_TAG: 2.2.0
    RELEASE: 2.1.12.dev166+ga34234b
2.1.12.dev166+ga34234b
``