### PR TITLE
Fix GitHub action - release branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,8 +67,7 @@ jobs:
       - name: Get tag for this build if it exists
         if: github.event_name == 'release'
         run: >
-          echo ::set-env name=RELEASE::$(docker run --rm -e DATACUBE_DB_URL=postgresql://username:password@hostname:5432/database
-          ${{ env.IMAGE_NAME }}:latest python3 -c 'import cubedash; print(cubedash.__version__)')
+          echo ::set-env name=RELEASE::$(git describe --tags)
 
       - name: Log the tag
         run: echo $RELEASE

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ on:
   release:
     types:
       - created
+      - edited
 
 env:
   OLD_IMAGE_NAME: opendatacube/dashboard


### PR DESCRIPTION
Problem:
Publish release `2.2.0` didn't push/publish explorer image with that tag to dockerhub. Also `Get tag for this build if it exists` step setting a wrong tag for release. see https://github.com/opendatacube/datacube-explorer/runs/1186441298?check_suite_focus=true for reference.  

Solution:
- run docker pipeline for release created and edited event
- trying to set `release` env var by `git describe --tags` instead to read latest tag