### PR TITLE
Give correct match count when searching by ids

### DIFF
--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -269,7 +269,7 @@ def search_stac_items(
     there_are_more = len(items) == limit + 1
 
     count_matching = _model.STORE.get_count(
-        product_names=product_names, time=time, bbox=bbox
+        product_names=product_names, time=time, bbox=bbox, dataset_ids=dataset_ids
     )
 
     page = 0

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -359,6 +359,7 @@ def test_stac_search_by_ids(stac_client: FlaskClient, populated_index: Index):
         "/stac/search?ids=cab65f3f-bb38-4605-9d6a-eff5ea786376",
     )
     assert geojson_feature_ids(geojson) == ["cab65f3f-bb38-4605-9d6a-eff5ea786376"]
+    assert geojson["numberMatched"] == 1
 
     # Other params are ignored when ids is specified (Matching the Stac API spec)
     geojson = get_items(
@@ -384,6 +385,7 @@ def test_stac_search_by_ids(stac_client: FlaskClient, populated_index: Index):
         "696c2481-700e-4fec-b438-01396430a688",
         "cab65f3f-bb38-4605-9d6a-eff5ea786376",
     ]
+    assert geojson["numberMatched"] == 3
 
     # Can filter using ids that don't exist.
     geojson = get_items(


### PR DESCRIPTION
And expand the test to cover it.

(otherwise a search such as `/stac/search?ids=cab65f3f-bb38-4605-9d6a-eff5ea786376` shows a huge count of all datasets in the datacube)