### PR TITLE
Add derived and source column to storage page

### DIFF
--- a/cubedash/templates/storage.html
+++ b/cubedash/templates/storage.html
@@ -19,7 +19,10 @@
         tbody tr:hover {
             background-color: #f0f0f0;
         }
-
+        li.lineage {
+            line-height: 15px !important;
+            list-style-type: none;
+        }
     </style>
 {% endblock %}
 {% block panel %}
@@ -44,6 +47,8 @@
                     <th class="numeric">License</th>
                     <th>Definition</th>
                     <th>Summary Age</th>
+                    <th>Derived Products</th>
+                    <th>Source Products</th>
                 </tr>
             </thead>
             <tbody>
@@ -69,6 +74,24 @@
                         {{ summary.last_refresh_age.seconds // 60 // 60 }} hours
                     {% else %}
                         {{ summary.last_refresh_age.seconds // 60 }} minutes
+                    {% endif %}
+                </td>
+                <td>
+                    {% if summary.derived_products %}
+                        {% for p in summary.derived_products %}
+                            <li class="lineage">{{ p | product_link }}</li>
+                        {% endfor%}
+                    {% else %}
+                        -
+                    {% endif %}
+                </td>
+                <td>
+                    {% if summary.source_products %}
+                        {% for p in summary.source_products %}
+                            <li class="lineage">{{ p | product_link}}</li>
+                        {% endfor%}
+                    {% else %}
+                        -
                     {% endif %}
                 </td>
                 </tr>


### PR DESCRIPTION
- add derived and source products columns to storage page

This allows user to see at a glance products lineages, helps to determine when a product has 0 datasets and is not source product to another product it is a good indication this product is leftover of a deleted product set.

![image](https://user-images.githubusercontent.com/24644475/100830484-e58fd400-34b7-11eb-9c34-772c6d3dadc2.png)
