### PR TITLE
Enable full Item Information on Stac searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ You can alter default [Flask](http://flask.pocoo.org/docs/1.0/config/) or
     # Full searches are much slower because they use ODC's own raw metadata table.
     # (Users can append "_full=true" to requests to manually ask for full metadata.
     #  Or preferrably, follow the `self` link of the Item record to get the whole record)
-    STAC_DEFAULT_FULL_ITEM_INFORMATION = False
+    STAC_DEFAULT_FULL_ITEM_INFORMATION = True
 
 
 [Sentry](https://sentry.io/) error reporting is supported by adding a `SENTRY_CONFIG` section.

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -331,7 +331,11 @@ def collection(collection: str):
 
 def _stac_collection(collection: str):
     summary = _model.get_product_summary(collection)
-    dataset_type = _model.STORE.get_dataset_type(collection)
+    try:
+        dataset_type = _model.STORE.get_dataset_type(collection)
+    except KeyError:
+        abort(404, f"Unknown collection {collection!r}")
+
     all_time_summary = _model.get_time_summary(collection)
 
     summary_props = {}

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -373,7 +373,7 @@ def collection_items(collection: str):
     """
     all_time_summary = _model.get_time_summary(collection)
     if not all_time_summary:
-        abort(404, "Product not yet summarised")
+        abort(404, f"Product {collection!r} not found among summaries.")
 
     feature_collection = _handle_search_request(
         request_args=request.args,
@@ -393,7 +393,7 @@ def collection_items(collection: str):
 def item(collection: str, dataset_id: str):
     dataset = _model.STORE.get_item(dataset_id)
     if not dataset:
-        abort(404, "No such dataset")
+        abort(404, f"No dataset found with id {dataset_id!r}")
 
     actual_product_name = dataset.product_name
     if collection != actual_product_name:

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -227,6 +227,7 @@ def _handle_search_request(
             ids=",".join(map(str, ids)) if ids else None,
             limit=limit,
             _o=next_offset,
+            _full=full_information,
         )
 
     return search_stac_items(

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -37,7 +37,7 @@ FORCE_ABSOLUTE_LINKS = _model.app.config.get("STAC_ABSOLUTE_HREFS", True)
 # Should searches return the full properties for every stac item by default?
 # These searches are much slower we're forced us to use ODC's own metadata table.
 DEFAULT_RETURN_FULL_ITEMS = _model.app.config.get(
-    "STAC_DEFAULT_FULL_ITEM_INFORMATION", False
+    "STAC_DEFAULT_FULL_ITEM_INFORMATION", True
 )
 
 STAC_VERSION = "1.0.0-beta.2"

--- a/integration_tests/asserts.py
+++ b/integration_tests/asserts.py
@@ -41,9 +41,14 @@ def get_html_response(client: FlaskClient, url: str) -> Tuple[HTML, Response]:
     return html, response
 
 
-def get_text_response(client: FlaskClient, url: str) -> Tuple[str, Response]:
+def get_text_response(
+    client: FlaskClient, url: str, expect_status_code=200
+) -> Tuple[str, Response]:
     response: Response = client.get(url, follow_redirects=True)
-    assert response.status_code == 200, response.data.decode("utf-8")
+    assert response.status_code == expect_status_code, (
+        f"Expected status {expect_status_code} not {response.status_code}."
+        f"\nGot:\n{indent(response.data.decode('utf-8'), ' ' * 6)}"
+    )
     return response.data.decode("utf-8"), response
 
 

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -195,11 +195,10 @@ def test_can_search_eo3_items(eo3_index, client: FlaskClient):
     """
     Searching returns lightweight item records, so the conversion code is different.
     """
-
     # Lightweight records...
     geojson = get_items(
         client,
-        "http://localhost/stac/collections/ga_ls5t_ard_3/items",
+        "http://localhost/stac/collections/ga_ls5t_ard_3/items?_full=false",
     )
     assert len(geojson.get("features")) == 1
     assert "gqa:abs_iterative_mean_xy" not in geojson["features"][0]["properties"]

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -2,6 +2,7 @@
 Tests that load pages and check the contained text.
 """
 import json
+from datetime import datetime
 from io import StringIO
 from textwrap import indent
 
@@ -708,3 +709,43 @@ def test_raw_documents(client: FlaskClient):
         "EO1 Dataset",
         "/dataset/57848615-2421-4d25-bfef-73f57de0574d.odc-metadata.yaml",
     )
+
+
+def test_all_give_404s(client: FlaskClient):
+    """
+    We should get 404 messages, not exceptions, for missing things.
+    """
+
+    def expect_404(url: str, message_contains: str = None):
+        __tracebackhide__ = True
+        response = get_text_response(client, url, expect_status_code=404)
+        if message_contains and message_contains not in response:
+            raise AssertionError(
+                f"Expected {message_contains!r} in response {response!r}"
+            )
+
+    name = "does_not_exist"
+    time = datetime.utcnow()
+    region_code = "not_a_region"
+    dataset_id = "37296b9a-e6ec-4bfd-ab80-cc32902429d1"
+
+    expect_404(f"/metadata-types/{name}")
+    expect_404(f"/metadata-types/{name}.odc-type.yaml")
+
+    expect_404(f"/datasets/{name}")
+    expect_404(f"/products/{name}")
+    expect_404(f"/products/{name}.odc-product.yaml")
+
+    expect_404(f"/products/{name}/extents/{time:%Y}")
+    expect_404(f"/products/{name}/extents/{time:%Y/%m}")
+    expect_404(f"/products/{name}/extents/{time:%Y/%m/%d}")
+
+    expect_404(f"/products/{name}/datasets/{time:%Y}")
+    expect_404(f"/products/{name}/datasets/{time:%Y/%m}")
+    expect_404(f"/products/{name}/datasets/{time:%Y/%m/%d}")
+
+    expect_404(f"/region/{name}/{region_code}")
+    expect_404(f"/region/{name}/{region_code}/{time:%Y/%m/%d}")
+
+    expect_404(f"/dataset/{dataset_id}")
+    expect_404(f"/dataset/{dataset_id}.odc-metadata.yaml")


### PR DESCRIPTION
Add an index that speeds up our default Stac Item searches.

... and change the Stac API to always return "Full Item Information" by default (addresses #227)

---

The new index removes the need for the DB to re-sort all items for paging on every query, so it is significantly faster (...at least in my clone-of-nci tests).

Users can rerun `cubedash-gen -v --init` to add the "missing" index. 

 - *Note* This addition takes an exclusive lock, but only runs for a few seconds on my local full copy of the NCI index (our biggest index). 
     - It's only running on the (relatively small) spatial table.
 - There's no forward or backward incompatibilities: the index is optional for current and past versions of Explorer, so can be run at any time. Or not run. I've not flagged it as an incompatible schema for Explorer.

---
Misc
- Ensure all api endpoints give 404 codes, not exceptions. I hit this during testing.
- Removed some of the older, defunct code for asset handling. It has been replaced by eodatasets3.