### PR TITLE
buffer polygon

### DIFF
--- a/cubedash/summary/_model.py
+++ b/cubedash/summary/_model.py
@@ -112,11 +112,7 @@ class TimePeriodOverview:
                 mpolygon.buffer(0.001)
 
             geometry_union = (
-                shapely.ops.unary_union(
-                    [p.footprint_geometry.buffer(0.001) for p in with_valid_geometries]
-                )
-                if with_valid_geometries
-                else None
+                shapely.ops.unary_union(mpolygon) if with_valid_geometries else None
             )
 
         if footprint_tolerance is not None and geometry_union is not None:

--- a/cubedash/summary/_model.py
+++ b/cubedash/summary/_model.py
@@ -104,6 +104,13 @@ class TimePeriodOverview:
             # Attempt 2 at union: Exaggerate the overlap *slightly* to
             # avoid non-noded intersection.
             # TODO: does shapely have a snap-to-grid?
+            mpolygon = MultiPolygon(
+                [p.footprint_geometry for p in with_valid_geometries]
+            )
+            if not mpolygon.is_valid:
+                # buffer invalid polygon
+                mpolygon.buffer(0.001)
+
             geometry_union = (
                 shapely.ops.unary_union(
                     [p.footprint_geometry.buffer(0.001) for p in with_valid_geometries]


### PR DESCRIPTION
fix for https://github.com/opendatacube/datacube-explorer/issues/251

```
[p.footprint_geometry.buffer(0.001) for p in with_valid_geometries]
```
this triggered `Shapely cannot be created from Null value`. This handling appears to be incorrect as it does buffer existing geometry,

instead the new Multipolygon should be buffered

```
mpolygon = MultiPolygon(
                [p.footprint_geometry for p in with_valid_geometries]
            )
            if not mpolygon.is_valid:
                # buffer invalid polygon
                mpolygon.buffer(0.001)

```

Proof this method is not breaking the union

```
        mpolygon = MultiPolygon(
                [p.footprint_geometry for p in with_valid_geometries]
            )
        try:
            geometry_union = (
                shapely.ops.unary_union(
                    mpolygon
                    # [p.footprint_geometry for p in with_valid_geometries]
                )
                if with_valid_geometries
                else None
            )
            print(geometry_union)
            geometry_union_b = (
                shapely.ops.unary_union(
                    # mpolygon
                    [p.footprint_geometry for p in with_valid_geometries]
                )
                if with_valid_geometries
                else None
            )
            print(geometry_union == geometry_union_b)
```

```
root@ip-10-0-13-62:/code# cubedash-gen --force-refresh --refresh-stats --no-init-database srtm
/env/lib/python3.6/site-packages/flask_caching/__init__.py:192: UserWarning: Flask-Caching: CACHE_TYPE is set to null, caching is effectively disabled.
  "Flask-Caching: CACHE_TYPE is set to null, "
Updating 1 products for LocalConfig<loaded_from=defaults, environment='default', config={'db_hostname': 'localhost', 'db_port': '5434', 'db_database': 'africa', 'db_username': 'africa', 'db_password': '***', 'index_driver': 'default', 'db_connection_timeout': '60'}>
Generating product summaries...
POLYGON ((-10005751.54513533 -12497933.65860013, -18469915.89987709 -9998865.580704065, -10160171.8473178 907764.4854519092, -5504094.101523061 -6589458.967744294, -10005751.54513533 -12497933.65860013))
True
POLYGON ((-10005751.54513533 -12497933.65860013, -18469915.89987709 -9998865.580704065, -10160171.8473178 907764.4854519092, -5504094.101523061 -6589458.967744294, -10005751.54513533 -12497933.65860013))
True
srtm done: (1 datasets)
done. 1/1 generated, 0 failures
Refreshing statistics...done

```

When buffered

```
        mpolygon = MultiPolygon(
                [p.footprint_geometry for p in with_valid_geometries]
            )
        print(mpolygon)
        try:
            geometry_union = (
                shapely.ops.unary_union(
                    mpolygon.buffer(0.001)
                    # [p.footprint_geometry for p in with_valid_geometries]
                )
                if with_valid_geometries
                else None
            )
            geometry_union_b = (
                shapely.ops.unary_union(
                    # mpolygon
                    [p.footprint_geometry for p in with_valid_geometries]
                )
                if with_valid_geometries
                else None
            )
            print(geometry_union == geometry_union_b)
```


```
root@ip-10-0-13-62:/code# cubedash-gen --force-refresh --refresh-stats --no-init-database srtm
/env/lib/python3.6/site-packages/flask_caching/__init__.py:192: UserWarning: Flask-Caching: CACHE_TYPE is set to null, caching is effectively disabled.
  "Flask-Caching: CACHE_TYPE is set to null, "
Updating 1 products for LocalConfig<loaded_from=defaults, environment='default', config={'db_hostname': 'localhost', 'db_port': '5434', 'db_database': 'africa', 'db_username': 'africa', 'db_password': '***', 'index_driver': 'default', 'db_connection_timeout': '60'}>
Generating product summaries...
MULTIPOLYGON (((-10005751.54513533 -12497933.65860013, -18469915.89987709 -9998865.580704065, -10160171.8473178 907764.4854519092, -5504094.101523061 -6589458.967744294, -10005751.54513533 -12497933.65860013)))
False
MULTIPOLYGON (((-10005751.5443399 -12497933.65920617, -18469915.90087675 -9998865.580730161, -10160171.84736685 907764.4864507053, -5504094.10052446 -6589458.967691413, -10005751.5443399 -12497933.65920617)))
False
srtm done: (1 datasets)
done. 1/1 generated, 0 failures
Refreshing statistics...done
```