### PR TITLE
Maintain query params when redirecting from legacy stac URLs

### DIFF
--- a/cubedash/_stac_legacy.py
+++ b/cubedash/_stac_legacy.py
@@ -4,7 +4,7 @@ Legacy redirects to maintain old stac api URLs
 import json
 
 import flask
-from flask import url_for, Response
+from flask import url_for, Response, request
 from werkzeug.urls import iri_to_uri
 
 bp = flask.Blueprint("stac_legacy", __name__)
@@ -13,20 +13,26 @@ bp = flask.Blueprint("stac_legacy", __name__)
 @bp.route("/collections/<collection>")
 def legacy_collection(collection: str):
     """Legacy redirect for non-stac prefixed offset"""
-    return legacy_redirect(url_for("stac.collection", collection=collection))
+    return legacy_redirect(
+        url_for("stac.collection", collection=collection, **request.args)
+    )
 
 
 @bp.route("/collections/<collection>/items")
 def legacy_collection_items(collection: str):
     """Legacy redirect for non-stac prefixed offset"""
-    return legacy_redirect(url_for("stac.collection_items", collection=collection))
+    return legacy_redirect(
+        url_for("stac.collection_items", collection=collection, **request.args)
+    )
 
 
 @bp.route("/collections/<collection>/items/<dataset_id>")
 def legacy_item(collection, dataset_id):
     """Legacy redirect for non-stac prefixed offset"""
     return legacy_redirect(
-        url_for("stac.item", collection=collection, dataset_id=dataset_id)
+        url_for(
+            "stac.item", collection=collection, dataset_id=dataset_id, **request.args
+        )
     )
 
 

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -916,6 +916,13 @@ def test_stac_item(stac_client: FlaskClient, populated_index: Index):
             "/stac/collections/ls7_nbar_scene/items",
         ),
         (
+            # Maintains extra query parameters in the redirect
+            "/collections/ls7_nbar_scene/items"
+            "?datetime=2000-01-01/2000-01-01&bbox=-48.206,-14.195,-45.067,-12.272",
+            "/stac/collections/ls7_nbar_scene/items"
+            "?datetime=2000-01-01/2000-01-01&bbox=-48.206,-14.195,-45.067,-12.272",
+        ),
+        (
             "/collections/ls7_nbar_scene/items/0c5b625e-5432-4911-9f7d-f6b894e27f3c",
             "/stac/collections/ls7_nbar_scene/items/0c5b625e-5432-4911-9f7d-f6b894e27f3c",
         ),

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -920,7 +920,11 @@ def test_stac_item(stac_client: FlaskClient, populated_index: Index):
             "/collections/ls7_nbar_scene/items"
             "?datetime=2000-01-01/2000-01-01&bbox=-48.206,-14.195,-45.067,-12.272",
             "/stac/collections/ls7_nbar_scene/items"
-            "?datetime=2000-01-01/2000-01-01&bbox=-48.206,-14.195,-45.067,-12.272",
+            + (
+                "?datetime=2000-01-01/2000-01-01&bbox=-48.206,-14.195,-45.067,-12.272"
+                # Flask will auto-escape parameters
+                .replace(",", "%2C").replace("/", "%2F")
+            ),
         ),
         (
             "/collections/ls7_nbar_scene/items/0c5b625e-5432-4911-9f7d-f6b894e27f3c",


### PR DESCRIPTION
The legacy URL redirects (from before everything was under `/stac`) are not always including extra query parameters. I don't know if anyone is using them, but we may as well make them complete.