### PR TITLE
Update Explorer's information incrementally

### DIFF
--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -3,7 +3,6 @@ import time
 from pathlib import Path
 from typing import Counter, Dict, Iterable, Optional, Tuple
 
-import dateutil.parser
 import flask
 import flask_themes
 import structlog
@@ -77,19 +76,6 @@ def get_time_summary(
 
 def get_product_summary(product_name: str) -> ProductSummary:
     return STORE.get_product_summary(product_name)
-
-
-@cache.memoize(timeout=120)
-def get_last_updated():
-    # Drop a text file in to override the "updated time": for example, when we know it's an old clone of our DB.
-    path = BASE_DIR / "generated.txt"
-    if path.exists():
-        date_text = path.read_text()
-        try:
-            return dateutil.parser.parse(date_text)
-        except ValueError:
-            _LOG.warn("invalid.summary.generated.txt", text=date_text, path=path)
-    return STORE.get_last_updated()
 
 
 ProductWithSummary = Tuple[DatasetType, ProductSummary]

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -67,10 +67,6 @@ def get_time_summary(
     month: Optional[int] = None,
     day: Optional[int] = None,
 ) -> Optional[TimePeriodOverview]:
-    # If it's a day, feel free to update/generate it, because it's quick.
-    if day is not None:
-        return STORE.get_or_update(product_name, year, month, day)
-
     return STORE.get(product_name, year, month, day)
 
 

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -364,7 +364,7 @@ def inject_globals():
             flask.request.view_args["product_name"]
         )
         if product_summary:
-            last_updated = datetime.now() - product_summary.last_refresh_age
+            last_updated = product_summary.last_refresh_time
 
     return dict(
         # Only the known, summarised products in groups.

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -104,11 +104,6 @@ def overview_page(
         default_center=default_center,
         year_selector_summary=year_selector_summary,
         time_selector_summary=time_selector_summary,
-        # Override the global "last updated" value: the chosen summary information
-        # may be older than the product.
-        last_updated_time=selected_summary.product_refresh_time
-        if selected_summary
-        else None,
     )
 
 

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -104,6 +104,11 @@ def overview_page(
         default_center=default_center,
         year_selector_summary=year_selector_summary,
         time_selector_summary=time_selector_summary,
+        # Override the global "last updated" value: the chosen summary information
+        # may be older than the product.
+        last_updated_time=selected_summary.product_refresh_time
+        if selected_summary
+        else None,
     )
 
 
@@ -357,14 +362,15 @@ def request_wants_json():
 
 @app.context_processor
 def inject_globals():
-    last_updated = _model.get_last_updated()
-    # If there's no global data refresh time, show the time the current product was summarised.
-    if not last_updated and "product_name" in flask.request.view_args:
+    # The footer "Last updated" date.
+    # The default is the currently-viewed product's summary refresh date.
+    last_updated = None
+    if "product_name" in flask.request.view_args:
         product_summary = _model.STORE.get_product_summary(
             flask.request.view_args["product_name"]
         )
         if product_summary:
-            last_updated = product_summary.last_refresh_time
+            last_updated = product_summary.last_successful_summary_time
 
     return dict(
         # Only the known, summarised products in groups.

--- a/cubedash/_product.py
+++ b/cubedash/_product.py
@@ -113,15 +113,19 @@ def product_page(name):
     ordered_metadata = utils.prepare_document_formatting(product.definition)
     product_summary = _model.get_product_summary(name)
 
+    extras = {}
+    # (Override the global default with a product-only time.
+    #  It's more useful to the user on this page, as we only show general product info.)
+    if product_summary is not None:
+        extras["last_updated_time"] = product_summary.last_refresh_time
+
     return utils.render(
         "product.html",
         product=product,
         product_summary=product_summary,
         location_samples=_model.STORE.product_location_samples(name),
         metadata_doc=ordered_metadata,
-        # (Override the global default with a product-only time.
-        #  It's more useful to the user on this page, as we only show general product info.)
-        last_updated_time=product_summary.last_refresh_time,
+        **extras,
     )
 
 

--- a/cubedash/_product.py
+++ b/cubedash/_product.py
@@ -119,6 +119,8 @@ def product_page(name):
         product_summary=product_summary,
         location_samples=_model.STORE.product_location_samples(name),
         metadata_doc=ordered_metadata,
+        # (Override the global default with a product-only time)
+        last_updated_time=product_summary.last_refresh_time,
     )
 
 

--- a/cubedash/_product.py
+++ b/cubedash/_product.py
@@ -119,7 +119,8 @@ def product_page(name):
         product_summary=product_summary,
         location_samples=_model.STORE.product_location_samples(name),
         metadata_doc=ordered_metadata,
-        # (Override the global default with a product-only time)
+        # (Override the global default with a product-only time.
+        #  It's more useful to the user on this page, as we only show general product info.)
         last_updated_time=product_summary.last_refresh_time,
     )
 

--- a/cubedash/_product.py
+++ b/cubedash/_product.py
@@ -41,7 +41,7 @@ def storage_csv():
                 ],
                 _utils.product_license(product),
                 url_for("product.raw_product_doc", name=product.name, _external=True),
-                _iso8601_duration(summary.last_refresh_age),
+                summary.last_refresh_time,
                 product.metadata_type.name,
             )
             for product, summary in _model.get_products_with_summaries()

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -627,6 +627,17 @@ except AttributeError:
 ODC_DATASET = datacube.drivers.postgres._schema.DATASET
 
 
+try:
+    from datacube.drivers.postgres._core import install_timestamp_trigger
+except ImportError:
+
+    def install_timestamp_trigger(connection):
+        raise RuntimeError(
+            "ODC version does not contain update-trigger installation. "
+            "Cannot install dataset-update trigger."
+        )
+
+
 def get_mutable_dataset_search_fields(
     index: Index, md: MetadataType
 ) -> Dict[str, PgDocField]:

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -369,7 +369,7 @@ def cli(
             + "Please rerun with --init to create one",
         )
         sys.exit(-1)
-    elif not store.is_schema_compatible():
+    elif not store.is_schema_compatible(for_writing_operations_too=True):
         user_message(
             style("Cubedash schema is out of date. ", fg="red")
             + "Please rerun with --init to apply updates.",

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -129,7 +129,6 @@ def generate_report(
         # Otherwise, regenerate only the months that changed,
         # (and parent nodes in the tree: month -> year -> whole-product)
         log.info("generate.product.changes")
-        updated_years = set()
 
         # Month
         for change_month, new_count in store.find_months_changed_since(
@@ -143,9 +142,9 @@ def generate_report(
             )
             year = change_month.year
             store.update(product_name, year, change_month.month, force_refresh=True)
-            updated_years.add(year)
-        # Year
-        for year in updated_years:
+
+        # Find years who are older than their months
+        for year in store.find_years_needing_update(product_name):
             # Note we don't force refresh: we've just replaced the months that needed updating!
             store.update(product_name, year)
 

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -118,7 +118,16 @@ def generate_report(
             current_summary = existing_summary
 
         # If it's new or we're force-creating, recreate the whole tree recursively (depth-first).
-        if existing_summary is None or force_refresh:
+        if (
+            # If it's a new product...
+            existing_summary is None
+            # ...or it was generated before incremental-updating was implemented.
+            or existing_summary.last_successful_summary_time is None
+            # ... or we're using brute force.
+            or force_refresh
+        ):
+            # Then regenerate every single summary.
+
             log.info("generate.product.whole")
             if force_refresh:
                 log.warn("generate.forcing_refresh")

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -111,8 +111,10 @@ def generate_report(
 
 
 def _get_index(config: LocalConfig, variant: str) -> Index:
+    # Avoid long names as they will print warnings all the time.
+    short_name = variant.replace("_", "")[:20]
     index: Index = index_connect(
-        config, application_name=f"dashgen.{variant}", validate_connection=False
+        config, application_name=f"gen.{short_name}", validate_connection=False
     )
     return index
 

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -9,8 +9,12 @@ to calculate this summary information ahead-of-time.
 The cubedash-gen command creates these summaries in a schema called
 `cubedash`, separate from datacube’s own schema.
 
-By default, only missing summaries will be added for the specified
-product names; and it will not recreate summaries that already exist.
+This can be re-run each time changes are made to an ODC product
+to show the updates in Explorer.
+
+The first run will be slow as it will scan all data, but later
+runs will be faster as it scans only modified data.
+(unless `--force-refresh` is specified)
 
 ---
 
@@ -29,12 +33,15 @@ See datacube’s own docs for this configuration handling.
 
 Examples
 
-Create Explorer's schemas and generate all summaries that don't exist:
+Create Explorer's schemas, then update (or create) all product summaries:
 
     cubedash-gen --init --all
 
+Update (or create) all product summaries:
 
-Recreate all summaries for two products:
+    cubedash-gen --all
+
+Recreate all information for two products:
 
     cubedash-gen --force-refresh ls8_nbart_scene ls8_level1_scene
 
@@ -278,7 +285,8 @@ def _load_products(index: Index, product_names) -> List[DatasetType]:
     default=False,
     help=dedent(
         """\
-        Force all time periods to be regenerated, rather than just the missing ones.
+        Force all time periods to be regenerated, rather than just applying updates
+        to existing ones.
 
         (default: false)
         """
@@ -290,7 +298,7 @@ def _load_products(index: Index, product_names) -> List[DatasetType]:
     default=False,
     help=dedent(
         """\
-        Rebuild Explorer's existing dataset extents rather than appending new datasets.
+        Rebuild Explorer's existing dataset extents even if they don't seem to be updated.
         (default: false)
 
         This is useful if you've patched datasets or products in-place with new geometry
@@ -317,7 +325,8 @@ def _load_products(index: Index, product_names) -> List[DatasetType]:
     default=False,
     help=dedent(
         """\
-        Create Explorer's schemas, and prepare the database, before doing anything.
+        Check the Explorer schema and create it (or apply updates to it) if needed,
+        before doing anything else.
         """
     ),
 )
@@ -328,7 +337,7 @@ def _load_products(index: Index, product_names) -> List[DatasetType]:
     default=False,
     help=dedent(
         """\
-        Drop all of Explorer's database additions and exit.
+        Drop all of Explorer's database schema+caches and exit.
         """
     ),
 )

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -73,9 +73,11 @@ user_message = partial(click_secho, err=True)
 
 
 class GenerateResult(enum.Enum):
-    # Newly summarised, or a force-refresh recreation of everything.
+    """What happened in a product generation task?"""
+
+    # Product was newly generated (or force-refreshed to recreate everything).
     CREATED = 2
-    # Updated only the changed months.
+    # Updated the existing summaries (for months that changed)
     UPDATED = 3
     # No new changes found.
     SKIPPED = 1

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -102,13 +102,13 @@ def generate_report(
         needs_refresh = store.needs_refresh(product)
         if (existing_summary is None) or recreate_dataset_extents or needs_refresh:
             log.info("generate.product.refresh")
-            store.refresh_product(
+            _, refresh_timestamp = store.refresh_product(
                 product,
                 force_dataset_extent_recompute=recreate_dataset_extents,
             )
             log.info("generate.product.refresh.done")
 
-        # !!! Uh-oh! if it fails now, it's already marked as refreshed!
+        # TODO !!! Uh-oh! if it fails now, it's already marked as refreshed!
         # (add refresh time to summaries? Find months with refresh-time older than product refresh time)
         #  ---  auto-populate column from current product.refresh_time.
         #  ---  Add a per-product lock?

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -117,7 +117,6 @@ def generate_report(
         else:
             current_summary = existing_summary
 
-        # If it's new or we're force-creating, recreate the whole tree recursively (depth-first).
         if (
             # If it's a new product...
             existing_summary is None
@@ -127,7 +126,6 @@ def generate_report(
             or force_refresh
         ):
             # Then regenerate every single summary.
-
             log.info("generate.product.whole")
             if force_refresh:
                 log.warn("generate.forcing_refresh")
@@ -156,9 +154,7 @@ def generate_report(
         log.info("generate.product.updating_incrementally")
 
         # Month
-        for change_month, new_count in store.find_months_changed_since(
-            product_name, existing_summary.last_refresh_time
-        ):
+        for change_month, new_count in store.find_months_needing_update(product_name):
             log.debug(
                 "generate.product.month_refresh",
                 product=product_name,

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -81,9 +81,13 @@ def generate_report(
         product=product_name, force=force_refresh, extents=recreate_dataset_extents
     )
 
+    started_years = set()
+
     def print_status(product_name=None, year=None, month=None, day=None, summary=None):
-        if year and (not month) and (not day):
-            click_secho(f"\t  {product_name} {year} done")
+        if year:
+            if (product_name, year) not in started_years:
+                user_message(f"\t  {product_name} {year}")
+                started_years.add((product_name, year))
 
     store = SummaryStore.create(_get_index(config, product_name), log=log)
     store.add_change_listener(print_status)
@@ -92,7 +96,7 @@ def generate_report(
         product = store.index.products.get_by_name(product_name)
         if product is None:
             raise ValueError(f"Unknown product: {product_name}")
-
+        user_message(f"{product_name} refresh")
         result, updated_summary = store.refresh(
             product_name,
             force=force_refresh,

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -84,6 +84,7 @@ def generate_report(
     started_years = set()
 
     def print_status(product_name=None, year=None, month=None, day=None, summary=None):
+        """Print status each time we start a year."""
         if year:
             if (product_name, year) not in started_years:
                 user_message(f"\t  {product_name} {year}")

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -133,10 +133,11 @@ def generate_report(
                 log.warn("generate.forcing_refresh")
             updated = store.get_or_update(
                 product.name,
-                force_refresh=force_refresh,
+                force_refresh=True,
                 product_refresh_time=current_summary.last_refresh_time,
             )
             log.info("generate.product.whole.done")
+            store.time_summary_was_successful(current_summary)
             return product_name, GenerateResult.CREATED, updated
 
         time_summaries_are_completed = (

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -188,7 +188,7 @@ def run_generation(
     _LOG.info(
         "completed",
         count=len(products),
-        **{f"status_{k}": count for k, count in counts.items()},
+        **{f"was_{k.name.lower()}": count for k, count in counts.items()},
     )
     return creation_count, failure_count
 
@@ -221,9 +221,9 @@ def _load_products(index: Index, product_names) -> List[DatasetType]:
     help="Refresh all products in the datacube, rather than the specified list.",
 )
 @click.option(
-    "-v",
     "--verbose",
-    is_flag=True,
+    "-v",
+    count=True,
     help=dedent(
         """\
         Enable all log messages, instead of just errors.
@@ -231,6 +231,8 @@ def _load_products(index: Index, product_names) -> List[DatasetType]:
         Logging goes to stdout unless `--event-log-file` is specified.
 
         Logging is coloured plain-text if going to a tty, and jsonl format otherwise.
+
+        Use twice to enable debug logging too.
         """
     ),
 )
@@ -336,13 +338,15 @@ def cli(
     event_log_file: str,
     refresh_stats: bool,
     force_concurrently: bool,
-    verbose: bool,
+    verbose: int,
     init_database: bool,
     drop_database: bool,
     force_refresh: bool,
     recreate_dataset_extents: bool,
 ):
-    init_logging(open(event_log_file, "a") if event_log_file else None, verbose=verbose)
+    init_logging(
+        open(event_log_file, "a") if event_log_file else None, verbosity=verbose
+    )
 
     index = _get_index(config, "setup")
     store = SummaryStore.create(index)

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -81,7 +81,13 @@ def generate_report(
         product=product_name, force=force_refresh, extents=recreate_dataset_extents
     )
 
+    def print_status(product_name=None, year=None, month=None, day=None, summary=None):
+        if year and (not month) and (not day):
+            click_secho(f"\t  {product_name} {year} done")
+
     store = SummaryStore.create(_get_index(config, product_name), log=log)
+    store.add_change_listener(print_status)
+
     try:
         product = store.index.products.get_by_name(product_name)
         if product is None:

--- a/cubedash/logs.py
+++ b/cubedash/logs.py
@@ -38,7 +38,7 @@ def init_logging(output_file=None, verbosity: int = 0, cache_logger_on_first_use
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
         # Coloured output if to terminal, otherwise json
-        structlog.dev.ConsoleRenderer()
+        BetterConsoleRenderer()
         if output_file.isatty()
         else structlog.processors.JSONRenderer(serializer=lenient_json_dump),
     ]
@@ -60,6 +60,15 @@ def init_logging(output_file=None, verbosity: int = 0, cache_logger_on_first_use
         cache_logger_on_first_use=cache_logger_on_first_use,
         logger_factory=structlog.PrintLoggerFactory(file=output_file),
     )
+
+
+class BetterConsoleRenderer(structlog.dev.ConsoleRenderer):
+    """A console renderer that shows dates in a readable manner."""
+
+    def _repr(self, val):
+        if isinstance(val, datetime.datetime):
+            return val.isoformat()
+        return super()._repr(val)
 
 
 def _filter_levels(logger, log_method, event_dict, hide_levels=("debug", "info")):

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -330,7 +330,7 @@ def refresh_spatial_extents(
             change_count=changed,
         )
 
-    # We'll apply updates, then insert new records.
+    # We'll update first, then insert new records.
     # -> We do it in this order so that inserted records aren't immediately updated.
     # (Note: why don't we do this in one upsert? Because we get our sqlalchemy expressions
     #        through ODC's APIs and can't choose alternative table aliases to make sub-queries.
@@ -469,10 +469,12 @@ def _select_dataset_extent_columns(dt: DatasetType) -> List[Label]:
 
 
 def center_time_expression(md_type: MetadataType):
-    # "expr == None" is valid in sqlalchemy:
-    # pylint: disable=singleton-comparison
+    """
+    The center time for the given metadata doc.
+
+    (Matches the logic in ODC's Dataset.center_time)
+    """
     time = md_type.dataset_fields["time"].alchemy_expression
-    # Matches the logic in Dataset.center_time
     center_time = (func.lower(time) + (func.upper(time) - func.lower(time)) / 2).label(
         "center_time"
     )

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -294,20 +294,20 @@ def refresh_spatial_extents(
         datasets_to_delete = datasets_to_delete.where(
             DATASET.c.archived > assume_after_date
         )
-    log.debug(
+    log.info(
         "extent_archival_removal.start",
     )
     changed = engine.execute(
         DATASET_SPATIAL.delete().where(DATASET_SPATIAL.c.id.in_(datasets_to_delete))
     ).rowcount
-    log.debug(
+    log.info(
         "extent_archival_removal.end",
         deleted_count=changed,
     )
 
     # Forcing? Check every other dataset for removal, so we catch manually-deleted rows from the table.
     if thorough:
-        log.debug(
+        log.info(
             "extent_force_removal.start",
         )
         changed = engine.execute(
@@ -321,7 +321,7 @@ def refresh_spatial_extents(
                 )
             )
         ).rowcount
-        log.debug(
+        log.info(
             "extent_force_removal.end",
             deleted_count=changed,
         )
@@ -342,7 +342,7 @@ def refresh_spatial_extents(
         only_where.append(dataset_changed_expression() > assume_after_date)
 
     # Update any changed datasets
-    log.debug(
+    log.info(
         "spatial_update_query.start",
         product_name=product.name,
         after_date=assume_after_date,
@@ -353,12 +353,12 @@ def refresh_spatial_extents(
         .where(DATASET_SPATIAL.c.id == column_values["id"])
         .where(and_(*only_where))
     ).rowcount
-    log.debug(
+    log.info(
         "spatial_update_query.end", product_name=product.name, change_count=changed
     )
 
     # ... and insert new ones.
-    log.debug(
+    log.info(
         "spatial_insert_query.start",
         product_name=product.name,
         after_date=assume_after_date,
@@ -375,7 +375,7 @@ def refresh_spatial_extents(
             .on_conflict_do_nothing(index_elements=["id"])
         )
     ).rowcount
-    log.debug(
+    log.info(
         "spatial_insert_query.end", product_name=product.name, change_count=changed
     )
 
@@ -387,7 +387,7 @@ def refresh_spatial_extents(
             if "sat_path" in product.metadata_type.dataset_fields:
 
                 # We can synthesize the polygons!
-                log.debug(
+                log.info(
                     "spatial_synthesizing.start",
                 )
                 shapes = _get_path_row_shapes()
@@ -423,7 +423,7 @@ def refresh_spatial_extents(
                             for id_, sat_path, sat_row in rows
                         ],
                     )
-            log.debug(
+            log.info(
                 "spatial_synthesizing.done",
             )
 

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -291,8 +291,12 @@ def refresh_spatial_extents(
         .where(DATASET.c.dataset_type_ref == product.id)
     )
     if assume_after_date is not None:
+        # Note that we use "dataset_changed_expression" to scan the datasets,
+        # rather than "where archived > date", because the latter has no index!
+        # (.... and we're using dataset_changed_expression's index everywhere else,
+        #       so it's probably still in memory and super fast!)
         datasets_to_delete = datasets_to_delete.where(
-            DATASET.c.archived > assume_after_date
+            dataset_changed_expression() > assume_after_date
         )
     log.info(
         "extent_archival_removal.start",

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -306,7 +306,7 @@ def refresh_spatial_extents(
     ).rowcount
     log.info(
         "extent_archival_removal.end",
-        deleted_count=changed,
+        change_count=changed,
     )
 
     # Forcing? Check every other dataset for removal, so we catch manually-deleted rows from the table.
@@ -314,7 +314,7 @@ def refresh_spatial_extents(
         log.info(
             "extent_force_removal.start",
         )
-        changed = engine.execute(
+        changed += engine.execute(
             DATASET_SPATIAL.delete().where(DATASET.c.dataset_type_ref == product.id)
             # Where it doesn't exist in the ODC dataset table.
             .where(
@@ -327,7 +327,7 @@ def refresh_spatial_extents(
         ).rowcount
         log.info(
             "extent_force_removal.end",
-            deleted_count=changed,
+            change_count=changed,
         )
 
     # We'll apply updates, then insert new records.

--- a/cubedash/summary/_model.py
+++ b/cubedash/summary/_model.py
@@ -84,6 +84,19 @@ class TimePeriodOverview:
         for p in periods:
             region_counter.update(p.region_dataset_counts)
 
+        # Attempt to fix broken geometries.
+        # -> The 'high_tide_comp_20p' tests give an example of this: geometry is valid when
+        #    created, but after serialisation+deserialisation become invalid due to float
+        #    rounding.
+        for time_period in periods:
+            if (
+                time_period.footprint_geometry
+                and not time_period.footprint_geometry.is_valid
+            ):
+                time_period.footprint_geometry = time_period.footprint_geometry.buffer(
+                    0
+                )
+
         with_valid_geometries = [
             p
             for p in periods

--- a/cubedash/summary/_model.py
+++ b/cubedash/summary/_model.py
@@ -40,6 +40,9 @@ class TimePeriodOverview:
 
     size_bytes: int
 
+    # What version of our product table this was based on (the last_refresh_time on ProductSummary)
+    product_refresh_time: datetime
+
     # When this summary was generated. Set on the server.
     summary_gen_time: datetime = None
 
@@ -152,6 +155,14 @@ class TimePeriodOverview:
                 default=None,
             ),
             crses=set.union(*(o.crses for o in periods)) if periods else set(),
+            product_refresh_time=min(
+                (
+                    p.product_refresh_time
+                    for p in periods
+                    if p.product_refresh_time is not None
+                ),
+                default=None,
+            ),
             summary_gen_time=min(
                 (p.summary_gen_time for p in periods if p.summary_gen_time is not None),
                 default=None,

--- a/cubedash/summary/_model.py
+++ b/cubedash/summary/_model.py
@@ -155,7 +155,9 @@ class TimePeriodOverview:
                 default=None,
             ),
             crses=set.union(*(o.crses for o in periods)) if periods else set(),
-            product_refresh_time=min(
+            # Why choose the max version? Because we assume older ones didn't need to be replaced,
+            # so the most recent refresh time is the version that we are current with.
+            product_refresh_time=max(
                 (
                     p.product_refresh_time
                     for p in periods

--- a/cubedash/summary/_model.py
+++ b/cubedash/summary/_model.py
@@ -72,6 +72,10 @@ class TimePeriodOverview:
         """
         return self.product_name, self.year, self.month, self.day
 
+    @period_tuple.setter
+    def period_tuple(self, v: Tuple[str, Optional[int], Optional[int], Optional[int]]):
+        self.product_name, self.year, self.month, self.day = v
+
     def as_flat_period(self):
         """
         How we "flatten" the time-slice for storage in DB columns. Must remain stable!

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -125,8 +125,7 @@ PRODUCT = Table(
         "last_refresh",
         DateTime(timezone=True),
         nullable=False,
-        server_default=func.now(),
-        comment="Last refresh of this product in the dataset_spatial table",
+        comment="Last refresh of this product's extents'",
     ),
     Column(
         "last_successful_summary",

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -276,7 +276,9 @@ class PleaseRefresh(Enum):
     What data should be refreshed/recomputed?
     """
 
-    # Refresh all calculated extents/geometry for datasets
+    # Refresh the product extents.
+    PRODUCTS = 2
+    # Recreate all dataset extents in the spatial table
     DATASET_EXTENTS = 1
 
 

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -129,11 +129,11 @@ PRODUCT = Table(
         comment="Last refresh of this product in the dataset_spatial table",
     ),
     Column(
-        "summary_refresh",
+        "last_successful_summary",
         DateTime(timezone=True),
-        nullable=False,
-        server_default=func.now(),
-        comment="The 'last_refresh' date when summaries were last regenerated.",
+        nullable=True,
+        comment="The `last_refresh` time that was current when summaries "
+        "were last *fully* generated successfully.",
     ),
     Column("source_product_refs", postgres.ARRAY(SmallInteger)),
     Column("derived_product_refs", postgres.ARRAY(SmallInteger)),

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -256,7 +256,7 @@ def is_compatible_schema(engine: Engine) -> bool:
     is_latest = True
 
     if not pg_column_exists(
-        engine, f"{CUBEDASH_SCHEMA}.time_overview", "product_refresh_time"
+        engine, f"{CUBEDASH_SCHEMA}.product", "last_successful_summary"
     ):
         is_latest = False
 
@@ -320,6 +320,17 @@ def update_schema(engine: Engine) -> Set[PleaseRefresh]:
             f"""
             alter table {CUBEDASH_SCHEMA}.time_overview
             add column product_refresh_time timestamp with time zone null
+        """
+        )
+
+    if not pg_column_exists(
+        engine, f"{CUBEDASH_SCHEMA}.product", "last_successful_summary"
+    ):
+        _LOG.warn("schema.applying_update.add_summary_success_time")
+        engine.execute(
+            f"""
+            alter table {CUBEDASH_SCHEMA}.product
+            add column last_successful_summary timestamp with time zone null
         """
         )
 

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -109,6 +109,7 @@ _ALL_COLLECTIONS_ORDER_INDEX = Index(
 )
 
 DATASET_SPATIAL.indexes.add(_COLLECTION_ITEMS_INDEX)
+DATASET_SPATIAL.indexes.add(_ALL_COLLECTIONS_ORDER_INDEX)
 
 # Note that we deliberately don't foreign-key to datacube tables:
 # - We don't want to add an external dependency on datacube core

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1220,8 +1220,8 @@ class SummaryStore:
         else:
             # Empty product
             summary = TimePeriodOverview.add_periods([])
-            summary.product_refresh_time = product_refresh_time
 
+        summary.product_refresh_time = product_refresh_time
         self._put(product.name, year, month, None, summary)
 
         for listener in self._update_listeners:

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -390,13 +390,14 @@ class SummaryStore:
         has_new_changes = most_recent_change and (
             most_recent_change > existing_product_summary.last_refresh_time
         )
-        if has_new_changes:
-            _LOG.debug(
-                "product.has_extent_changes",
-                product_name=product_name,
-                refresh_time=str(existing_product_summary.last_refresh_time),
-                most_recent_change=most_recent_change,
-            )
+
+        _LOG.debug(
+            "product.last_extent_changes",
+            product_name=product_name,
+            last_refresh_time=existing_product_summary.last_refresh_time,
+            most_recent_change=most_recent_change,
+            has_new_changes=has_new_changes,
+        )
         return has_new_changes
 
     def refresh_product_extent(
@@ -1210,16 +1211,7 @@ class SummaryStore:
             summary.product_name = product.name
 
         summary.product_refresh_time = product_refresh_time
-
-        # Dev sanity check:
-        #   all the above methods should have calculated our expected
-        #   period information correctly.
-        assert summary.period_tuple == (
-            product.name,
-            year,
-            month,
-            None,
-        ), f"{summary.period_tuple} != {(product.name, year, month, None)}"
+        summary.period_tuple = (product.name, year, month, None)
 
         self._put(summary)
         for listener in self._update_listeners:

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -374,6 +374,10 @@ class SummaryStore:
                         select([updated_months.c.start_day])
                         .where(updated_months.c.period_type == "month")
                         .where(
+                            func.extract("year", updated_months.c.start_day)
+                            == func.extract("year", years.c.start_day)
+                        )
+                        .where(
                             updated_months.c.product_ref == product.id_,
                         )
                         .where(
@@ -384,7 +388,6 @@ class SummaryStore:
                 )
             )
         )
-
         return sorted(missing_years.union(outdated_years))
 
     def needs_refresh(self, product_name: str) -> bool:

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1350,6 +1350,7 @@ class SummaryStore:
                 .values(last_successful_summary=refresh_timestamp.isoformat())
             )
         )
+        self._product.cache_clear()
 
     @ttl_cache(ttl=DEFAULT_TTL)
     def _get_srid_name(self, srid: int):

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -96,6 +96,8 @@ class ProductSummary:
     # The db-server-local time when this product was refreshed.
     last_refresh_time: datetime = None
 
+    # Not recommended for use by users, as ids are local and internal.
+    # The 'name' is typically used as an identifier, and with ODC itself.
     id_: Optional[int] = None
 
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -201,6 +201,9 @@ class SummaryStore:
         self._engine: Engine = _utils.alchemy_engine(index)
         self._summariser = summariser
 
+    def add_change_listener(self, listener):
+        self._update_listeners.append(listener)
+
     def is_initialised(self) -> bool:
         """
         Do our DB schemas exist?
@@ -1218,7 +1221,13 @@ class SummaryStore:
         self._put(product.name, year, month, None, summary)
 
         for listener in self._update_listeners:
-            listener(product.name, year, month, None, summary)
+            listener(
+                product_name=product.name,
+                year=year,
+                month=month,
+                day=None,
+                summary=summary,
+            )
         return summary
 
     def refresh(

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -813,19 +813,19 @@ class SummaryStore:
 
         if row:
             # Product already exists, so update it
-            self._engine.execute(
+            row = self._engine.execute(
                 PRODUCT.update()
                 .returning(PRODUCT.c.id, PRODUCT.c.last_refresh)
                 .where(PRODUCT.c.id == row[0])
                 .values(fields)
-            )
+            ).fetchone()
         else:
             # Product doesn't exist, so insert it
             row = self._engine.execute(
                 postgres.insert(PRODUCT)
                 .returning(PRODUCT.c.id, PRODUCT.c.last_refresh)
                 .values(**fields, name=product.name)
-            )
+            ).fetchone()
         self._product.cache_clear()
         return row[0], row[1]
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -211,7 +211,7 @@ class SummaryStore:
         """
         return _schema.has_schema(self._engine)
 
-    def is_schema_compatible(self) -> bool:
+    def is_schema_compatible(self, for_writing_operations_too=False) -> bool:
         """
         Have all schema update been applied?
         """
@@ -220,7 +220,10 @@ class SummaryStore:
             postgis=_schema.get_postgis_versions(self._engine),
             explorer=EXPLORER_VERSION,
         )
-        return _schema.is_compatible_schema(self._engine)
+        if for_writing_operations_too:
+            return _schema.is_compatible_generate_schema(self._engine)
+        else:
+            return _schema.is_compatible_schema(self._engine)
 
     def init(self):
         """

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -216,7 +216,7 @@ class SummaryStore:
         """
         Have all schema update been applied?
         """
-        _LOG.info(
+        _LOG.debug(
             "software.version",
             postgis=_schema.get_postgis_versions(self._engine),
             explorer=EXPLORER_VERSION,
@@ -476,7 +476,6 @@ class SummaryStore:
         new_summary.last_refresh_time = product_refresh_time
 
         self._refresh_product_regions(product)
-        _LOG.info("init.regions.done", product_name=product.name)
 
         return change_count, new_summary
 
@@ -1255,7 +1254,7 @@ class SummaryStore:
             force = True
 
         if force or (old_product is None) or self.needs_extent_refresh(product_name):
-            log.info("generate.product.refresh")
+            log.info("generate.extent.refresh")
             _, new_product = self.refresh_product_extent(
                 product_name,
                 force_recompute=recreate_dataset_extents,
@@ -1265,7 +1264,7 @@ class SummaryStore:
                     else old_product.last_refresh_time
                 ),
             )
-            log.info("generate.product.refresh.done")
+            log.info("generate.extent.refresh.done")
         else:
             new_product = old_product
 
@@ -1304,7 +1303,7 @@ class SummaryStore:
                 log.info("generate.product.no_changes")
                 return GenerateResult.SKIPPED, self.get(product_name)
 
-            log.info("generate.product.updating_incrementally")
+            log.info("generate.product.incremental_update")
             months_to_update = self.find_months_needing_update(product_name)
             refresh_type = GenerateResult.UPDATED
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -692,6 +692,9 @@ class SummaryStore:
                     PRODUCT.c.time_earliest,
                     PRODUCT.c.time_latest,
                     PRODUCT.c.last_refresh.label("last_refresh_time"),
+                    PRODUCT.c.last_successful_summary.label(
+                        "last_successful_summary_time"
+                    ),
                     PRODUCT.c.id.label("id_"),
                     PRODUCT.c.source_product_refs,
                     PRODUCT.c.derived_product_refs,

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -917,7 +917,7 @@ class SummaryStore:
             time=(year, month, day),
             summary_count=summary.dataset_count,
         )
-        log.debug("product.put")
+        log.info("product.put")
         product = self._product(product_name)
         start_day, period = self._start_day(year, month, day)
         row = _summary_to_row(summary)

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -405,11 +405,11 @@ class SummaryStore:
             .where(PRODUCT.c.id == product.id_)
             .where(
                 or_(
-                    PRODUCT.c.last_successful_summary_time.is_(None),
-                    PRODUCT.c.last_successful_summary_time < product.last_refresh_time,
+                    PRODUCT.c.last_successful_summary.is_(None),
+                    PRODUCT.c.last_successful_summary < product.last_refresh_time,
                 )
             )
-            .values(last_successful_summary_time=product.last_refresh_time),
+            .values(last_successful_summary=product.last_refresh_time),
         )
 
     def _refresh_product_regions(self, dataset_type: DatasetType) -> int:

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -309,7 +309,7 @@ class SummaryStore:
         # Years who have month-records updated more recently than their own record.
         outdated_years = set(
             start_day.year
-            for start_day in self._engine.execute(
+            for [start_day] in self._engine.execute(
                 # Select years
                 select([years.c.start_day])
                 .where(years.c.period_type == "year")

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -284,8 +284,8 @@ class SummaryStore:
         updated_months = TIME_OVERVIEW.alias("updated_months")
         years = TIME_OVERVIEW.alias("years_needing_update")
         product = self.get_product_summary(product_name)
-        if product is None:
-            # ? raise RuntimeError("Product is not yet summarised, no diff of years")
+        # Empty product? No years
+        if product.dataset_count == 0:
             return []
 
         # All years we are expected to have

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -307,7 +307,7 @@ class SummaryStore:
         )
 
         # Find the most-recently updated datasets and group them by month.
-        return [
+        return sorted(
             (month, count)
             for month, count in self._engine.execute(
                 select(
@@ -323,7 +323,7 @@ class SummaryStore:
                 .group_by("month")
                 .order_by("month")
             )
-        ]
+        )
 
     def find_years_needing_update(self, product_name: str):
         """
@@ -1281,9 +1281,9 @@ class SummaryStore:
             # Regenerate the old months too, in case any have been deleted.
             old_months = set(old_product.iter_months()) if old_product else set()
 
-            months_to_update = [
+            months_to_update = sorted(
                 (month, "all") for month in old_months.union(new_product.iter_months())
-            ]
+            )
             refresh_type = GenerateResult.CREATED
 
         # Otherwise, only regenerate the things that changed.

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -39,7 +39,9 @@ class Summariser:
         # EPSG code for all polygons to be converted to (for footprints).
         self.output_crs_epsg_code = FOOTPRINT_SRID
 
-    def calculate_summary(self, product_name: str, time: Range) -> TimePeriodOverview:
+    def calculate_summary(
+        self, product_name: str, time: Range, product_refresh_time: datetime
+    ) -> TimePeriodOverview:
         """
         Create a summary of the given product/time range.
         """
@@ -155,8 +157,15 @@ class Summariser:
                 }
             )
 
+        if product_refresh_time is None:
+            raise RuntimeError(
+                "Internal error: Newly-made time summaries should "
+                "not have a null product refresh time."
+            )
+
         summary = TimePeriodOverview(
             **row,
+            product_refresh_time=product_refresh_time,
             timeline_period="day",
             time_range=Range(begin_time, end_time),
             timeline_dataset_counts=day_counts,

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from collections import Counter
 from datetime import datetime
+from typing import Tuple
 
 import pandas as pd
 import structlog
@@ -11,6 +12,7 @@ from geoalchemy2 import Geometry
 from geoalchemy2 import shape as geo_shape
 from sqlalchemy import and_, func, select, or_
 from sqlalchemy.dialects.postgresql import TSTZRANGE
+from sqlalchemy.sql import ColumnElement
 
 from cubedash._utils import ODC_DATASET_TYPE
 from cubedash.summary import TimePeriodOverview
@@ -175,7 +177,9 @@ class Summariser:
             return d.replace(tzinfo=self._grouping_time_zone_tz)
         return d
 
-    def _where(self, product_name, time):
+    def _where(
+        self, product_name: str, time: Range
+    ) -> Tuple[datetime, datetime, ColumnElement]:
         begin_time = self._with_default_tz(time.begin)
         end_time = self._with_default_tz(time.end)
         where_clause = and_(

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -7,6 +7,7 @@ scripts and the command-line.
 """
 import sys
 import time
+from textwrap import dedent
 
 import click
 import structlog
@@ -33,7 +34,22 @@ def _get_store(config: LocalConfig, variant: str, log=_LOG) -> SummaryStore:
 @environment_option
 @config_option
 @pass_config
-@click.option("-v", "--verbose", is_flag=True)
+@click.option(
+    "--verbose",
+    "-v",
+    count=True,
+    help=dedent(
+        """\
+        Enable all log messages, instead of just errors.
+
+        Logging goes to stdout unless `--event-log-file` is specified.
+
+        Logging is coloured plain-text if going to a tty, and jsonl format otherwise.
+
+        Use twice to enable debug logging too.
+        """
+    ),
+)
 @click.option(
     "-l",
     "--event-log-file",
@@ -58,7 +74,9 @@ def cli(
     """
     Print the recorded summary information for the given product
     """
-    init_logging(open(event_log_file, "a") if event_log_file else None, verbose=verbose)
+    init_logging(
+        open(event_log_file, "a") if event_log_file else None, verbosity=verbose
+    )
 
     store = _get_store(config, "setup")
 

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -92,14 +92,26 @@ def cli(
         for k, v in product.fixed_metadata.items():
             echo(f"\t{k}: {v}")
 
+    echo()
+    secho(
+        f"Period: {year or 'all-year'} {month or 'all-monday'} {day or 'all-days'}",
+        fg="blue",
+    )
     if summary:
-        echo()
-        secho(f"Period: {year or 'all'} {month or 'all'} {day or 'all'}", fg="blue")
         if summary.size_bytes:
             echo(f"\tStorage size: {sizeof_fmt(summary.size_bytes)}")
 
         echo(f"\t{summary.dataset_count} datasets")
         echo(f"\tSummarised: {summary.summary_gen_time}")
+
+        if summary.footprint_geometry:
+            secho(f"\tFootprint area: {summary.footprint_geometry.area}")
+            if not summary.footprint_geometry.is_valid:
+                secho("\tInvalid Geometry", fg="red")
+        else:
+            secho("\tNo footprint")
+    elif year or month or day:
+        echo("\tNo summary for chosen period.")
 
     echo()
     echo(f"(fetched in {round(t_end - t, 2)} seconds)")

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -56,14 +56,12 @@ def _get_store(config: LocalConfig, variant: str, log=_LOG) -> SummaryStore:
     help="Output jsonl logs to file",
     type=click.Path(writable=True, dir_okay=True),
 )
-@click.option("--allow-cache/--no-cache", is_flag=True, default=True)
 @click.argument("product_name")
 @click.argument("year", type=int, required=False)
 @click.argument("month", type=int, required=False)
 @click.argument("day", type=int, required=False)
 def cli(
     config: LocalConfig,
-    allow_cache: bool,
     product_name: str,
     year: int,
     month: int,

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -81,9 +81,13 @@ def cli(
     t = time.time()
     summary = store.get(product_name, year, month, day)
     t_end = time.time()
+
+    if not store.index.products.get_by_name(product_name):
+        echo(f"Unknown product {product_name!r}", err=True)
+        sys.exit(-1)
     product = store.get_product_summary(product_name)
     if product is None:
-        echo(f"Unsummarised product {product_name}", err=True)
+        echo(f"No info: product {product_name!r} has not been summarised", err=True)
         sys.exit(-1)
 
     secho(product_name, bold=True)

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -63,10 +63,7 @@ def cli(
     region_info = store.get_product_region_info(product_name)
 
     t = time.time()
-    if allow_cache:
-        summary = store.get_or_update(product_name, year, month, day)
-    else:
-        summary = store.update(product_name, year, month, day)
+    summary = store.get(product_name, year, month, day)
     t_end = time.time()
 
     echo(f"{summary.dataset_count} ", nl=False)

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -94,7 +94,7 @@ def cli(
 
     echo()
     secho(
-        f"Period: {year or 'all-year'} {month or 'all-monday'} {day or 'all-days'}",
+        f"Period: {year or 'all-years'} {month or 'all-months'} {day or 'all-days'}",
         fg="blue",
     )
     if summary:

--- a/cubedash/templates/storage.html
+++ b/cubedash/templates/storage.html
@@ -64,15 +64,7 @@
                     </td>
                     <td class="numeric">{{ product | product_license_link }}</td>
                     <td><a href="{{url_for('product.raw_product_doc', name=product.name)}}" class="badge">doc</a></td>
-                                <td>
-                    {% if summary.last_refresh_age.days > 1 %}
-                        {{ summary.last_refresh_age.days }} days
-                    {% elif summary.last_refresh_age.seconds // 60 // 60 > 1 %}
-                        {{ summary.last_refresh_age.seconds // 60 // 60 }} hours
-                    {% else %}
-                        {{ summary.last_refresh_age.seconds // 60 }} minutes
-                    {% endif %}
-                </td>
+                    <td>{{ summary.last_refresh_time | timesince }}</td>
                 <td>
                     {% if summary.derived_products %}
                         {% for p in summary.derived_products %}

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -219,7 +219,7 @@ def unpopulated_client(
     empty_client: FlaskClient, summary_store: SummaryStore
 ) -> FlaskClient:
     with disable_logging():
-        _model.STORE.refresh_all_products()
+        _model.STORE.refresh_all_product_extents()
     return empty_client
 
 
@@ -247,7 +247,7 @@ def client(unpopulated_client: FlaskClient) -> FlaskClient:
 
     with disable_logging():
         for product in _model.STORE.index.products.get_all():
-            _model.STORE.get_or_update(product.name)
+            _model.STORE.refresh(product.name)
 
     return unpopulated_client
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -135,7 +135,7 @@ def summariser(summary_store: SummaryStore):
 @pytest.fixture(autouse=True, scope="session")
 def _init_logs(pytestconfig):
     logs.init_logging(
-        verbose=pytestconfig.getoption("verbose") > 0, cache_logger_on_first_use=False
+        verbosity=pytestconfig.getoption("verbose"), cache_logger_on_first_use=False
     )
 
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -174,7 +174,7 @@ def run_generate(clirunner, summary_store, multi_processed=False):
 
 
 @pytest.fixture(scope="module")
-def dataset_loader(module_dea_index):
+def dataset_loader(module_dea_index: Index):
     def _populate_from_dump(expected_type: str, dump_path: Path):
         ls8_nbar_scene = module_dea_index.products.get_by_name(expected_type)
         dataset_count = 0

--- a/integration_tests/data_wofs_summary.py
+++ b/integration_tests/data_wofs_summary.py
@@ -15,6 +15,10 @@ from datacube.model import Range
 # (perhaps the non-footprint data can be thrown away in the future if too unmaintable)
 #
 wofs_time_summary = TimePeriodOverview(
+    product_name="wofs_summary",
+    year=None,
+    month=None,
+    day=None,
     dataset_count=1244,
     timeline_dataset_counts=Counter(
         {

--- a/integration_tests/data_wofs_summary.py
+++ b/integration_tests/data_wofs_summary.py
@@ -1401,4 +1401,14 @@ wofs_time_summary = TimePeriodOverview(
         853_756,
         tzinfo=FixedOffsetTimezone(offset=660, name=None),
     ),
+    product_refresh_time=datetime(
+        2019,
+        2,
+        22,
+        21,
+        22,
+        16,
+        853_756,
+        tzinfo=FixedOffsetTimezone(offset=660, name=None),
+    ),
 )

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -158,6 +158,7 @@ def _create_overview():
         crses=set(),
         summary_gen_time=datetime.now(),
         size_bytes=256,
+        product_refresh_time=datetime.now(),
     )
     return overview
 

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -123,7 +123,7 @@ def test_invalid_footprint_wofs_summary_load(client: FlaskClient):
     # when reprojected to wgs84 by shapely.
     from .data_wofs_summary import wofs_time_summary
 
-    _model.STORE._put("wofs_summary", None, None, None, wofs_time_summary)
+    _model.STORE._put(wofs_time_summary)
     html = get_html(client, "/wofs_summary")
     check_dataset_count(html, 1244)
 

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -123,7 +123,7 @@ def test_invalid_footprint_wofs_summary_load(client: FlaskClient):
     # when reprojected to wgs84 by shapely.
     from .data_wofs_summary import wofs_time_summary
 
-    _model.STORE._do_put("wofs_summary", None, None, None, wofs_time_summary)
+    _model.STORE._put("wofs_summary", None, None, None, wofs_time_summary)
     html = get_html(client, "/wofs_summary")
     check_dataset_count(html, 1244)
 

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -618,12 +618,38 @@ def test_show_summary_cli(clirunner, client: FlaskClient):
     # ls7_nbar_scene / 2017 / 05
     res: Result = clirunner(show.cli, ["ls7_nbar_scene", "2017", "5"])
     print(res.output)
-    assert "Landsat WRS2 scene-based product" in res.output
-    assert "3 ls7_nbar_scene datasets for 2017 5" in res.output
-    assert "727.4MiB" in res.output
-    assert (
-        "96  97  98  99 100 101 102 103 104 105" in res.output
-    ), "No list of paths displayed"
+
+    expected_header = "\n".join(
+        (
+            "ls7_nbar_scene",
+            "",
+            "3  datasets",
+            "from 2017-04-20T10:03:26+10:00 ",
+            "  to 2017-05-03T11:06:41.500000+10:00 ",
+        )
+    )
+    assert res.output.startswith(expected_header)
+    expected_metadata = "\n".join(
+        (
+            "Metadata",
+            "\tgsi: ASA",
+            "\torbit: None",
+            "\tformat: GeoTIFF",
+            "\tplatform: LANDSAT_7",
+            "\tinstrument: ETM",
+            "\tproduct_type: nbar",
+        )
+    )
+    assert expected_metadata in res.output
+    expected_period = "\n".join(
+        (
+            "Period: 2017 5 all-days",
+            "\tStorage size: 727.4MiB",
+            "\t3 datasets",
+            "",
+        )
+    )
+    assert expected_period in res.output
 
 
 def test_extent_debugging_method(module_dea_index: Index, client: FlaskClient):

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -615,11 +615,14 @@ def test_invalid_product_returns_not_found(client: FlaskClient):
 
 
 def test_show_summary_cli(clirunner, client: FlaskClient):
-    # ls7_nbar_scene / 2017 / 05
+    """
+    You should be able to view a product with cubedash-view command-line program.
+    """
+    # ls7_nbar_scene, 2017, May
     res: Result = clirunner(show.cli, ["ls7_nbar_scene", "2017", "5"])
     print(res.output)
 
-    # It shows the dates in local timezone.
+    # Expect it to show the dates in local timezone.
     expected_from = datetime(2017, 4, 20, 0, 3, 26, tzinfo=tz.tzutc()).astimezone()
     expected_to = datetime(2017, 5, 3, 1, 6, 41, 500000, tzinfo=tz.tzutc()).astimezone()
 
@@ -654,6 +657,30 @@ def test_show_summary_cli(clirunner, client: FlaskClient):
         )
     )
     assert expected_period in res.output
+
+
+def test_show_summary_cli_missing_product(clirunner, client: FlaskClient):
+    """
+    A missing product should return a nice error message from cubedash-view.
+
+    (and error return code)
+    """
+    res: Result = clirunner(show.cli, ["does_not_exist"], expect_success=False)
+    output: str = res.output
+    assert output.strip().startswith("Unknown product 'does_not_exist'")
+    assert res.exit_code != 0
+
+
+def test_show_summary_cli_unsummarised_product(clirunner, empty_client: FlaskClient):
+    """
+    An unsummarised product should return a nice error message from cubedash-view.
+
+    (and error return code)
+    """
+    res: Result = clirunner(show.cli, ["ls7_nbar_scene"], expect_success=False)
+    out = res.output.strip()
+    assert out.startswith("No info: product 'ls7_nbar_scene' has not been summarised")
+    assert res.exit_code != 0
 
 
 def test_extent_debugging_method(module_dea_index: Index, client: FlaskClient):

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -619,13 +619,17 @@ def test_show_summary_cli(clirunner, client: FlaskClient):
     res: Result = clirunner(show.cli, ["ls7_nbar_scene", "2017", "5"])
     print(res.output)
 
+    # It shows the dates in local timezone.
+    expected_from = datetime(2017, 4, 20, 0, 3, 26, tzinfo=tz.tzutc()).astimezone()
+    expected_to = datetime(2017, 5, 3, 1, 6, 41, 500000, tzinfo=tz.tzutc()).astimezone()
+
     expected_header = "\n".join(
         (
             "ls7_nbar_scene",
             "",
             "3  datasets",
-            "from 2017-04-20T10:03:26+10:00 ",
-            "  to 2017-05-03T11:06:41.500000+10:00 ",
+            f"from {expected_from.isoformat()} ",
+            f"  to {expected_to.isoformat()} ",
         )
     )
     assert res.output.startswith(expected_header)

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -659,6 +659,17 @@ def test_show_summary_cli(clirunner, client: FlaskClient):
     assert expected_period in res.output
 
 
+def test_show_summary_cli_out_of_bounds(clirunner, client: FlaskClient):
+    """
+    Can you view a date that doesn't exist?
+    """
+    # A period that's out of bounds.
+    res: Result = clirunner(
+        show.cli, ["ls7_nbar_scene", "2030", "5"], expect_success=False
+    )
+    assert "No summary for chosen period." in res.output
+
+
 def test_show_summary_cli_missing_product(clirunner, client: FlaskClient):
     """
     A missing product should return a nice error message from cubedash-view.

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -191,8 +191,7 @@ def test_uninitialised_overview(
 ):
     # Populate one product, so they don't get the usage error message ("run cubedash generate")
     # Then load an unpopulated product.
-    summary_store.refresh_product(summary_store.get_dataset_type("ls7_nbar_albers"))
-    summary_store.get_or_update("ls7_nbar_albers")
+    summary_store.refresh("ls7_nbar_albers")
 
     html = get_html(unpopulated_client, "/ls7_nbar_scene/2017")
 
@@ -210,8 +209,7 @@ def test_uninitialised_product(empty_client: FlaskClient, summary_store: Summary
     """
     # Populate one product, so they don't get the usage error message ("run cubedash generate")
     # Then load an unpopulated product.
-    summary_store.refresh_product(summary_store.get_dataset_type("ls7_nbar_albers"))
-    summary_store.get_or_update("ls7_nbar_albers")
+    summary_store.refresh("ls7_nbar_albers")
 
     html = get_html(empty_client, "/products/ls7_nbar_scene")
 
@@ -286,10 +284,7 @@ def test_uninitialised_search_page(
     empty_client: FlaskClient, summary_store: SummaryStore
 ):
     # Populate one product, so they don't get the usage error message ("run cubedash generate")
-    summary_store.refresh_product(
-        summary_store.index.products.get_by_name("ls7_nbar_albers")
-    )
-    summary_store.get_or_update("ls7_nbar_albers")
+    summary_store.refresh("ls7_nbar_albers")
 
     # Then load a completely uninitialised product.
     html = get_html(empty_client, "/datasets/ls7_nbar_scene")

--- a/integration_tests/test_s2_l2a_footprint.py
+++ b/integration_tests/test_s2_l2a_footprint.py
@@ -65,7 +65,7 @@ def test_product_dataset(client: FlaskClient):
 def test_s2_l2a_summary(run_generate, summary_store: SummaryStore):
     run_generate("s2_l2a")
     expect_values(
-        summary_store.update("s2_l2a"),
+        summary_store.get("s2_l2a"),
         dataset_count=4,
         footprint_count=4,
         time_range=Range(

--- a/integration_tests/test_s2_l2a_footprint.py
+++ b/integration_tests/test_s2_l2a_footprint.py
@@ -131,8 +131,7 @@ def test_get_overview_date_selector(client: FlaskClient):
 
 def test_refresh_product(empty_client: FlaskClient, summary_store: SummaryStore):
     # Populate one product, so they don't get the usage error message ("run cubedash generate")
-    summary_store.refresh_product(summary_store.index.products.get_by_name("s2_l2a"))
-    summary_store.get_or_update("s2_l2a")
+    summary_store.refresh("s2_l2a")
 
     # Then load a completely uninitialised product.
     html = get_html(empty_client, "/datasets/s2_l2a")

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -649,7 +649,7 @@ def test_stac_collection_items(stac_client: FlaskClient):
     else:
         raise AssertionError("high_tide_comp_20p not found in collection list")
 
-    scene_collection = get_collection(stac_client, collection_href)
+    scene_collection = get_collection(stac_client, collection_href, validate=False)
 
     assert scene_collection == {
         "stac_version": "1.0.0-beta.2",
@@ -685,7 +685,7 @@ def test_stac_collection_items(stac_client: FlaskClient):
         ],
         "providers": [],
     }
-
+    assert_collection(scene_collection)
     item_links = scene_collection["links"][0]["href"]
     validate_items(_iter_items_across_pages(stac_client, item_links), expect_count=306)
 

--- a/integration_tests/test_stores.py
+++ b/integration_tests/test_stores.py
@@ -14,8 +14,17 @@ from cubedash.summary._summarise import Summariser
 from datacube.model import Range
 
 
-def _overview():
+def _overview(
+    product_name: str = "test_product",
+    year: int = None,
+    month: int = None,
+    day: int = None,
+):
     orig = TimePeriodOverview(
+        product_name=product_name,
+        year=year,
+        month=month,
+        day=day,
         dataset_count=4,
         timeline_dataset_counts=Counter(
             [
@@ -171,10 +180,10 @@ def test_put_get_summaries(summary_store: SummaryStore):
     """
     Test the serialisation/deserialisation from postgres
     """
-    o = _overview()
+    product_name = "some_product"
+    o = _overview(product_name, 2017)
     assert o.summary_gen_time is None, "Generation time should be set by server"
 
-    product_name = "some_product"
     summary_store._set_product_extent(
         ProductSummary(
             product_name,
@@ -188,7 +197,7 @@ def test_put_get_summaries(summary_store: SummaryStore):
         )
     )
 
-    summary_store._put(product_name, 2017, None, None, o)
+    summary_store._put(o)
     loaded = summary_store.get(product_name, 2017, None, None)
 
     assert o is not loaded, (
@@ -218,7 +227,7 @@ def test_put_get_summaries(summary_store: SummaryStore):
     o.dataset_count = 4321
     o.newest_dataset_creation_time = datetime(2018, 2, 2, 2, 2, 2, tzinfo=tz.tzutc())
     time.sleep(1)
-    summary_store._put(product_name, 2017, None, None, o)
+    summary_store._put(o)
     assert o.summary_gen_time != original_gen_time
 
     loaded = summary_store.get(product_name, 2017, None, None)

--- a/integration_tests/test_stores.py
+++ b/integration_tests/test_stores.py
@@ -91,7 +91,7 @@ def test_add_no_periods(summary_store: SummaryStore):
     """
     All the get/update methods should work on products with no datasets.
     """
-    summary_store._set_product_extent(
+    summary_store._persist_product_extent(
         ProductSummary("ga_ls8c_level1_3", 0, None, None, [], [], {}, datetime.now())
     )
     assert summary_store.get("ga_ls8c_level1_3", 2015, 7, 4).dataset_count == 0
@@ -184,7 +184,7 @@ def test_put_get_summaries(summary_store: SummaryStore):
     o = _overview(product_name, 2017)
     assert o.summary_gen_time is None, "Generation time should be set by server"
 
-    summary_store._set_product_extent(
+    summary_store._persist_product_extent(
         ProductSummary(
             product_name,
             4321,

--- a/integration_tests/test_stores.py
+++ b/integration_tests/test_stores.py
@@ -83,17 +83,16 @@ def test_add_no_periods(summary_store: SummaryStore):
     All the get/update methods should work on products with no datasets.
     """
     summary_store._set_product_extent(
-        ProductSummary("test_empty_product", 0, None, None, [], [], {}, datetime.now())
+        ProductSummary("ga_ls8c_level1_3", 0, None, None, [], [], {}, datetime.now())
     )
-    assert summary_store.get("test_empty_product", 2015, 7, 4).dataset_count == 0
+    assert summary_store.get("ga_ls8c_level1_3", 2015, 7, 4).dataset_count == 0
 
-    result, summary = summary_store.refresh("test_empty_product")
+    result, summary = summary_store.refresh("ga_ls8c_level1_3")
     assert result == GenerateResult.CREATED
     assert summary.dataset_count == 0
 
-    assert summary_store.get("test_empty_product", 2015, 7, None).dataset_count == 0
-    assert summary_store.get("test_empty_product", 2015, None, None).dataset_count == 0
-    assert summary_store.get("test_empty_product", None, None, None).dataset_count == 0
+    assert summary_store.get("ga_ls8c_level1_3").dataset_count == 0
+    assert summary_store.get("ga_ls8c_level1_3", 2015, 7, None) is None
 
 
 def test_month_iteration():

--- a/integration_tests/test_stores.py
+++ b/integration_tests/test_stores.py
@@ -46,6 +46,7 @@ def _overview():
         newest_dataset_creation_time=datetime(2018, 1, 1, 1, 1, 1, tzinfo=tz.tzutc()),
         crses={"epsg:1234"},
         size_bytes=123_400_000,
+        product_refresh_time=datetime(2018, 2, 3, 1, 1, 1, tzinfo=tz.tzutc()),
     )
     return orig
 
@@ -80,7 +81,7 @@ def test_add_no_periods(summary_store: SummaryStore):
     All the get/update methods should work on products with no datasets.
     """
     summary_store._set_product_extent(
-        ProductSummary("test_empty_product", 0, None, None, [], [], {})
+        ProductSummary("test_empty_product", 0, None, None, [], [], {}, datetime.now())
     )
     summary_store.get_or_update("test_empty_product", 2015, 7, 4)
     summary_store.get_or_update("test_empty_product", 2015, 7, None)
@@ -125,7 +126,14 @@ def test_put_get_summaries(summary_store: SummaryStore):
     product_name = "some_product"
     summary_store._set_product_extent(
         ProductSummary(
-            product_name, 4321, datetime(2017, 1, 1), datetime(2017, 4, 1), [], [], {}
+            product_name,
+            4321,
+            datetime(2017, 1, 1),
+            datetime(2017, 4, 1),
+            [],
+            [],
+            {},
+            datetime.now(),
         )
     )
 

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -124,8 +124,13 @@ def test_generate_scene_all_time(run_generate, summary_store: SummaryStore):
     run_generate("ls8_nbar_scene")
 
     # All time
+    summary = summary_store.get("ls8_nbar_scene", year=None, month=None, day=None)
+    assert (
+        summary_store.index.datasets.count(product="ls8_nbar_scene")
+        == summary.dataset_count
+    )
     _expect_values(
-        summary_store.get("ls8_nbar_scene", year=None, month=None, day=None),
+        summary,
         dataset_count=3036,
         footprint_count=3036,
         time_range=Range(

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -68,7 +68,7 @@ def test_generate_month(run_generate, summary_store: SummaryStore):
     run_generate("ls8_nbar_scene")
     # One Month
     _expect_values(
-        summary_store.update("ls8_nbar_scene", 2017, 4, None),
+        summary_store.get("ls8_nbar_scene", 2017, 4, None),
         dataset_count=408,
         footprint_count=408,
         time_range=Range(

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -466,7 +466,6 @@ def test_force_dataset_regeneration(
 
 
 def test_calc_albers_summary_with_storage(summary_store: SummaryStore):
-    summary_store.refresh_all_product_extents()
 
     # Should not exist yet.
     summary = summary_store.get("ls8_nbar_albers", year=None, month=None, day=None)
@@ -475,6 +474,7 @@ def test_calc_albers_summary_with_storage(summary_store: SummaryStore):
     assert summary is None
 
     # Calculate overall summary
+
     _, summary = summary_store.refresh("ls8_nbar_albers")
     _expect_values(
         summary,
@@ -500,12 +500,12 @@ def test_calc_albers_summary_with_storage(summary_store: SummaryStore):
     summary_store.refresh("ls8_nbar_albers")
 
     cached_s = summary_store.get("ls8_nbar_albers", 2017)
-
+    assert original is not cached_s
+    assert cached_s.dataset_count == original.dataset_count
     assert cached_s.summary_gen_time is not None
     assert (
         cached_s.summary_gen_time == original.summary_gen_time
     ), "A new, rather than cached, summary was returned"
-    assert cached_s.dataset_count == original.dataset_count
 
 
 def test_cubedash_gen_refresh(run_generate, module_index: Index):

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -226,11 +226,10 @@ def test_sampled_product_fixed_fields(summary_store: SummaryStore):
 
 def test_generate_empty_time(run_generate, summary_store: SummaryStore):
     run_generate("ls8_nbar_albers")
-
     # No datasets in 2018
-    summary = summary_store.get("ls8_nbar_albers", year=2018)
-    assert summary.dataset_count == 0, "There should be no datasets in 2018"
-    # assert len(summary.timeline_dataset_counts) == 365, "Empty regions should still show up in timeline histogram"
+    assert (
+        summary_store.get("ls8_nbar_albers", year=2018) is None
+    ), "There should be no datasets in 2018"
 
     # Year that does not exist for LS8
     summary = summary_store.get("ls8_nbar_albers", year=2006, month=None, day=None)
@@ -387,14 +386,18 @@ def test_calc_albers_summary_with_storage(summary_store: SummaryStore):
         size_bytes=0,
     )
 
+    original = summary_store.get("ls8_nbar_albers", 2017)
+
     # It should now return the same copy, not rebuild it.
-    _, cached_s = summary_store.refresh("ls8_nbar_albers")
+    summary_store.refresh("ls8_nbar_albers")
+
+    cached_s = summary_store.get("ls8_nbar_albers", 2017)
 
     assert cached_s.summary_gen_time is not None
     assert (
-        cached_s.summary_gen_time == summary.summary_gen_time
+        cached_s.summary_gen_time == original.summary_gen_time
     ), "A new, rather than cached, summary was returned"
-    assert cached_s.dataset_count == summary.dataset_count
+    assert cached_s.dataset_count == original.dataset_count
 
 
 def test_cubedash_gen_refresh(run_generate, module_index: Index):

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -150,6 +150,27 @@ def test_generate_scene_all_time(run_generate, summary_store: SummaryStore):
     )
 
 
+def test_generate_incremental_archivals(run_generate, summary_store: SummaryStore):
+    run_generate("ls8_nbar_scene")
+    index = summary_store.index
+
+    # When we have a summarised product...
+    original_summary = summary_store.get("ls8_nbar_scene")
+
+    # ... and we archive one dataset ...
+    [[dataset_id]] = index.datasets.search_returning(
+        ("id",), product="ls8_nbar_scene", limit=1
+    )
+    index.datasets.archive([dataset_id])
+
+    # ... the next generation should catch it and update with one less dataset....
+    run_generate("ls8_nbar_scene")
+    updated_summary = summary_store.get("ls8_nbar_scene")
+    assert (
+        original_summary.dataset_count == updated_summary.dataset_count + 1
+    ), "Expected dataset count to decrease after archival"
+
+
 def test_has_source_derived_product_links(run_generate, summary_store: SummaryStore):
     run_generate()
 

--- a/integration_tests/test_wagl_data.py
+++ b/integration_tests/test_wagl_data.py
@@ -33,7 +33,7 @@ def populate_index(dataset_loader, module_dea_index):
 def test_s2_ard_summary(run_generate, summary_store: SummaryStore):
     run_generate("s2a_ard_granule")
     expect_values(
-        summary_store.update("s2a_ard_granule"),
+        summary_store.get("s2a_ard_granule"),
         dataset_count=8,
         footprint_count=8,
         time_range=Range(
@@ -51,7 +51,7 @@ def test_s2_ard_summary(run_generate, summary_store: SummaryStore):
 def test_s2a_l1_summary(run_generate, summary_store: SummaryStore):
     run_generate("s2a_level1c_granule")
     expect_values(
-        summary_store.update("s2a_level1c_granule"),
+        summary_store.get("s2a_level1c_granule"),
         dataset_count=8,
         footprint_count=8,
         time_range=Range(


### PR DESCRIPTION
A complete rewrite of the `cubdash-gen` update logic.

It now keeps track of the changes in the upstream datacube, and applies those updates to Explorer's summaries in-place.

It supports adding, updating and archiving datasets. Users that manually delete rows from the database will still need a `--force-refresh` as we have no efficient way to know that it happened.

`cubedash-gen <products>`, without other arguments, will now calculate what has changed since the last successful run, and apply those changes. So almost everyone using `--force-refresh` will no longer need to do it.

- [x] Fix new-year roll-over bug.
- [x] Expand doc strings with explanations of the complicated parts of logic.
- [x] Remove/replace the old recursive update logic
- [x] Fix geometry extraction for `high_tide_comp_20p`
- [x] Further testing of failure situations (it should always be hands-off and re-runnable safely without missing/skipping data)
- [x] Add a check for ODC's optional `dataset.updated` column. We use the column to know what datasets have changed.
- [x] Retry (manually) the migration from a previous version of Explorer.
- [x] Tell users about, ~or deprecate~, the `--force` option, as most people using it shouldn't be now? Putting in release notes


----

This includes schema changes (which is why it was hard to break up into smaller PRs).

They are applied using the normal `cubedash-gen --init` command.

- Old web instances are compatible with the new schema. So we can run `cubedash-gen --init` to update the schema before deployment.
- The first time someone runs `cubedash-gen` it will not be incremental. It will regenerate every time period with markers against their latest change date. Future runs will be incremental (... and super fast, in my testing!)