### PR TITLE
Remove expensive db-join from dataset deletion clean-up

### DIFF
--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -315,12 +315,14 @@ def refresh_spatial_extents(
             "extent_force_removal.start",
         )
         changed += engine.execute(
-            DATASET_SPATIAL.delete().where(DATASET.c.dataset_type_ref == product.id)
+            DATASET_SPATIAL.delete().where(
+                DATASET_SPATIAL.c.dataset_type_ref == product.id,
+            )
             # Where it doesn't exist in the ODC dataset table.
             .where(
                 ~DATASET_SPATIAL.c.id.in_(
                     select([DATASET.c.id]).where(
-                        DATASET.c.dataset_type_ref == product.id
+                        DATASET.c.dataset_type_ref == product.id,
                     )
                 )
             )

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -271,7 +271,7 @@ def _gis_point(doc, doc_offset):
 def refresh_spatial_extents(
     index: Index,
     product: DatasetType,
-    thorough=False,
+    clean_up_deleted=False,
     assume_after_date: datetime = None,
 ):
     """
@@ -310,7 +310,7 @@ def refresh_spatial_extents(
     )
 
     # Forcing? Check every other dataset for removal, so we catch manually-deleted rows from the table.
-    if thorough:
+    if clean_up_deleted:
         log.info(
             "extent_force_removal.start",
         )

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1245,7 +1245,7 @@ class SummaryStore:
 
         change_count, new_product = self.refresh_product_extent(
             product_name,
-            scan_for_deleted=force or recreate_dataset_extents,
+            scan_for_deleted=recreate_dataset_extents,
             only_those_newer_than=(
                 None
                 if (force or (old_product is None))

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -249,12 +249,10 @@ class SummaryStore:
 
     def refresh_all_product_extents(
         self,
-        force_dataset_extent_recompute=False,
     ):
         for product in self.all_dataset_types():
             self.refresh_product_extent(
                 product.name,
-                force_recompute=force_dataset_extent_recompute,
             )
         self.refresh_stats()
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1243,7 +1243,6 @@ class SummaryStore:
 
         old_product: ProductSummary = self.get_product_summary(product_name)
 
-        log.info("extent.refresh")
         change_count, new_product = self.refresh_product_extent(
             product_name,
             scan_for_deleted=force or recreate_dataset_extents,

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1246,7 +1246,7 @@ class SummaryStore:
             scan_for_deleted=recreate_dataset_extents,
             only_those_newer_than=(
                 None
-                if (force or (old_product is None))
+                if (force or recreate_dataset_extents or (old_product is None))
                 else old_product.last_successful_summary_time
             ),
         )

--- a/cubedash/warmup.py
+++ b/cubedash/warmup.py
@@ -4,7 +4,7 @@ import time
 import urllib.request
 from textwrap import indent
 from typing import List, Tuple
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.parse import urljoin
 
 import click
@@ -145,7 +145,10 @@ def cli(
                 )
                 response_times.append((finished_in, url))
         except socket.timeout:
-            secho(f"timeout (> {timeout_seconds}s)", fg="purple", err=True)
+            secho(f"timeout (> {timeout_seconds}s)", fg="magenta", err=True)
+            failures.append(url)
+        except URLError as e:
+            secho(f"connection error {e.reason}", fg="magenta", err=True)
             failures.append(url)
         except HTTPError as e:
             secho(f"fail {e.code}", fg="red", err=True)
@@ -167,7 +170,7 @@ def cli(
                 break
             secho(f"\t{_format_time(response_secs)}\t{url}")
 
-    sys.exit(failures)
+    sys.exit(len(failures))
 
 
 def _format_time(t: float):


### PR DESCRIPTION
The deletion query had an extra, unnecessary join which was causing an extremely slow, nested loop in Postgres.

...and it perhaps should be a separate PR, but I've also added timing information to the output of `cubedash-page-test` to help debug slow pages.