### PR TITLE
Expand incremental-update function: no fast-product-skipping, allow marker reset

### DIFF
--- a/cubedash/summary/__init__.py
+++ b/cubedash/summary/__init__.py
@@ -1,6 +1,7 @@
-from ._extents import RegionInfo
+from ._extents import RegionInfo, UnsupportedWKTProductCRS
 from ._model import TimePeriodOverview
 from ._stores import (
+    GenerateResult,
     SummaryStore,
     ItemSort,
     ProductLocationSample,
@@ -10,10 +11,12 @@ from ._stores import (
 
 __all__ = (
     "DatasetItem",
+    "GenerateResult",
     "ItemSort",
     "ProductLocationSample",
     "ProductSummary",
     "RegionInfo",
     "SummaryStore",
     "TimePeriodOverview",
+    "UnsupportedWKTProductCRS",
 )

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -48,6 +48,13 @@ _WRS_PATH_ROW = [
 ]
 
 
+class UnsupportedWKTProductCRS(NotImplementedError):
+    """We can't, within Postgis, support arbitrary WKT CRSes at the moment."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+
+
 def get_dataset_extent_alchemy_expression(md: MetadataType, default_crs: str = None):
     """
     Build an SQLAlchemy expression to get the extent for a dataset.
@@ -168,8 +175,11 @@ def get_dataset_srid_alchemy_expression(md: MetadataType, default_crs: str = Non
             # HACK: Change default CRS with inference
             inferred_crs = infer_crs(default_crs)
             if inferred_crs is None:
-                raise NotImplementedError(
-                    f"CRS expected in form of 'EPSG:1234'. Got: {default_crs!r}"
+                raise UnsupportedWKTProductCRS(
+                    f"WKT Product CRSes are not currently well supported, and "
+                    f"we can't infer this product's one. "
+                    f"(Ideally use an auth-name format for CRS, such as 'EPSG:1234') "
+                    f"Got: {default_crs!r}"
                 )
             default_crs = inferred_crs
 

--- a/cubedash/summary/_model.py
+++ b/cubedash/summary/_model.py
@@ -112,6 +112,12 @@ class TimePeriodOverview:
         return year, month, day
 
     @classmethod
+    def empty(cls, product_name: str):
+        p = cls.add_periods([])
+        p.product_name = product_name
+        return p
+
+    @classmethod
     def add_periods(
         cls,
         periods: Iterable["TimePeriodOverview"],

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -202,6 +202,24 @@ class SummaryStore:
         self._engine: Engine = _utils.alchemy_engine(index)
         self._summariser = summariser
 
+        # How much extra time to include in incremental update scans?
+        #    Incremental update are searching for any datasets with a a change-timestamp after our
+        #    last changes were applied. But some earlier-timestamped datasets may not have been
+        #    present last run if they were added in a concurrent, open transaction. And we don't
+        #    want to miss them! So we give a buffer assuming no transaction was open longer than
+        #    this buffer. (It doesn't matter at all if we repeat datasets).
+        #
+        #    This is not solution of perfection. But ODC's indexing does happen with quick,
+        #    auto-committing transactions, so they're unlikely to actually be open for more
+        #    than a few milliseconds. Fifteen minutes feels generous.
+        #
+        #    (You can judge if this assumption has failed by comparing our dataset_spatial
+        #     count(*) to ODC's dataset count(*) for the same product. They should match
+        #     for active datasets.)
+        #
+        #    tldr: "15 minutes == max expected transaction age of indexer"
+        self.dataset_overlap_carefulness = timedelta(minutes=15)
+
     def add_change_listener(self, listener):
         self._update_listeners.append(listener)
 
@@ -1253,24 +1271,9 @@ class SummaryStore:
             )
         else:
             # Otherwise only refresh datasets newer than the last successful run.
-            #
-            # Why do we have an extra 15 minute fudge?
-            #    We are searching for any datasets with a a change-timestamp after our last changes were applied.
-            #    But some earlier-timestamped datasets may not have been present last run if they were added
-            #    in a concurrent, open transaction. And we don't want to miss them! So we give a buffer assuming
-            #    no transaction was open longer than this buffer. (It doesn't matter at all if we repeat datasets).
-            #
-            #    This is not solution of perfection. But ODC's indexing does happen with quick, auto-committing
-            #    transactions, so they're unlikely to actually be open for more than a few milliseconds. Fifteen
-            #    minutes feels generous.
-            #
-            #    (You can judge if this assumption has failed by comparing our dataset_spatial
-            #     count(*) to ODC's dataset count(*) for the same product. They should match
-            #     for active datasets.)
-            #
-            #    tldr: "15 minutes == max expected transaction age of indexer"
             only_datasets_newer_than = (
-                old_product.last_successful_summary_time - timedelta(minutes=15)
+                old_product.last_successful_summary_time
+                - self.dataset_overlap_carefulness
             )
 
         extent_changes, new_product = self.refresh_product_extent(

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1245,9 +1245,6 @@ class SummaryStore:
 
         old_product: ProductSummary = self.get_product_summary(product_name)
 
-        if force and reset_incremental_position:
-            raise ValueError("Cannot both force and reset the incremental position.")
-
         # Which datasets to scan for updates?
         if (
             # If they've never summarised this product before

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1217,6 +1217,7 @@ class SummaryStore:
         product_name: str,
         force: bool = False,
         recreate_dataset_extents: bool = False,
+        reset_incremental_position: bool = False,
     ) -> Tuple[GenerateResult, TimePeriodOverview]:
         """
         Update all information known about the product, if it has changed.
@@ -1224,9 +1225,12 @@ class SummaryStore:
         This will update the spatial tables (extents) and update
         any outdated time summaries.
         """
-        log = _LOG
+        log = _LOG.bind(product_name=product_name)
 
         old_product: ProductSummary = self.get_product_summary(product_name)
+
+        if force and reset_incremental_position:
+            raise ValueError("Cannot both force and reset the incremental position.")
 
         # Which datasets to scan for updates?
         only_datasets_newer_than = (
@@ -1253,6 +1257,21 @@ class SummaryStore:
             else old_product.last_successful_summary_time - timedelta(minutes=15)
         )
 
+        # Maybe they want to reset the incremental position?
+        # -> Find the most recently indexed dataset that exists in our own spatial table,
+        #    and use that time as the position to scan changes from.
+        if reset_incremental_position:
+            log.info("resetting_incremental_position")
+            only_datasets_newer_than = self._newest_known_dataset_addition_time(
+                product_name
+            )
+            if (
+                only_datasets_newer_than is None
+                and old_product
+                and old_product.dataset_count > 0
+            ):
+                raise RuntimeError("BUG? Non-empty product had no dataset change?")
+
         extent_changes, new_product = self.refresh_product_extent(
             product_name,
             scan_for_deleted=recreate_dataset_extents,
@@ -1265,17 +1284,15 @@ class SummaryStore:
         refresh_timestamp = new_product.last_refresh_time
         assert refresh_timestamp is not None
 
-        # Do we need to regenerate everything?
+        # What month summaries do we need to generate?
         if (
-            # If it's a new product...
-            old_product is None
+            # If we're scanning all of them...
+            only_datasets_newer_than is None
             # ...or it was generated before incremental-updating was implemented.
             or old_product.last_successful_summary_time is None
-            # ... or we're using brute force.
-            or force
         ):
-            # Then regenerate every single summary.
-            log.info("product.generate_whole")
+            # Then choose the whole time range of the product to generate.
+            log.info("product.generate_whole_range")
             if force:
                 log.warn("forcing_refresh")
 
@@ -1287,13 +1304,14 @@ class SummaryStore:
             )
             refresh_type = GenerateResult.CREATED
 
-        # Otherwise, only regenerate the things that changed.
+        # Otherwise, only regenerate the ones that changed.
         else:
             log.info("product.incremental_update")
             months_to_update = self.find_months_needing_update(
                 product_name, only_datasets_newer_than
             )
             refresh_type = GenerateResult.UPDATED
+
         # Months
         for change_month, new_count in months_to_update:
             log.debug(
@@ -1336,6 +1354,24 @@ class SummaryStore:
             refresh_type = GenerateResult.NO_CHANGES
 
         return refresh_type, updated_summary
+
+    def _newest_known_dataset_addition_time(self, product_name) -> datetime:
+        """
+        Of all the datasets that are present in Explorer's own tables, when
+        was the most recent one added?
+        """
+        return self._engine.execute(
+            select([func.max(ODC_DATASET.c.added)])
+            .select_from(
+                DATASET_SPATIAL.join(
+                    ODC_DATASET, onclause=DATASET_SPATIAL.c.id == ODC_DATASET.c.id
+                )
+            )
+            .where(
+                DATASET_SPATIAL.c.dataset_type_ref
+                == self.get_dataset_type(product_name).id
+            )
+        ).scalar()
 
     def _mark_product_refresh_completed(
         self, product: ProductSummary, refresh_timestamp: datetime

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -91,6 +91,8 @@ class GenerateResult(Enum):
     NO_CHANGES = 1
     # Exception was thrown
     ERROR = 4
+    # A unsupported product (eg. Unsupported CRS)
+    UNSUPPORTED = 5
 
 
 @dataclass

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -30,7 +30,7 @@ from geoalchemy2.shape import to_shape
 from sqlalchemy import DDL, String, and_, func, select, exists, or_
 from sqlalchemy.dialects import postgresql as postgres
 from sqlalchemy.dialects.postgresql import TSTZRANGE
-from sqlalchemy.engine import Engine, RowProxy
+from sqlalchemy.engine import Engine
 from sqlalchemy.sql import Select
 
 try:
@@ -598,7 +598,7 @@ class SummaryStore:
             product=product.name,
             sample_percentage=round(sample_percentage, 2),
         )
-        result: List[RowProxy] = self._engine.execute(
+        result = self._engine.execute(
             select(
                 [
                     (
@@ -611,7 +611,7 @@ class SummaryStore:
             )
             .select_from(dataset_table)
             .where(dataset_table.c.dataset_type_ref == product.id)
-            .where(dataset_table.c.archived == None)
+            .where(dataset_table.c.archived.is_(None))
         ).fetchall()
         assert len(result) == 1
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -88,7 +88,7 @@ class GenerateResult(Enum):
     # Updated the existing summaries (for months that changed)
     UPDATED = 3
     # No new changes found.
-    SKIPPED = 1
+    NO_CHANGES = 1
     # Exception was thrown
     ERROR = 4
 
@@ -299,7 +299,7 @@ class SummaryStore:
             )
         )
 
-    def find_years_needing_update(self, product_name: str):
+    def find_years_needing_update(self, product_name: str) -> List[int]:
         """
         Find any years that need to be generated.
 
@@ -1239,25 +1239,28 @@ class SummaryStore:
             #    We are searching for any datasets with a a change-timestamp after our last changes were applied.
             #    But some earlier-timestamped datasets may not have been present last run if they were added
             #    in a concurrent, open transaction. And we don't want to miss them! So we give a buffer assuming
-            #    no transaction was open longer than this buffer. (I doesn't matter at all if we repeat datasets).
-            #    Yes, this is not an ideal world of technical purity.
+            #    no transaction was open longer than this buffer. (It doesn't matter at all if we repeat datasets).
             #
-            #    ODC's indexing does happen with quick, autocommitting transactions. So they're unlikely to actually
-            #    be open for more than a few milliseconds. And there are other issues with using timestamps so
-            #    this is, short-term, not likely our biggest priority.
+            #    This is not solution of perfection. But ODC's indexing does happen with quick, auto-committing
+            #    transactions, so they're unlikely to actually be open for more than a few milliseconds. Fifteen
+            #    minutes feels generous.
+            #
+            #    (You can judge if this assumption has failed by comparing our dataset_spatial
+            #     count(*) to ODC's dataset count(*) for the same product. They should match
+            #     for active datasets.)
             #
             #    tldr: "15 minutes == max expected transaction age of indexer"
             else old_product.last_successful_summary_time - timedelta(minutes=15)
         )
 
-        change_count, new_product = self.refresh_product_extent(
+        extent_changes, new_product = self.refresh_product_extent(
             product_name,
             scan_for_deleted=recreate_dataset_extents,
             only_those_newer_than=(
                 None if recreate_dataset_extents else only_datasets_newer_than
             ),
         )
-        log.info("extent.refresh.done", changed=change_count)
+        log.info("extent.refresh.done", changed=extent_changes)
 
         refresh_timestamp = new_product.last_refresh_time
         assert refresh_timestamp is not None
@@ -1286,17 +1289,11 @@ class SummaryStore:
 
         # Otherwise, only regenerate the things that changed.
         else:
-            if change_count == 0:
-                log.info("product.no_changes")
-                self._mark_product_refresh_completed(new_product, refresh_timestamp)
-                return GenerateResult.SKIPPED, self.get(product_name)
-
             log.info("product.incremental_update")
             months_to_update = self.find_months_needing_update(
                 product_name, only_datasets_newer_than
             )
             refresh_type = GenerateResult.UPDATED
-
         # Months
         for change_month, new_count in months_to_update:
             log.debug(
@@ -1315,7 +1312,8 @@ class SummaryStore:
         # Find year records who are older than their month records
         #   (This will find any months calculated above, as well
         #    as from previous interrupted runs.)
-        for year in self.find_years_needing_update(product_name):
+        years_to_update = self.find_years_needing_update(product_name)
+        for year in years_to_update:
             self._recalculate_period(
                 new_product,
                 year,
@@ -1334,6 +1332,9 @@ class SummaryStore:
             new_refresh_time=refresh_timestamp,
         )
         self._mark_product_refresh_completed(new_product, refresh_timestamp)
+        if (not extent_changes) and (not months_to_update) and (not years_to_update):
+            refresh_type = GenerateResult.NO_CHANGES
+
         return refresh_type, updated_summary
 
     def _mark_product_refresh_completed(

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1194,9 +1194,7 @@ class SummaryStore:
                 )
             )
         else:
-            # Empty product
-            summary = TimePeriodOverview.add_periods([])
-            summary.product_name = product.name
+            summary = TimePeriodOverview.empty(product.name)
 
         summary.product_refresh_time = product_refresh_time
         summary.period_tuple = (product.name, year, month, None)
@@ -1353,7 +1351,15 @@ class SummaryStore:
             new_refresh_time=refresh_timestamp,
         )
         self._mark_product_refresh_completed(new_product, refresh_timestamp)
-        if (not extent_changes) and (not months_to_update) and (not years_to_update):
+
+        # If nothing changed?
+        if (
+            (not extent_changes)
+            and (not months_to_update)
+            and (not years_to_update)
+            # ... and it already existed:
+            and old_product
+        ):
             refresh_type = GenerateResult.NO_CHANGES
 
         return refresh_type, updated_summary

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1233,10 +1233,27 @@ class SummaryStore:
             raise ValueError("Cannot both force and reset the incremental position.")
 
         # Which datasets to scan for updates?
-        only_datasets_newer_than = (
-            # None means "No limit". Recompute all.
-            None
-            if (force or (old_product is None))
+        if (
+            # If they've never summarised this product before
+            (old_product is None)
+            # ... Or it's an old Explorer from before incremental-updates were added.
+            or (old_product.last_successful_summary_time is None)
+            # Or we're using brute force
+            or force
+        ):
+            # "No limit". Recompute all.
+            only_datasets_newer_than = None
+
+        # Otherwise, do they want to reset the incremental position?
+        # -> Find the most recently indexed dataset that has touched our own spatial table,
+        #    and only scan changes from that time onward.
+        #    (this will be more expensive than normal incremental [below], as it may scan a
+        #     lot more datasets, not just the ones from the last generate run.)
+        elif reset_incremental_position:
+            only_datasets_newer_than = self._newest_known_dataset_addition_time(
+                product_name
+            )
+        else:
             # Otherwise only refresh datasets newer than the last successful run.
             #
             # Why do we have an extra 15 minute fudge?
@@ -1254,23 +1271,9 @@ class SummaryStore:
             #     for active datasets.)
             #
             #    tldr: "15 minutes == max expected transaction age of indexer"
-            else old_product.last_successful_summary_time - timedelta(minutes=15)
-        )
-
-        # Maybe they want to reset the incremental position?
-        # -> Find the most recently indexed dataset that exists in our own spatial table,
-        #    and use that time as the position to scan changes from.
-        if reset_incremental_position:
-            log.info("resetting_incremental_position")
-            only_datasets_newer_than = self._newest_known_dataset_addition_time(
-                product_name
+            only_datasets_newer_than = (
+                old_product.last_successful_summary_time - timedelta(minutes=15)
             )
-            if (
-                only_datasets_newer_than is None
-                and old_product
-                and old_product.dataset_count > 0
-            ):
-                raise RuntimeError("BUG? Non-empty product had no dataset change?")
 
         extent_changes, new_product = self.refresh_product_extent(
             product_name,

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from datetime import timedelta
 from pathlib import Path
 from pprint import pformat
 from textwrap import indent
@@ -118,6 +119,10 @@ def summary_store(module_dea_index: Index) -> SummaryStore:
     store = SummaryStore.create(module_dea_index)
     store.drop_all()
     module_dea_index.close()
+
+    # In tests, we don't want it to add a few minutes overlap buffer,
+    # as tests will add datasets and refresh immediately.
+    summary_store.dataset_overlap_carefulness = timedelta(seconds=0)
 
     with disable_logging():
         store.init()

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-from datetime import timedelta
 from pathlib import Path
 from pprint import pformat
 from textwrap import indent
@@ -119,10 +118,6 @@ def summary_store(module_dea_index: Index) -> SummaryStore:
     store = SummaryStore.create(module_dea_index)
     store.drop_all()
     module_dea_index.close()
-
-    # In tests, we don't want it to add a few minutes overlap buffer,
-    # as tests will add datasets and refresh immediately.
-    summary_store.dataset_overlap_carefulness = timedelta(seconds=0)
 
     with disable_logging():
         store.init()

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -153,7 +153,7 @@ def test_undo_eo3_doc_compatibility(eo3_index: Index):
 
     # And does our original, pre-indexed document match exactly?
     with TEST_EO3_DATASET_ARD.open("r") as f:
-        raw_doc = yaml.load(f)
+        raw_doc = yaml.safe_load(f)
 
     assert (
         indexed_doc == raw_doc

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -757,7 +757,7 @@ def test_raw_documents(client: FlaskClient):
         )
 
         try:
-            yaml.load(StringIO(doc))
+            yaml.safe_load(StringIO(doc))
         except YAMLError as e:
             raise AssertionError(f"Expected valid YAML document for url {url!r}") from e
 

--- a/integration_tests/test_stores.py
+++ b/integration_tests/test_stores.py
@@ -91,13 +91,13 @@ def test_add_no_periods(summary_store: SummaryStore):
     """
     All the get/update methods should work on products with no datasets.
     """
-    summary_store._persist_product_extent(
-        ProductSummary("ga_ls8c_level1_3", 0, None, None, [], [], {}, datetime.now())
-    )
+    result, summary = summary_store.refresh("ga_ls8c_level1_3")
+    assert result == GenerateResult.CREATED
+    assert summary.dataset_count == 0
     assert summary_store.get("ga_ls8c_level1_3", 2015, 7, 4).dataset_count == 0
 
     result, summary = summary_store.refresh("ga_ls8c_level1_3")
-    assert result == GenerateResult.CREATED
+    assert result == GenerateResult.NO_CHANGES
     assert summary.dataset_count == 0
 
     assert summary_store.get("ga_ls8c_level1_3").dataset_count == 0

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -3,7 +3,7 @@ Load a lot of real-world DEA datasets (very slow)
 
 And then check their statistics match expected.
 """
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from uuid import UUID
 
@@ -473,9 +473,13 @@ def test_calc_albers_summary_with_storage(summary_store: SummaryStore):
     summary = summary_store.get("ls8_nbar_albers", year=2017, month=None, day=None)
     assert summary is None
 
-    # Calculate overall summary
+    # We don't want it to add a few minutes overlap buffer,
+    # as we add datasets and refresh immediately.
+    summary_store.dataset_overlap_carefulness = timedelta(seconds=0)
 
+    # Calculate overall summary
     _, summary = summary_store.refresh("ls8_nbar_albers")
+
     _expect_values(
         summary,
         dataset_count=918,


### PR DESCRIPTION
Most importantly, **tldr**: this fixes an issue where if `generate` is killed half way through processing, you _may_ miss some new datasets in the statistics.

### Removal of fast-product-skipping
The `generate` command would skip month-and-year recalculations when no datasets seemed to have changed.

... but our way of calculating dataset changes can be inaccurate if `generate` was killed during its previous execution. Which would make us skip the product incorrectly.

Instead, we should still check that all months and years are accurate each time we run.  This slightly slows down incremental updates, but they're still very quick (seconds) locally in my testing. Which is better than being corruptible via system crashes.

### Add `--reset-incremental-position` to the generate command

This option will make the incremental-updater more conservative in where it starts scanning from: it moves the marker back to the last position with a newly-added dataset in Explorer's own tables. 

This is useful in development when cloning an external DB, as we want to reset the incremental marker to fit the new DB. 

(The catch: it makes the update take longer as more data than strictly necessary will be recomputed.)


### Cleaner logging, user messages.

.... and say "No changes", rather than "Skipped", since that's more accurate.
