### PR TITLE
Add a minimum change scan window for summary generation

### DIFF
--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -481,14 +481,18 @@ _TIME_PERIOD_FORMAT = re.compile(
 
 def parse_timedelta(value: str) -> Optional[timedelta]:
     """
-    >>> parse_timedelta('4d')
-    datetime.timedelta(days=4)
-    >>> parse_timedelta('40h')
-    datetime.timedelta(days=1, seconds=57600)
-    >>> parse_timedelta('30m')
-    datetime.timedelta(seconds=1800)
-    >>> parse_timedelta('3h30m')
-    datetime.timedelta(seconds=12600)
+    Parse a string such as "30h40m" into a timedelta.
+
+    >>> # we have to use `total_seconds()`, because python 3.6
+    >>> #  has different repr() output to newer pythons (3.9, at least)
+    >>> parse_timedelta('4d').total_seconds()
+    345600.0
+    >>> parse_timedelta('40h').total_seconds()
+    144000.0
+    >>> parse_timedelta('30m').total_seconds()
+    1800.0
+    >>> parse_timedelta('3h30m').total_seconds()
+    12600.0
     >>> parse_timedelta('30')
     Traceback (most recent call last):
     ...

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -376,8 +376,7 @@ class SummaryStore:
                             updated_months.c.product_ref == product.id_,
                         )
                         .where(
-                            updated_months.c.product_refresh_time
-                            > years.c.product_refresh_time
+                            updated_months.c.generation_time > years.c.generation_time
                         )
                     )
                 )
@@ -414,6 +413,7 @@ class SummaryStore:
         dataset_sample_size: int = 1000,
         scan_for_deleted: bool = False,
         only_those_newer_than: datetime = None,
+        force: bool = False,
     ) -> Tuple[int, ProductSummary]:
         """
         Update Explorer's computed extents for the given product, and record any new
@@ -438,7 +438,7 @@ class SummaryStore:
 
         existing_summary = self.get_product_summary(product_name)
         # Did nothing change at all? Just bump the refresh time.
-        if change_count == 0 and existing_summary:
+        if change_count == 0 and existing_summary and not force:
             new_summary = copy(existing_summary)
             new_summary.last_refresh_time = covers_up_to
             self._persist_product_extent(new_summary)


### PR DESCRIPTION
DEA's NCI instance of Explorer has a sync process that introduces a delay before datasets are visible. This can cause issues with Explorer because the change timestamps are not trustworthy ("it says that it was added a day ago, so I assume I've already seen it").

This PR adds an option to give Explorer a minimum window of time to always rescan.

Example usage:

```
    cubedash-gen --minimum-scan-window 24h  --all
```

(which will make it scan all changes from the past 24hrs, even if it thinks it has seen that time period already)


---

Secondly: the force flag should always regenerate product extent information too. It was the one part not included by force.