### PR TITLE
removes the codecov token from explorer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CodeCovToken }}
           file: ./coverage.xml
           fail_ci_if_error: false
 


### PR DESCRIPTION
### Reason for this pull request

A CodeCov token not required for public repositories uploading from Travis, CircleCI, AppVeyor, Azure Pipelines or GitHub Actions

The existing CodeCov token will be regenerated


### Proposed changes
Remove the CodeCov secret and remove from the codecov-action
 - [x] Fixes a security compromise

