### PR TITLE
Update extension loading for jinja3

### DIFF
--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -36,8 +36,8 @@ app.wsgi_app = ProxyFix(app.wsgi_app)
 app.config.from_pyfile(BASE_DIR / "settings.env.py", silent=True)
 app.config.from_envvar("CUBEDASH_SETTINGS", silent=True)
 
-# Enable do template extension
-app.jinja_options["extensions"].append("jinja2.ext.do")
+# Enable 'do' template extension
+app.jinja_env.add_extension("jinja2.ext.do")
 
 app.config.setdefault("CACHE_TYPE", "null")
 cache = Cache(app=app, config=app.config)


### PR DESCRIPTION
Reported by @alexgleith after the new Jinja 3 release
```
explorer_1 |  File "/code/cubedash/_model.py", line 40, in <module>
explorer_1 |   app.jinja_options["extensions"].append("jinja2.ext.do")
explorer_1 | KeyError: 'extensions'
```

(... a draft, as I don't know if other things will fail yet)