### PR TITLE
Fix up as_external_url to do correct S3 HTTPS URI

### DIFF
--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -133,7 +133,7 @@ def as_external_url(url: str, s3_region: str = None) -> Optional[str]:
     parsed = urlparse(url)
 
     if s3_region and parsed.scheme == "s3":
-        return f"https://{parsed.netloc}.s3-{s3_region}.amazonaws.com{parsed.path}"
+        return f"https://{parsed.netloc}.s3.{s3_region}.amazonaws.com{parsed.path}"
 
     return url
 

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -122,7 +122,7 @@ def as_external_url(url: str, s3_region: str = None) -> Optional[str]:
 
     >>> # Converts s3 to http
     >>> as_external_url('s3://some-data/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml', "ap-southeast-2")
-    'https://some-data.s3-ap-southeast-2.amazonaws.com/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml'
+    'https://some-data.s3.ap-southeast-2.amazonaws.com/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml'
     >>> # Other URLs are left as-is
     >>> unconvertable_url = 'file:///g/data/xu18/ga_ls8c_ard_3-1-0_095073_2019-03-22_final.odc-metadata.yaml'
     >>> unconvertable_url == as_external_url(unconvertable_url)


### PR DESCRIPTION
My favourite PR, I think. Change `-` to `.` :-) 

Justification is this doesn't work: https://deafrica-services.s3-af-south-1.amazonaws.com/ga_ls8c_wofs_2_summary/WOFS_6933_25_5_summary_count_clear.tif

This does: https://deafrica-services.s3.af-south-1.amazonaws.com/ga_ls8c_wofs_2_summary/WOFS_6933_25_5_summary_count_clear.tif