### PR TITLE
Add GeoJSON and All-Products download options

### DIFF
--- a/cubedash/_product.py
+++ b/cubedash/_product.py
@@ -194,6 +194,38 @@ def raw_metadata_type_doc(name):
     return utils.as_yaml(ordered_metadata)
 
 
+@bp.route("/products.odc-product.yaml")
+def raw_all_products_doc():
+    return utils.as_yaml(
+        *(
+            utils.prepare_document_formatting(
+                product.definition,
+                f"Product {product.name}",
+                include_source_url=url_for(
+                    ".raw_product_doc", name=product.name, _external=True
+                ),
+            )
+            for product in _model.STORE.all_dataset_types()
+        )
+    )
+
+
+@bp.route("/metadata-types.odc-type.yaml")
+def raw_all_metadata_types_doc():
+    return utils.as_yaml(
+        *(
+            utils.prepare_document_formatting(
+                type_.definition,
+                f"Metadata Type {type_.name}",
+                include_source_url=url_for(
+                    ".raw_metadata_type_doc", name=type_.name, _external=True
+                ),
+            )
+            for type_ in _model.STORE.all_metadata_types()
+        )
+    )
+
+
 def _iso8601_duration(tdelta: timedelta):
     """
     Format a timedelta as an iso8601 duration

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -400,8 +400,24 @@ def as_json(o, content_type="application/json") -> flask.Response:
     )
 
 
-def as_geojson(o):
-    return as_json(o, content_type="application/geo+json")
+def as_geojson(o, downloadable_filename_prefix: str = None):
+    """
+    Serialise the given object into a GeoJSON flask response.
+
+    Optionally provide a filename, to tell web-browsers to download
+    it on click with that filename.
+    """
+    response = as_json(o, content_type="application/geo+json")
+    if downloadable_filename_prefix:
+        explorer_id = _only_alphanumeric(
+            flask.current_app.config.get("STAC_ENDPOINT_ID", "")
+        )
+        if explorer_id:
+            downloadable_filename_prefix += f"-{explorer_id}"
+        response.headers[
+            "Content-Disposition"
+        ] = f"attachment; filename={downloadable_filename_prefix}.geojson"
+    return response
 
 
 def as_yaml(*o, content_type="text/yaml"):

--- a/cubedash/templates/about.html
+++ b/cubedash/templates/about.html
@@ -41,27 +41,49 @@
     </div>
 
     <div class="panel">
+        <h3>Extents and summaries</h3>
+    </div>
+
+    <div class="panel">
         <h3>Datacube Resources</h3>
 
         Datacube-ready config and metadata can be downloaded from Explorer programatically:
 
+        <h4>Individual</h4>
         <ul>
             <li>
-                Datasets:
+                A dataset:
                 <span class="uri-path">
                      {{ explorer_root_url}}dataset/<span class="path-variable">Dataset UUID</span>.odc-metadata.yaml
                 </span>
             </li>
             <li>
-                Products:
+                A Product:
                 <span class="uri-path">
                     {{ explorer_root_url}}products/<span class="path-variable">Product Name</span>.odc-product.yaml
                 </span>
             </li>
             <li>
-                Metadata types:
+                A Metadata Type:
                 <span class="uri-path">
                     {{ explorer_root_url}}metadata-types/<span class="path-variable">Metadata Type Name</span>.odc-type.yaml
+                </span>
+            </li>
+        </ul>
+
+
+        <h4>All</h4>
+        <ul>
+            <li>
+                All Product definitions:
+                <span class="uri-path">
+                    <a href="{{ url_for('product.raw_all_products_doc', _external=True) }}">{{ url_for('product.raw_all_products_doc', _external=True) }}</a>
+                </span>
+            </li>
+            <li>
+                All Metadata Type definitions:
+                <span class="uri-path">
+                    <a href="{{ url_for('product.raw_all_metadata_types_doc', _external=True) }}">{{ url_for('product.raw_all_metadata_types_doc', _external=True) }}</a>
                 </span>
             </li>
         </ul>
@@ -86,7 +108,7 @@
                 </span>
             </li>
             <li>
-                Simple, bash-ready contents:
+                Simple, bash-ready list of names:
                 <span class="uri-path">
                     {{ url_for('product.product_list_text', _external=True) }}<br/>
                     {{ url_for('product.metadata_type_list_text', _external=True) }}

--- a/cubedash/templates/overview.html
+++ b/cubedash/templates/overview.html
@@ -55,6 +55,7 @@
                                    {% if not show_individual_datasets %}disabled="disabled"{% endif %}
                                    title="Show individual datasets">Datasets</label>
                         </div>
+
                     {% endif %}
 
                     <h1><strong>{{ product.name }}</strong>{{ product_args_label }}</h1>
@@ -141,9 +142,10 @@
                     {% endif %}
 
                     <h4>
-                        <a href="{{ url_for('product.metadata_type_page', name=product.metadata_type.name) }}">
-                            {{ product.metadata_type.name }}</a>
-                        metadata:
+                        Common Metadata
+                        (<a href="{{ url_for('product.metadata_type_page', name=product.metadata_type.name) }}">
+                            {{- product.metadata_type.name -}}
+                        </a>)
                     </h4>
 
                     {% if (product.fields | all_values_none) and (product_summary.fixed_metadata == {}) %}
@@ -158,6 +160,34 @@
                                 Unknown (needs refresh)
                             </em>
                         {% endif %}
+                    {% endif %}
+
+                    {% if have_displayable_data %}
+                    <h4>GeoJSON</h4>
+                    <ul>
+                        {% if product_region_info %}
+                        <li>
+                            <a href="{{ url_for('api.regions_geojson', **product_args) }}">
+                                <i class="fa fa-file-text-o" aria-hidden="true"></i>
+                                <span style="text-transform: capitalize">{{ product_region_info.units_label }}</span>
+                            </a>
+                        </li>
+                        {% endif %}
+                        <li>
+                            <a href="{{ url_for('api.footprint_geojson', **product_args) }}" >
+                                <i class="fa fa-file-text-o" aria-hidden="true"></i>
+                                Footprint
+                            </a>
+                        </li>
+                        {% if show_individual_datasets %}
+                        <li>
+                            <a href="{{ url_for('api.datasets_geojson', limit=dataset_limit, **product_args)}}" >
+                                <i class="fa fa-file-text-o" aria-hidden="true"></i>
+                                Datasets
+                            </a>
+                        </li>
+                        {% endif %}
+                    </ul>
                     {% endif %}
 
                     {% if product_summary.derived_products %}

--- a/cubedash/warmup.py
+++ b/cubedash/warmup.py
@@ -22,7 +22,9 @@ def find_examples_of_all_public_urls(index: Index):
     yield "/arrivals.csv"
 
     yield "/products.txt"
+    yield "/products.odc-product.yaml"
     yield "/metadata-types.txt"
+    yield "/metadata-types.odc-type.yaml"
 
     yield "/audit/storage"
     yield "/audit/storage.csv"


### PR DESCRIPTION
## Yaml downloads

Add paths to download all products/metadata-types as a single yaml file:

- All Product definitions: `http://explorer.example/products.odc-product.yaml`
- All Metadata Type definitions: `http://explorer.example/metadata-types.odc-type.yaml`

So people can, for example, clone remote datacube config in two commands:
```
datacube type add http://explorer.test/metadata-types.odc-type.yaml
datacube product add http://explorer.test/products.odc-product.yaml
```

## GeoJSON downloads

Add links in the sidebar to download the displayed product extents as GeoJSON files:

![Screenshot from 2021-07-09 11-31-35](https://user-images.githubusercontent.com/25688/125010154-51b76380-e0a9-11eb-8ed0-a90544a4ddf9.png)
(People have asked for these on Slack, as well as for DEA's product coverage as a shape)

