### PR TITLE
Extra yaml download links, names

### DIFF
--- a/cubedash/_product.py
+++ b/cubedash/_product.py
@@ -196,7 +196,7 @@ def raw_metadata_type_doc(name):
 
 @bp.route("/products.odc-product.yaml")
 def raw_all_products_doc():
-    return utils.as_yaml(
+    resp = utils.as_yaml(
         *(
             utils.prepare_document_formatting(
                 product.definition,
@@ -208,11 +208,19 @@ def raw_all_products_doc():
             for product in _model.STORE.all_dataset_types()
         )
     )
+    # Add Explorer ID to the download filename if they have one.
+    utils.suggest_download_filename(
+        resp,
+        prefix="products",
+        suffix=".odc-product.yaml",
+    )
+
+    return resp
 
 
 @bp.route("/metadata-types.odc-type.yaml")
 def raw_all_metadata_types_doc():
-    return utils.as_yaml(
+    resp = utils.as_yaml(
         *(
             utils.prepare_document_formatting(
                 type_.definition,
@@ -222,8 +230,15 @@ def raw_all_metadata_types_doc():
                 ),
             )
             for type_ in _model.STORE.all_metadata_types()
-        )
+        ),
     )
+    # Add Explorer ID to the download filename if they have one.
+    utils.suggest_download_filename(
+        resp,
+        prefix="metadata-types",
+        suffix=".odc-type.yaml",
+    )
+    return resp
 
 
 def _iso8601_duration(tdelta: timedelta):

--- a/cubedash/templates/metadata-types.html
+++ b/cubedash/templates/metadata-types.html
@@ -4,7 +4,7 @@
 
 {% block head %}
     {{ super() }}
-    <style type="text/css">
+    <style>
         .panel.odd > h3 {
             margin-bottom: 10px;
         }
@@ -19,6 +19,10 @@
             <a href="{{ url_for('product.metadata_type_list_text') }}"
                class="badge header-badge">
                 Text <i class="fa fa-file-text-o" aria-hidden="true"></i>
+            </a>
+            <a href="{{ url_for('product.raw_all_metadata_types_doc') }}"
+               class="badge header-badge">
+                Yaml <i class="fa fa-file-text" aria-hidden="true"></i>
             </a>
         </div>
         <table class="data-table">

--- a/cubedash/templates/products.html
+++ b/cubedash/templates/products.html
@@ -18,11 +18,15 @@
                class="badge header-badge">
                 Text <i class="fa fa-file-text-o" aria-hidden="true"></i>
             </a>
-        </div>
-        <a href="{{ url_for('stac.collections') }}"
+            <a href="{{ url_for('stac.collections') }}"
                class="badge header-badge">
-            As Stac <i class="fa fa-file-text-o" aria-hidden="true"></i>
-        </a>
+                Stac <i class="fa fa-file-text-o" aria-hidden="true"></i>
+            </a>
+            <a href="{{ url_for('product.raw_all_metadata_types_doc') }}"
+               class="badge header-badge">
+                Yaml <i class="fa fa-file-text" aria-hidden="true"></i>
+            </a>
+        </div>
 
     <table class="data-table">
         {% for group_name, product_summaries in grouped_products %}


### PR DESCRIPTION
Tiny amendments to #298 


- Add the Explorer endpoint name to the download filename hint. 
    - `products-deafrica.odc-product.yaml`, rather than `products.odc-product.yaml`. 
    - (Helpful when you have multiple in your downloads folder.)
- Include Yaml download icons on the products/metadata-types pages:

![Screenshot from 2021-07-09 14-54-24](https://user-images.githubusercontent.com/25688/125025242-ab2d8b80-e0c5-11eb-8270-bb46391cb475.png)

![Screenshot from 2021-07-09 14-54-44](https://user-images.githubusercontent.com/25688/125025250-aec11280-e0c5-11eb-84a9-5f56686259c7.png)
