### PR TITLE
Expand api docs, fix products link

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,9 @@ You can alter default [Flask](http://flask.pocoo.org/docs/1.0/config/) or
     CUBEDASH_DEFAULT_GROUP_NAME = 'Other Products'
     # Maximum search results
     CUBEDASH_HARD_SEARCH_LIMIT = 100
-    CUBEDASH_DEFAULT_API_DATASETS = 500
-    CUBEDASH_MAX_API_DATASETS = 4000
+    # Dataset records returned by '/api'
+    CUBEDASH_DEFAULT_API_LIMIT = 500
+    CUBEDASH_HARD_API_LIMIT = 4000
     # Maximum number of source/derived datasets to show
     CUBEDASH_PROVENANCE_DISPLAY_LIMIT = 20
     

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ You can alter default [Flask](http://flask.pocoo.org/docs/1.0/config/) or
     CUBEDASH_DEFAULT_GROUP_NAME = 'Other Products'
     # Maximum search results
     CUBEDASH_HARD_SEARCH_LIMIT = 100
+    CUBEDASH_DEFAULT_API_DATASETS = 500
+    CUBEDASH_MAX_API_DATASETS = 4000
     # Maximum number of source/derived datasets to show
     CUBEDASH_PROVENANCE_DISPLAY_LIMIT = 20
     

--- a/cubedash/_api.py
+++ b/cubedash/_api.py
@@ -42,10 +42,10 @@ def datasets_geojson(
 ):
     limit = request.args.get(
         "limit",
-        default=flask.current_app.config["CUBEDASH_DEFAULT_API_DATASETS"],
+        default=flask.current_app.config["CUBEDASH_DEFAULT_API_LIMIT"],
         type=int,
     )
-    hard_limit = flask.current_app.config["CUBEDASH_MAX_API_DATASETS"]
+    hard_limit = flask.current_app.config["CUBEDASH_HARD_API_LIMIT"]
     if limit > hard_limit:
         limit = hard_limit
 

--- a/cubedash/_api.py
+++ b/cubedash/_api.py
@@ -9,7 +9,6 @@ from . import _model
 from ._utils import as_geojson
 from .summary import ItemSort
 
-_MAX_DATASET_RETURN = 2000
 
 _LOG = logging.getLogger(__name__)
 bp = Blueprint("api", __name__, url_prefix="/api")
@@ -41,9 +40,14 @@ def _api_path_as_filename_prefix():
 def datasets_geojson(
     product_name: str, year: int = None, month: int = None, day: int = None
 ):
-    limit = request.args.get("limit", default=500, type=int)
-    if limit > _MAX_DATASET_RETURN:
-        limit = _MAX_DATASET_RETURN
+    limit = request.args.get(
+        "limit",
+        default=flask.current_app.config["CUBEDASH_DEFAULT_API_DATASETS"],
+        type=int,
+    )
+    hard_limit = flask.current_app.config["CUBEDASH_MAX_API_DATASETS"]
+    if limit > hard_limit:
+        limit = hard_limit
 
     time = _utils.as_time_range(year, month, day, tzinfo=_model.STORE.grouping_timezone)
 

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -40,6 +40,15 @@ app.config.from_envvar("CUBEDASH_SETTINGS", silent=True)
 app.jinja_env.add_extension("jinja2.ext.do")
 
 app.config.setdefault("CACHE_TYPE", "null")
+
+# Global defaults
+app.config.from_mapping(
+    dict(
+        CUBEDASH_DEFAULT_API_DATASETS=500,
+        CUBEDASH_MAX_API_DATASETS=4000,
+    )
+)
+
 cache = Cache(app=app, config=app.config)
 
 cors = (

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -44,8 +44,8 @@ app.config.setdefault("CACHE_TYPE", "null")
 # Global defaults
 app.config.from_mapping(
     dict(
-        CUBEDASH_DEFAULT_API_DATASETS=500,
-        CUBEDASH_MAX_API_DATASETS=4000,
+        CUBEDASH_DEFAULT_API_LIMIT=500,
+        CUBEDASH_HARD_API_LIMIT=4000,
     )
 )
 

--- a/cubedash/templates/about.html
+++ b/cubedash/templates/about.html
@@ -81,7 +81,7 @@
     </div>
 
     <div class="panel odd">
-        <h3>Extents</h3>
+        <h3>Extents and Summaries</h3>
         Extent data displayed by Explorer can be downloaded as GeoJSON
         <ul>
             <li>

--- a/cubedash/templates/about.html
+++ b/cubedash/templates/about.html
@@ -105,8 +105,8 @@
             <li>
                 Dataset footprints
                 <span class="muted">
-                    (<tt>?limit={{ config['CUBEDASH_DEFAULT_API_DATASETS'] }}</tt> by default,
-                    can be increased up to {{ config["CUBEDASH_MAX_API_DATASETS"] }} on this host)
+                    (<tt>?limit={{ config['CUBEDASH_DEFAULT_API_LIMIT'] }}</tt> by default,
+                    can be increased up to {{ config["CUBEDASH_HARD_API_LIMIT"] }} on this host)
                 </span>
                 <span class="uri-path">
                     {{ explorer_root_url}}api/datasets/<span class="path-variable">Product Name</span><br/>

--- a/cubedash/templates/about.html
+++ b/cubedash/templates/about.html
@@ -40,9 +40,7 @@
         </p>
     </div>
 
-    <div class="panel">
-        <h3>Extents and summaries</h3>
-    </div>
+
 
     <div class="panel">
         <h3>Datacube Resources</h3>
@@ -84,6 +82,44 @@
                 All Metadata Type definitions:
                 <span class="uri-path">
                     <a href="{{ url_for('product.raw_all_metadata_types_doc', _external=True) }}">{{ url_for('product.raw_all_metadata_types_doc', _external=True) }}</a>
+                </span>
+            </li>
+        </ul>
+    </div>
+
+    <div class="panel">
+        <h3>Extents and summaries</h3>
+        Extent data displayed by Explorer can be downloaded as GeoJSON
+        <ul>
+            <li>
+                Total footprint
+                <span class="uri-path">
+                    {{ explorer_root_url}}api/footprint/<span class="path-variable">Product Name</span><br/>
+                    {{ explorer_root_url}}api/footprint/<span class="path-variable">Product Name</span>/<span class="path-variable">Year</span><br/>
+                    {{ explorer_root_url}}api/footprint/<span class="path-variable">Product Name</span>/<span class="path-variable">Year</span>/<span class="path-variable">Month</span><br/>
+                    {{ explorer_root_url}}api/footprint/<span class="path-variable">Product Name</span>/<span class="path-variable">Year</span>/<span class="path-variable">Month</span>/<span class="path-variable">Day</span><br/>
+                </span>
+            </li>
+            <li>
+                Region footprints
+                <span class="uri-path">
+                    {{ explorer_root_url}}api/regions/<span class="path-variable">Product Name</span><br/>
+                    {{ explorer_root_url}}api/regions/<span class="path-variable">Product Name</span>/<span class="path-variable">Year</span><br/>
+                    {{ explorer_root_url}}api/regions/<span class="path-variable">Product Name</span>/<span class="path-variable">Year</span>/<span class="path-variable">Month</span><br/>
+                    {{ explorer_root_url}}api/regions/<span class="path-variable">Product Name</span>/<span class="path-variable">Year</span>/<span class="path-variable">Month</span>/<span class="path-variable">Day</span><br/>
+                </span>
+            </li>
+            <li>
+                Dataset footprints
+                <span class="muted">
+                    (<tt>?limit={{ config['CUBEDASH_DEFAULT_API_DATASETS'] }}</tt> by default,
+                    can be increased up to {{ config["CUBEDASH_MAX_API_DATASETS"] }} on this host)
+                </span>
+                <span class="uri-path">
+                    {{ explorer_root_url}}api/datasets/<span class="path-variable">Product Name</span><br/>
+                    {{ explorer_root_url}}api/datasets/<span class="path-variable">Product Name</span>/<span class="path-variable">Year</span><br/>
+                    {{ explorer_root_url}}api/datasets/<span class="path-variable">Product Name</span>/<span class="path-variable">Year</span>/<span class="path-variable">Month</span><br/>
+                    {{ explorer_root_url}}api/datasets/<span class="path-variable">Product Name</span>/<span class="path-variable">Year</span>/<span class="path-variable">Month</span>/<span class="path-variable">Day</span><br/>
                 </span>
             </li>
         </ul>

--- a/cubedash/templates/about.html
+++ b/cubedash/templates/about.html
@@ -4,12 +4,11 @@
 {% block title %}About Explorer{% endblock %}
 {% block head %}
     {{ super() }}
-    <style type="text/css">
+    <style>
 
         .uri-path {
             margin-bottom: 15px;
             display: block;
-
         }
 
         .path-variable {
@@ -47,7 +46,6 @@
 
         Datacube-ready config and metadata can be downloaded from Explorer programatically:
 
-        <h4>Individual</h4>
         <ul>
             <li>
                 A dataset:
@@ -67,28 +65,23 @@
                     {{ explorer_root_url}}metadata-types/<span class="path-variable">Metadata Type Name</span>.odc-type.yaml
                 </span>
             </li>
-        </ul>
-
-
-        <h4>All</h4>
-        <ul>
             <li>
-                All Product definitions:
+                All Products:
                 <span class="uri-path">
-                    <a href="{{ url_for('product.raw_all_products_doc', _external=True) }}">{{ url_for('product.raw_all_products_doc', _external=True) }}</a>
+                    {{ url_for('product.raw_all_products_doc', _external=True) }}
                 </span>
             </li>
             <li>
-                All Metadata Type definitions:
+                All Metadata Types:
                 <span class="uri-path">
-                    <a href="{{ url_for('product.raw_all_metadata_types_doc', _external=True) }}">{{ url_for('product.raw_all_metadata_types_doc', _external=True) }}</a>
+                    {{ url_for('product.raw_all_metadata_types_doc', _external=True) }}
                 </span>
             </li>
         </ul>
     </div>
 
-    <div class="panel">
-        <h3>Extents and summaries</h3>
+    <div class="panel odd">
+        <h3>Extents</h3>
         Extent data displayed by Explorer can be downloaded as GeoJSON
         <ul>
             <li>
@@ -126,7 +119,7 @@
     </div>
 
     <div class="panel">
-         <h3>Audit and Summaries</h3>
+         <h3>Audit and Examine</h3>
 
         Much of Explorer's audit pages are available in CSV or text format.
 

--- a/cubedash/templates/products.html
+++ b/cubedash/templates/products.html
@@ -22,7 +22,7 @@
                class="badge header-badge">
                 Stac <i class="fa fa-file-text-o" aria-hidden="true"></i>
             </a>
-            <a href="{{ url_for('product.raw_all_metadata_types_doc') }}"
+            <a href="{{ url_for('product.raw_all_products_doc') }}"
                class="badge header-badge">
                 Yaml <i class="fa fa-file-text" aria-hidden="true"></i>
             </a>


### PR DESCRIPTION
Added section to the About page:

![Screenshot from 2021-07-13 16-40-11](https://user-images.githubusercontent.com/25688/125403682-201c0080-e3f9-11eb-8b39-d608ab959797.png)

... and fixed the yaml link on the products page, which was wrongly going to metadata-types.


### Todo

- [x] Pick better config names, they're inconsistent with the others
- [x] Fix the layout of the about page -- the sections are now inconsistent