### PR TITLE
Force refresh should scan for deleted extents too

### DIFF
--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1361,7 +1361,7 @@ class SummaryStore:
 
         extent_changes, new_product = self.refresh_product_extent(
             product_name,
-            scan_for_deleted=recreate_dataset_extents,
+            scan_for_deleted=recreate_dataset_extents or force,
             only_those_newer_than=(
                 None if recreate_dataset_extents else only_datasets_newer_than
             ),


### PR DESCRIPTION
`--force` is supposed to be the "just recreate everything" option, for when someone has messed with their postgres database manually.

A few people on Slack (including myself) found it confusing that you need to include a second option in addition to `--force`
to scan for deleted datasets. By default, it's only recreating the datasets that it can see, not those that are missing. I think `--force` should do both.