### PR TITLE
Move Docker image to the standard gdal base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,7 @@ RUN if [ "$ENVIRONMENT" = "deployment" ] ; then\
 
 RUN pip freeze
 
-# Is it working?
-RUN cubedash-run --version
+ENTRYPOINT ["/bin/tini", "--"]
 
 # This is for prod, and serves as docs. It's usually overwritten
 CMD gunicorn -b '0.0.0.0:8080' -w 1 '--worker-class=egg:meinheld#gunicorn_worker'  --timeout 60 --config python:cubedash.gunicorn_config cubedash:app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,77 @@
-ARG V_BASE=3.3.0
+FROM osgeo/gdal:ubuntu-small-3.3.2
 
-FROM opendatacube/geobase-builder:${V_BASE} as env_builder
+ENV DEBIAN_FRONTEND=noninteractive \
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8 \
+    PYTHONFAULTHANDLER=1
 
-COPY requirements-docker.txt constraints-docker.txt /
-RUN env-build-tool new /requirements-docker.txt /constraints-docker.txt /env
+# Apt installation
+RUN apt-get update && \
+    apt-get install -y \
+      build-essential \
+      git \
+      vim \
+      nano \
+      tini \
+      wget \
+      python3-pip \
+      # For Psycopg2
+      libpq-dev python-dev \
+    && apt-get autoclean && \
+    apt-get autoremove && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}
 
-# Copy the environment in
-FROM opendatacube/geobase-runner:${V_BASE}
-COPY --from=env_builder /env /env
-ENV LC_ALL=C.UTF-8
-ENV DEBIAN_FRONTEND=noninteractive
 
 # Environment can be whatever is supported by setup.py
 # so, either deployment, test
 ARG ENVIRONMENT=deployment
+# ARG ENVIRONMENT=test
 
-# Do the apt install process, including more recent Postgres/PostGIS
-RUN apt-get update && apt-get install -y \
-  make curl gnupg git build-essential \
-  && rm -rf /var/lib/apt/lists/*
+RUN echo "Environment is: $ENVIRONMENT"
 
-# Install postgres client 11
-RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-  sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
-  apt-get update && apt-get install -y \
-  postgresql-client-11 \
-  && rm -rf /var/lib/apt/lists/*
+RUN pip install pip-tools pre-commit pytest-cov
 
-ENV PATH="/env/bin:${PATH}"
+# Pip installation
+RUN mkdir -p /conf
+COPY requirements-docker.txt constraints-docker.txt /conf/
+RUN pip install -r /conf/requirements-docker.txt -c /conf/constraints-docker.txt
 
-# Set up a nice workdir, and only copy the things we care about in
-RUN mkdir -p /code
-WORKDIR /code
 
-ADD . /code
+# Dev setup: run pre-commit once, so its virtualenv is built and cached.
+#    We do this in a tmp repository, before copying our real code, as we
+#    want this cached by Docker and not rebuilt every time code changes
+COPY .pre-commit-config.yaml /conf/
+
+RUN if [ "$ENVIRONMENT" = "test" ] ; then \
+       mkdir -p ~/pre-commit \
+       && cp /conf/.pre-commit-config.yaml ~/pre-commit \
+       && cd ~/pre-commit \
+       && git init \
+       && pre-commit run \
+       && rm -rf ~/pre-commit ; \
+    fi
+
+
+# Set up a nice workdir and add the live code
+ENV APPDIR=/code
+RUN mkdir -p $APPDIR
+WORKDIR $APPDIR
+ADD . $APPDIR
 
 # These ENVIRONMENT flags make this a bit complex, but basically, if we are in dev
 # then we want to link the source (with the -e flag) and if we're in prod, we
 # want to delete the stuff in the /code folder to keep it simple.
-RUN if [ "$ENVIRONMENT" = "deployment" ] ; then FLAG='' ; else FLAG='-e'; fi \
-  && /env/bin/pip install ${FLAG} .[${ENVIRONMENT}] \
-  && rm -rf $HOME/.cache/pip
+RUN if [ "$ENVIRONMENT" = "deployment" ] ; then\
+        pip install .[$ENVIRONMENT] ; \
+        rm -rf /code/* ; \
+    else \
+        pip install --editable .[$ENVIRONMENT] ; \
+    fi
 
-# Delete code from the /code folder if we're in a prod build
-RUN if [ "$ENVIRONMENT" = "deployment" ]; then rm -rf /code/*; fi
+RUN pip freeze
+
+# Is it working?
+RUN cubedash-run --version
 
 # This is for prod, and serves as docs. It's usually overwritten
 CMD gunicorn -b '0.0.0.0:8080' -w 1 '--worker-class=egg:meinheld#gunicorn_worker'  --timeout 60 --config python:cubedash.gunicorn_config cubedash:app

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
       nano \
       tini \
       wget \
+      postgresql-client \
       python3-pip \
       # For Psycopg2
       libpq-dev python-dev \

--- a/constraints-docker.txt
+++ b/constraints-docker.txt
@@ -1,4 +1,1 @@
-datacube==1.8.3
-sqlalchemy==1.3.20
-click<8.0.0
-eodatasets3>=0.17.0
+datacube==1.8.6

--- a/integration_tests/asserts.py
+++ b/integration_tests/asserts.py
@@ -3,7 +3,7 @@ import operator
 import re
 from datetime import datetime
 from pathlib import Path
-from pprint import pprint
+from pprint import pformat, pprint
 from textwrap import indent
 from typing import Dict, Iterable, Optional, Set, Tuple
 
@@ -13,7 +13,6 @@ from datacube.model import Range
 from datacube.utils import InvalidDocException, validate_document
 from dateutil.tz import tzutc
 from deepdiff import DeepDiff
-from deepdiff.model import DiffLevel
 from flask import Response
 from flask.testing import FlaskClient
 from requests_html import HTML
@@ -323,30 +322,7 @@ def format_doc_diffs(left: Dict, right: Dict) -> Iterable[str]:
         out.append("Doc differs in minor float precision:")
         doc_diffs = DeepDiff(left, right)
 
-    def clean_offset(offset: str):
-        if offset.startswith("root"):
-            return offset[len("root") :]
-        return offset
-
-    if "values_changed" in doc_diffs:
-        for offset, change in doc_diffs["values_changed"].items():
-            out.extend(
-                (
-                    f"   {clean_offset(offset)}: ",
-                    f'          {change["old_value"]!r}',
-                    f'       != {change["new_value"]!r}',
-                )
-            )
-    if "dictionary_item_added" in doc_diffs:
-        out.append("Added fields:")
-        for offset in doc_diffs.tree["dictionary_item_added"].items:
-            offset: DiffLevel
-            out.append(f"    {clean_offset(offset.path())} = {repr(offset.t2)}")
-    if "dictionary_item_removed" in doc_diffs:
-        out.append("Removed fields:")
-        for offset in doc_diffs.tree["dictionary_item_removed"].items:
-            offset: DiffLevel
-            out.append(f"    {clean_offset(offset.path())} = {repr(offset.t1)}")
+    out.append(indent(pformat(doc_diffs), " " * 4))
 
     # If pytest verbose:
     out.extend(("Full output document: ", repr(left)))

--- a/integration_tests/test_arb_crs.py
+++ b/integration_tests/test_arb_crs.py
@@ -2,17 +2,26 @@
 Test utility method for creating valid EPSG code based CRS from
 possible WKT String
 """
+from pyproj import CRS
+
 from cubedash._utils import infer_crs
 
+# This CRS was embedded in DEA's gamma-ray product definition.
 TEST_CRS_RAW = """
 GEOGCS["GEOCENTRIC DATUM of AUSTRALIA",DATUM["GDA94",SPHEROID["GRS80",6378137,298.257222101]],
 PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]
 """
 
 
-def test_crs_infer_fail():
+def test_crs_infer_has_match_floor():
+    """Don't match something that's too different"""
     assert infer_crs("") is None
 
 
 def test_crs_infer_pass():
     assert infer_crs(TEST_CRS_RAW) == "epsg:4283"
+
+
+def test_crs_infers_itself():
+    """Sanity check: something should match itself!"""
+    assert infer_crs(CRS.from_epsg(4326).to_wkt()) == "epsg:4326"

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -696,10 +696,10 @@ def test_stac_collection_items(stac_client: FlaskClient):
             "spatial": {
                 "bbox": [
                     [
-                        pytest.approx(112.223_058_990_767_51),
-                        pytest.approx(-43.829_196_553_065_4),
-                        pytest.approx(153.985_054_424_922_77),
-                        pytest.approx(-10.237_104_814_250_783),
+                        pytest.approx(112.223_058_990_767_51, abs=0.0001),
+                        pytest.approx(-43.829_196_553_065_4, abs=0.0001),
+                        pytest.approx(153.985_054_424_922_77, abs=0.0001),
+                        pytest.approx(-10.237_104_814_250_783, abs=0.0001),
                     ]
                 ]
             },

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -696,10 +696,10 @@ def test_stac_collection_items(stac_client: FlaskClient):
             "spatial": {
                 "bbox": [
                     [
-                        112.223_058_990_767_51,
-                        -43.829_196_553_065_4,
-                        153.985_054_424_922_77,
-                        -10.237_104_814_250_783,
+                        pytest.approx(112.223_058_990_767_51),
+                        pytest.approx(-43.829_196_553_065_4),
+                        pytest.approx(153.985_054_424_922_77),
+                        pytest.approx(-10.237_104_814_250_783),
                     ]
                 ]
             },


### PR DESCRIPTION
It's less maintenance than the geo-base one, and brings us in-line with datacube-alchemist and eodatasets.

It also fixes the current security-scan failure.