### PR TITLE
Make grouping CRS configurable

### DIFF
--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -77,6 +77,7 @@ from cubedash.summary import (
     TimePeriodOverview,
     UnsupportedWKTProductCRS,
 )
+from cubedash.summary._stores import DEFAULT_EPSG
 
 # Machine (json) logging.
 _LOG = structlog.get_logger()
@@ -261,6 +262,14 @@ class TimeDeltaParam(click.ParamType):
     help="Refresh all products in the datacube, rather than the specified list.",
 )
 @click.option(
+    "--epsg",
+    "epsg_code",
+    type=int,
+    default=DEFAULT_EPSG,
+    show_default=True,
+    help="The equal-area epsg code to use internally for grouping spatial data",
+)
+@click.option(
     "--verbose",
     "-v",
     count=True,
@@ -416,6 +425,7 @@ def cli(
     init_database: bool,
     drop_database: bool,
     force_refresh: bool,
+    epsg_code: int,
     recreate_dataset_extents: bool,
     reset_incremental_position: bool,
     minimum_scan_window: Optional[timedelta],
@@ -435,7 +445,7 @@ def cli(
 
     if init_database:
         user_message("Initialising schema")
-        store.init()
+        store.init(grouping_epsg_code=epsg_code)
     elif not store.is_initialised():
         user_message(
             style("No cubedash schema exists. ", fg="red")

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -445,7 +445,7 @@ def cli(
         sys.exit(0)
 
     if init_database:
-        user_message("Initialising schema")
+        user_message(f"Initialising schema (EPSG:{epsg_code or DEFAULT_EPSG})")
         store.init(grouping_epsg_code=epsg_code)
     elif not store.is_initialised():
         user_message(

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -265,9 +265,10 @@ class TimeDeltaParam(click.ParamType):
     "--epsg",
     "epsg_code",
     type=int,
-    default=DEFAULT_EPSG,
-    show_default=True,
-    help="The equal-area epsg code to use internally for grouping spatial data",
+    # We default to None as we want to know later if they explicitly specified one or not.
+    default=None,
+    help=f"The equal-area epsg code to use internally for grouping spatial data. "
+    f"(default: {DEFAULT_EPSG})",
 )
 @click.option(
     "--verbose",

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -197,7 +197,7 @@ TIME_OVERVIEW = Table(
 )
 
 # An SQLAlchemy expression to read the configured SRID.
-FOOTPRINT_SRID_EXPRESSION = func.FindSRID(
+FOOTPRINT_SRID_EXPRESSION = func.Find_SRID(
     TIME_OVERVIEW.schema, TIME_OVERVIEW.name, "footprint_geometry"
 )
 

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -39,9 +39,6 @@ CUBEDASH_SCHEMA = "cubedash"
 METADATA = MetaData(schema=CUBEDASH_SCHEMA)
 GRIDCELL_COL_SPEC = f"{CUBEDASH_SCHEMA}.gridcell"
 
-# Albers equal area. Allows us to show coverage in m^2 easily.
-FOOTPRINT_SRID = 3577
-
 DATASET_SPATIAL = Table(
     "dataset_spatial",
     METADATA,
@@ -79,6 +76,7 @@ DATASET_SPATIAL = Table(
         postgresql_ops={"region_code": "text_pattern_ops"},
     ),
 )
+
 
 DATASET_SPATIAL.indexes.add(
     Index(
@@ -185,7 +183,8 @@ TIME_OVERVIEW = Table(
         comment="The 'last_refresh' timestamp of the product at the time of generation.",
     ),
     Column("footprint_count", Integer, nullable=False),
-    Column("footprint_geometry", Geometry(srid=FOOTPRINT_SRID, spatial_index=False)),
+    # SRID is overridden via config.
+    Column("footprint_geometry", Geometry(srid=-999, spatial_index=False)),
     Column("crses", postgres.ARRAY(String)),
     # Size of this dataset in bytes, if the product includes it.
     Column("size_bytes", BigInteger),
@@ -195,6 +194,11 @@ TIME_OVERVIEW = Table(
         r"array_length(timeline_dataset_counts, 1)",
         name="timeline_lengths_equal",
     ),
+)
+
+# An SQLAlchemy expression to read the configured SRID.
+FOOTPRINT_SRID_EXPRESSION = func.FindSRID(
+    TIME_OVERVIEW.schema, TIME_OVERVIEW.name, "footprint_geometry"
 )
 
 # The geometry of each unique 'region' for a product.
@@ -480,7 +484,20 @@ def pg_column_exists(conn, table_name: str, column_name: str) -> bool:
     )
 
 
-def create_schema(engine: Engine):
+def _epsg_to_srid(engine: Engine, code: int) -> int:
+    """
+    Convert an epsg code to Postgis' srid number.
+
+    They're usually the same in Postgis' default srid table... but they don't
+    have to be. We'll do this lookup anyway to be good citizens.
+    """
+    return engine.execute(
+        "select srid from spatial_ref_sys where auth_name = 'EPSG' and auth_srid=%(epsg_code)s",
+        epsg_code=code,
+    ).scalar()
+
+
+def create_schema(engine: Engine, epsg_code: int):
     """
     Create any missing parts of the cubedash schema
     """
@@ -505,6 +522,15 @@ def create_schema(engine: Engine):
         == 0
     ):
         engine.execute(DDL("create extension postgis"))
+
+    srid = _epsg_to_srid(engine, epsg_code)
+    if srid is None:
+        raise RuntimeError(
+            f"Postgis doesn't seem to know about epsg code {epsg_code!r}."
+        )
+
+    # Our global SRID.
+    TIME_OVERVIEW.c.footprint_geometry.type.srid = srid
 
     # We want an index on the spatial_ref_sys table to do authority name/code lookups.
     # But in RDS environments we cannot add indexes to it.

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -202,9 +202,6 @@ class ProductLocationSample:
     example_uris: List[str]
 
 
-_NOT_SET = object()
-
-
 class SummaryStore:
     def __init__(self, index: Index, summariser: Summariser, log=_LOG) -> None:
         self.index = index
@@ -282,13 +279,13 @@ class SummaryStore:
 
                 Eg.
 
+                    # Drop schema
                     cubedash-gen --drop
 
-                And create with the new code:
-
+                    # Create schema with new epsg, and summarise all products again.
                     cubedash-gen --init --epsg {grouping_epsg_code} --all
 
-                (Warning: this can take a long time!)
+                (Warning: Resummarising all of your products may take a long time!)
                 """
                 )
         refresh_also = _schema.update_schema(self._engine)
@@ -300,6 +297,7 @@ class SummaryStore:
     def create(cls, index: Index, log=_LOG) -> "SummaryStore":
         return cls(index, Summariser(_utils.alchemy_engine(index)), log=log)
 
+    @property
     def grouping_crs(self):
         """
         Get the crs name used for grouping summaries.

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -6,7 +6,6 @@ from copy import copy
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from enum import Enum, auto
-from functools import cached_property
 from itertools import groupby
 from typing import (
     Dict,
@@ -301,7 +300,6 @@ class SummaryStore:
     def create(cls, index: Index, log=_LOG) -> "SummaryStore":
         return cls(index, Summariser(_utils.alchemy_engine(index)), log=log)
 
-    @cached_property
     def grouping_crs(self):
         """
         Get the crs name used for grouping summaries.

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -95,7 +95,7 @@ class Summariser:
                     func.sum(select_by_srid.c.size_bytes).label("size_bytes"),
                     func.ST_Union(
                         func.ST_Buffer(select_by_srid.c.footprint_geometry, 0),
-                        type_=Geometry(srid=FOOTPRINT_SRID_EXPRESSION),
+                        type_=Geometry(),
                     ).label("footprint_geometry"),
                     func.max(select_by_srid.c.newest_dataset_creation_time).label(
                         "newest_dataset_creation_time"

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -18,8 +18,7 @@ from cubedash._utils import ODC_DATASET_TYPE
 from cubedash.summary import TimePeriodOverview
 from cubedash.summary._schema import (
     DATASET_SPATIAL,
-    FOOTPRINT_SRID,
-    SPATIAL_REF_SYS,
+    FOOTPRINT_SRID_EXPRESSION,
     get_srid_name,
 )
 
@@ -51,8 +50,6 @@ class Summariser:
         self.grouping_time_zone = grouping_time_zone
         # cache
         self._grouping_time_zone_tz = tz.gettz(self.grouping_time_zone)
-        # EPSG code for all polygons to be converted to (for footprints).
-        self.output_crs_epsg_code = FOOTPRINT_SRID
 
     def calculate_summary(
         self,
@@ -75,7 +72,7 @@ class Summariser:
                     func.count().label("dataset_count"),
                     func.ST_Transform(
                         func.ST_Union(DATASET_SPATIAL.c.footprint),
-                        self._target_srid(),
+                        FOOTPRINT_SRID_EXPRESSION,
                         type_=Geometry(),
                     ).label("footprint_geometry"),
                     func.sum(DATASET_SPATIAL.c.size_bytes).label("size_bytes"),
@@ -98,7 +95,7 @@ class Summariser:
                     func.sum(select_by_srid.c.size_bytes).label("size_bytes"),
                     func.ST_Union(
                         func.ST_Buffer(select_by_srid.c.footprint_geometry, 0),
-                        type_=Geometry(srid=self._target_srid()),
+                        type_=Geometry(srid=FOOTPRINT_SRID_EXPRESSION),
                     ).label("footprint_geometry"),
                     func.max(select_by_srid.c.newest_dataset_creation_time).label(
                         "newest_dataset_creation_time"
@@ -231,20 +228,6 @@ class Summariser:
             ),
         )
         return begin_time, end_time, where_clause
-
-    @lru_cache(1)
-    def _target_srid(self):
-        """
-        Get the srid key for our target CRS (that all geometry is returned as)
-
-        The pre-populated srid primary keys in postgis all default to the epsg code,
-        but we'll do the lookup anyway to be good citizens.
-        """
-        return self._engine.execute(
-            select([SPATIAL_REF_SYS.c.srid])
-            .where(SPATIAL_REF_SYS.c.auth_name == "EPSG")
-            .where(SPATIAL_REF_SYS.c.auth_srid == self.output_crs_epsg_code)
-        ).scalar()
 
     @lru_cache()
     def _get_srid_name(self, srid: int):

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -90,7 +90,9 @@ def summary_store(module_dea_index: Index) -> SummaryStore:
     module_dea_index.close()
 
     with disable_logging():
-        store.init()
+        # Some CRS/storage tests use test data that is 3577
+        store.init(grouping_epsg_code=3577)
+
     _make_all_tables_unlogged(
         _utils.alchemy_engine(module_dea_index), CUBEDASH_METADATA
     )

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -47,7 +47,9 @@ def eo3_index(module_dea_index: Index, dataset_loader):
     assert loaded == 1
 
     # We need postgis and some support tables (eg. srid lookup).
-    SummaryStore.create(module_dea_index).init()
+    store = SummaryStore.create(module_dea_index)
+    store.drop_all()
+    store.init(grouping_epsg_code=3577)
 
     return module_dea_index
 

--- a/integration_tests/test_stores.py
+++ b/integration_tests/test_stores.py
@@ -11,7 +11,6 @@ from shapely import geometry as geo
 
 from cubedash.summary import SummaryStore, TimePeriodOverview
 from cubedash.summary._stores import GenerateResult, ProductSummary
-from cubedash.summary._summarise import Summariser
 
 
 def _overview(
@@ -160,20 +159,8 @@ def test_get_null(summary_store: SummaryStore):
     assert loaded is None
 
 
-def test_srid_lookup(summariser: Summariser):
-    srid = summariser._target_srid()
-    assert srid is not None
-    assert isinstance(srid, int)
-
-    srid2 = summariser._target_srid()
-    assert srid == srid2
-
-    assert summariser._get_srid_name(srid) == "EPSG:3577"
-
-    # Cached?
-    cache_hits = summariser._get_srid_name.cache_info().hits
-    assert summariser._get_srid_name(srid) == "EPSG:3577"
-    assert summariser._get_srid_name.cache_info().hits > cache_hits
+def test_srid_lookup(summary_store: SummaryStore):
+    assert summary_store.grouping_crs == "EPSG:3577"
 
 
 def test_put_get_summaries(summary_store: SummaryStore):


### PR DESCRIPTION
Closes #206 

- A different CRS can be chosen on init of your Explorer schema: `cubedash-gen --init --epsg 3577`
- If not specified, the default is now global equal-area `epsg:6933` instead of Australian Albers.
