### PR TITLE
Update default Docker command to match deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,4 +74,16 @@ RUN pip freeze
 ENTRYPOINT ["/bin/tini", "--"]
 
 # This is for prod, and serves as docs. It's usually overwritten
-CMD gunicorn -b '0.0.0.0:8080' -w 1 '--worker-class=egg:meinheld#gunicorn_worker'  --timeout 60 --config python:cubedash.gunicorn_config cubedash:app
+CMD ["gunicorn", \
+     "-b", \
+     "0.0.0.0:8080", \
+     "-w", \
+     "3", \
+     "--threads=2", \
+     "-k", \
+     "gthread", \
+     "--timeout", \
+     "60", \
+     "--config", \
+     "python:cubedash.gunicorn_config", \
+     "cubedash:app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       - FLASK_APP=cubedash
       - FLASK_DEBUG=1
       # - VIRTUAL_HOST=datacube.explorer
-    command: gunicorn -b '0.0.0.0:8080' -w 1 '--worker-class=egg:meinheld#gunicorn_worker'  --timeout 60 cubedash:app
     depends_on:
       - postgres
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ extras_require = {
         # The default run.sh and docs use gunicorn+meinheld
         "gunicorn",
         "setproctitle",
-        "meinheld",
         "gevent",
         # Monitoring
         "raven",
@@ -44,6 +43,7 @@ extras_require = {
     ],
 }
 
+extras_require["test"].extend(extras_require["deployment"])
 
 setup(
     name="datacube-explorer",


### PR DESCRIPTION
Someone on Slack pointed out the default Docker CMD is not working, as meinheld has a dependency conflict.

We don't use meinheld on our prod deployments, so didn't notice.