### PR TITLE
Fix breadcrumb links when deploying with a prefix

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -439,29 +439,41 @@ def inject_globals():
             "CUBEDASH_INSTANCE_TITLE",
         )
         or app.config.get("STAC_ENDPOINT_TITLE", ""),
-        breadcrumb=_get_breadcrumbs(request.path),
+        breadcrumb=_get_breadcrumbs(request.path, request.script_root),
     )
 
 
-def _get_breadcrumbs(url: str):
+HREF = str
+SHOULD_LINK = bool
+
+
+def _get_breadcrumbs(url: str, script_root: str) -> List[Tuple[HREF, str, SHOULD_LINK]]:
     """
-    >>> _get_breadcrumbs('/products/great_product')
+    >>> _get_breadcrumbs('/products/great_product', '/')
     [('/products', 'products', True), ('/products/great_product', 'great_product', False)]
-    >>> _get_breadcrumbs('/products')
+    >>> _get_breadcrumbs('/products/great_product', '/prefix')
+    [('/prefix/products', 'products', True), ('/prefix/products/great_product', 'great_product', False)]
+    >>> _get_breadcrumbs('/products', '/')
     [('/products', 'products', False)]
-    >>> _get_breadcrumbs('/')
+    >>> _get_breadcrumbs('/products', '/pref')
+    [('/pref/products', 'products', False)]
+    >>> _get_breadcrumbs('/', '/')
     []
-    >>> _get_breadcrumbs('')
+    >>> _get_breadcrumbs('/', '/pref')
+    []
+    >>> _get_breadcrumbs('', '/')
     []
     """
     breadcrumb = []
     i = 2
+    script_root = script_root.rstrip("/")
+
     for part_name in url.split("/"):
         if part_name:
             part_href = "/".join(url.split("/")[:i])
             breadcrumb.append(
                 (
-                    part_href,
+                    f"{script_root}{part_href}",
                     part_name,
                     # Don't link to the current page.
                     part_href != url,

--- a/cubedash/templates/layout/base.html
+++ b/cubedash/templates/layout/base.html
@@ -64,7 +64,7 @@
         </div>
     </div>
     <div id="breadcrumb">
-        <a class="item" href="/">home</a>
+        <a class="item" href="{{url_for('default_redirect')}}">home</a>
         {% if breadcrumb %}
             {% for url, title, valid_link in breadcrumb %}
                 {% if valid_link %}


### PR DESCRIPTION
Their links did not include the deployed application prefix, so would break when an app is not at the root of the domain (`/`).

Fixes #330