### PR TITLE
Fix for stability/metrics

### DIFF
--- a/constraints-docker.txt
+++ b/constraints-docker.txt
@@ -1,1 +1,2 @@
 datacube==1.8.6
+eodatasets3==0.22.2

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -292,7 +292,7 @@ def enable_prometheus():
             GunicornInternalPrometheusMetrics,
         )
 
-        metrics = GunicornInternalPrometheusMetrics(app)
+        metrics = GunicornInternalPrometheusMetrics(app, group_by="endpoint")
         _LOG.info(f"Prometheus metrics enabled : {metrics}")
 
 


### PR DESCRIPTION
* Address #337 (explosion of metrics) by labelling metrics by endpoint, rather than by path. Because the number of distinct paths is nearly unbounded (distinguishing those is a role for logs not metrics).
* Resolve repo staleness (previously passing tests now fail) by pinning a dependency version to the last compatible version (pending further updates).