### PR TITLE
Capitalise prometheus env var

### DIFF
--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -287,7 +287,7 @@ def enable_sentry():
 @app.before_first_request
 def enable_prometheus():
     # Enable deployment specific code for Prometheus metrics
-    if os.environ.get("prometheus_multiproc_dir", False):
+    if os.environ.get("PROMETHEUS_MULTIPROC_DIR", False):
         from prometheus_flask_exporter.multiprocess import (
             GunicornInternalPrometheusMetrics,
         )

--- a/cubedash/gunicorn_config.py
+++ b/cubedash/gunicorn_config.py
@@ -4,7 +4,7 @@ import os
 
 
 def child_exit(server, worker):
-    if os.environ.get("prometheus_multiproc_dir", False):
+    if os.environ.get("PROMETHEUS_MULTIPROC_DIR", False):
         from prometheus_flask_exporter.multiprocess import (
             GunicornInternalPrometheusMetrics,
         )

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,7 +7,7 @@ services:
       args:
         ENVIRONMENT: test
     environment:
-      - prometheus_multiproc_dir=/tmp # Enable prometheus metrics
+      - PROMETHEUS_MULTIPROC_DIR=/dev/shm # Enable prometheus metrics
     volumes:
       - ./:/code
       - ./.docker/.datacube_integration.conf:/root/.datacube_integration.conf


### PR DESCRIPTION
* Capitalise the Prometheus environment variable name
  * By convention, environment variable names should always be uppercase.
  * Using lowercase is now triggering a _deprecation warning_ (visible in CI test runs).
  * We have seen bugs (e.g. [opendatacube/datacube-wps#129](https://github.com/opendatacube/datacube-wps/issues/129)) related to continued use of lowercase.
* Default to explicitly using the shared memory location for Prometheus (aggregating metrics data between processes).
   * We want to ensure we're using a `tmpfs` mount, to avoid potential IO performance issues. 
   * On the current container images, `/tmp` is not `tmpfs`.