### PR TITLE
Use the embedded datetime on eo3 products, not a calculated center time

### DIFF
--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -112,7 +112,7 @@ def expects_eo3_metadata_type(md: MetadataType) -> bool:
     """
     # We don't have a clean way to say that a product expects EO3
 
-    measurements_offset = md.definition["dataset"]["measurements"]
+    measurements_offset = md.definition["dataset"].get("measurements")
 
     # In EO3, the measurements are in ['measurments'],
     # In EO1, they are in ['image', 'bands'].

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -50,8 +50,8 @@ from cubedash.summary import RegionInfo, TimePeriodOverview, _extents, _schema
 from cubedash.summary._extents import (
     ProductArrival,
     RegionSummary,
-    center_time_expression,
     dataset_changed_expression,
+    datetime_expression,
 )
 from cubedash.summary._schema import (
     DATASET_SPATIAL,
@@ -354,7 +354,7 @@ class SummaryStore:
                 select(
                     [
                         func.date_trunc(
-                            "month", center_time_expression(dataset_type.metadata_type)
+                            "month", datetime_expression(dataset_type.metadata_type)
                         ).label("month"),
                         func.count(),
                     ]

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -65,9 +65,12 @@ def test_eo3_extents(eo3_index: Index):
 
     assert dataset_extent_row["id"] == UUID("5b2f2c50-e618-4bef-ba1f-3d436d9aed14")
 
+    # On older products, the center time was calculated from the range.
+    # But on EO3 we have a singular 'datetime' to use directly.
     assert dataset_extent_row["center_time"] == datetime(
-        1988, 3, 30, 1, 41, 16, 855723, tzinfo=tz.tzutc()
+        1988, 3, 30, 1, 41, 16, 892044, tzinfo=tz.tzutc()
     )
+
     assert dataset_extent_row["creation_time"] == datetime(
         2020, 6, 5, 7, 15, 26, 599544, tzinfo=tz.tzutc()
     )

--- a/integration_tests/test_stores.py
+++ b/integration_tests/test_stores.py
@@ -1,7 +1,7 @@
 import operator
 import time
 from collections import Counter
-from datetime import datetime
+from datetime import date, datetime
 from typing import List
 
 import pytest
@@ -105,7 +105,7 @@ def test_add_no_periods(summary_store: SummaryStore):
 
 def test_month_iteration():
     def assert_month_iteration(
-        start: datetime, end: datetime, expected_months: List[datetime]
+        start: datetime, end: datetime, expected_months: List[date]
     ):
         __tracebackhide__ = operator.methodcaller("errisinstance", AssertionError)
 
@@ -120,11 +120,11 @@ def test_month_iteration():
         datetime(2003, 2, 2),
         datetime(2003, 6, 2),
         [
-            datetime(2003, 2, 1, 0, 0),
-            datetime(2003, 3, 1, 0, 0),
-            datetime(2003, 4, 1, 0, 0),
-            datetime(2003, 5, 1, 0, 0),
-            datetime(2003, 6, 1, 0, 0),
+            date(2003, 2, 1),
+            date(2003, 3, 1),
+            date(2003, 4, 1),
+            date(2003, 5, 1),
+            date(2003, 6, 1),
         ],
     )
     # Across year bounds
@@ -132,19 +132,19 @@ def test_month_iteration():
         datetime(2003, 11, 2),
         datetime(2004, 2, 2),
         [
-            datetime(2003, 11, 1, 0, 0),
-            datetime(2003, 12, 1, 0, 0),
-            datetime(2004, 1, 1, 0, 0),
-            datetime(2004, 2, 1, 0, 0),
+            date(2003, 11, 1),
+            date(2003, 12, 1),
+            date(2004, 1, 1),
+            date(2004, 2, 1),
         ],
     )
     # Within same month
     assert_month_iteration(
-        datetime(2003, 11, 1), datetime(2003, 11, 30), [datetime(2003, 11, 1, 0, 0)]
+        datetime(2003, 11, 1), datetime(2003, 11, 30), [date(2003, 11, 1)]
     )
     # Identical dates
     assert_month_iteration(
-        datetime(2003, 11, 1), datetime(2003, 11, 1), [datetime(2003, 11, 1, 0, 0)]
+        datetime(2003, 11, 1), datetime(2003, 11, 1), [date(2003, 11, 1)]
     )
 
 


### PR DESCRIPTION
ODC's model represents time as a range, but Explorer needs a single timestamp to place the dataset. It has historically used the `center_time` to  do this (matching other ODC tools like the ingestor).

.... but @erin-telfer has pointed out on Slack that this is not ideal for downstream summary products, where the start time is a better indicator of the data than a calculated center time.

In the EO3 format (and Stac), there is a `datetime` field that can be set independently from the time range. This is correctly set to the start_time on Erin's data. 

We should use that explicit `datetime` on EO3+Stac products rather than our own calculation. This will allow product creators to choose which datetime makes sense to them. And we can continue to fallback to a calculated center_time otherwise.
