### PR TITLE
Support datasets with null datetimes

### DIFF
--- a/integration_tests/data/gm_s2_semiannual/856e45bf-cd50-5a5a-b1cd-12b85df99b24.odc-metadata.yaml
+++ b/integration_tests/data/gm_s2_semiannual/856e45bf-cd50-5a5a-b1cd-12b85df99b24.odc-metadata.yaml
@@ -1,0 +1,95 @@
+---
+# Dataset
+# url: https://explorer.digitalearth.africa/dataset/856e45bf-cd50-5a5a-b1cd-12b85df99b24.odc-metadata.yaml
+$schema: https://schemas.opendatacube.org/dataset
+id: 856e45bf-cd50-5a5a-b1cd-12b85df99b24
+
+label: gm_s2_semiannual_2017-07--P6M
+product:
+  name: gm_s2_semiannual_lowres
+
+location: s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M.stac-item.json
+
+crs: epsg:6933
+geometry:
+  type: Polygon
+  coordinates: [[[-2688000.0, 4608000.0], [-2688000.0, -5472000.0], [6240000.0, -5472000.0],
+      [6240000.0, 4608000.0], [-2688000.0, 4608000.0]]]
+grids:
+  default:
+    shape: [84000, 74400]
+    transform: [120.0, 0.0, -2688000.0, 0.0, -120.0, 4608000.0, 0.0, 0.0, 1.0]
+
+properties:
+  datetime:
+  dtr:end_datetime: '2017-12-31T23:59:59Z'
+  dtr:start_datetime: '2017-07-01T00:00:00Z'
+  odc:file_format: GeoTIFF
+  odc:product: gm_s2_semiannual_lowres
+  proj:bbox:
+  - -2688000.0
+  - -5472000.0
+  - 6240000.0
+  - 4608000.0
+  proj:epsg: 6933
+  proj:geometry:
+    type: Polygon
+    coordinates:
+    - - - -2688000.0
+        - 4608000.0
+      - - -2688000.0
+        - -5472000.0
+      - - 6240000.0
+        - -5472000.0
+      - - 6240000.0
+        - 4608000.0
+      - - -2688000.0
+        - 4608000.0
+  proj:shape:
+  - 84000
+  - 74400
+  proj:transform:
+  - 120.0
+  - 0.0
+  - -2688000.0
+  - 0.0
+  - -120.0
+  - 4608000.0
+  - 0.0
+  - 0.0
+  - 1.0
+
+measurements:
+  B02:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_B02.tif
+  B03:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_B03.tif
+  B04:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_B04.tif
+  B05:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_B05.tif
+  B06:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_B06.tif
+  B07:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_B07.tif
+  B08:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_B08.tif
+  B11:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_B11.tif
+  B12:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_B12.tif
+  B8A:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_B8A.tif
+  EMAD:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_EMAD.tif
+  SMAD:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_SMAD.tif
+  BCMAD:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_BCMAD.tif
+  COUNT:
+    path: gm_s2_semiannual_lowres_2017-07--P6M_COUNT.tif
+
+accessories: {}
+
+lineage: {}
+...

--- a/integration_tests/data/gm_s2_semiannual/gm_s2_semiannual_lowres.odc-product.yaml
+++ b/integration_tests/data/gm_s2_semiannual/gm_s2_semiannual_lowres.odc-product.yaml
@@ -1,0 +1,122 @@
+---
+# Product
+# url: https://explorer.digitalearth.africa/products/gm_s2_semiannual_lowres.odc-product.yaml
+name: gm_s2_semiannual_lowres
+license: CC-BY-4.0
+metadata_type: eo3
+description: Surface Reflectance Semiannual Geometric Median and Median Absolute Deviations,
+  Sentinel-2. Low resolution version used for visualisations.
+metadata:
+  product:
+    name: gm_s2_semiannual_lowres
+measurements:
+- name: B02
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_02
+  - blue
+- name: B03
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_03
+  - green
+- name: B04
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_04
+  - red
+- name: B05
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_05
+  - red_edge_1
+- name: B06
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_06
+  - red_edge_2
+- name: B07
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_07
+  - red_edge_3
+- name: B08
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_08
+  - nir
+  - nir_1
+- name: B8A
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_8a
+  - nir_narrow
+  - nir_2
+- name: B11
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_11
+  - swir_1
+  - swir_16
+- name: B12
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - band_12
+  - swir_2
+  - swir_22
+- name: SMAD
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - smad
+  - sdev
+  - SDEV
+- name: EMAD
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - emad
+  - edev
+  - EDEV
+- name: BCMAD
+  dtype: float32
+  units: '1'
+  nodata: NaN
+  aliases:
+  - bcmad
+  - bcdev
+  - BCDEV
+- name: COUNT
+  dtype: uint16
+  units: '1'
+  nodata: 0
+  aliases:
+  - count
+storage:
+  crs: EPSG:6933
+  resolution:
+    x: 120
+    y: -120
+...

--- a/integration_tests/data/gm_s2_semiannual/gm_s2_semiannual_lowres_2017-07--P6M.stac-item.json
+++ b/integration_tests/data/gm_s2_semiannual/gm_s2_semiannual_lowres_2017-07--P6M.stac-item.json
@@ -1,0 +1,203 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "gm_s2_semiannual_2017-07--P6M",
+    "properties": {
+        "odc:product": "gm_s2_semiannual_lowres",
+        "start_datetime": "2017-07-01T00:00:00Z",
+        "end_datetime": "2017-12-31T23:59:59Z",
+        "proj:epsg": 6933,
+        "proj:geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [
+                        -2688000.0,
+                        4608000.0
+                    ],
+                    [
+                        -2688000.0,
+                        -5472000.0
+                    ],
+                    [
+                        6240000.0,
+                        -5472000.0
+                    ],
+                    [
+                        6240000.0,
+                        4608000.0
+                    ],
+                    [
+                        -2688000.0,
+                        4608000.0
+                    ]
+                ]
+            ]
+        },
+        "proj:bbox": [
+            -2688000.0,
+            -5472000.0,
+            6240000.0,
+            4608000.0
+        ],
+        "proj:shape": [
+            84000,
+            74400
+        ],
+        "proj:transform": [
+            120.0,
+            0.0,
+            -2688000.0,
+            0.0,
+            -120.0,
+            4608000.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "datetime": null
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -27.858883076540035,
+                    38.99888289900373
+                ],
+                [
+                    -27.858883076540035,
+                    -48.31042171670349
+                ],
+                [
+                    64.67240714196794,
+                    -48.31042171670349
+                ],
+                [
+                    64.67240714196794,
+                    38.99888289900373
+                ],
+                [
+                    -27.858883076540035,
+                    38.99888289900373
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M.stac-item.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "B02": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_B02.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "B03": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_B03.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "B04": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_B04.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "B05": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_B05.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "B06": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_B06.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "B07": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_B07.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "B08": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_B08.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "B8A": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_B8A.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "B11": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_B11.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "B12": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_B12.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "EMAD": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_EMAD.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "SMAD": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_SMAD.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "BCMAD": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_BCMAD.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "COUNT": {
+            "href": "s3://deafrica-services/gm_s2_semiannual_lowres/2017-07--P6M/gm_s2_semiannual_lowres_2017-07--P6M_COUNT.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -27.858883076540035,
+        -48.31042171670349,
+        64.67240714196794,
+        38.99888289900373
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    ]
+}

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -151,10 +151,10 @@ def test_eo3_dateless_extents(eo3_index: Index):
 
     assert dataset_extent_row["id"] == UUID("856e45bf-cd50-5a5a-b1cd-12b85df99b24")
 
-    # Since it has no datetime, the chosen one should default to a calculated center time.
-    center_time: datetime = dataset_extent_row["center_time"]
-    assert center_time.astimezone(tz.tzutc()) == datetime(
-        2017, 9, 30, 23, 59, 59, 500000, tzinfo=tz.tzutc()
+    # Since it has no datetime, the chosen one should default to the start
+    time_record: datetime = dataset_extent_row["center_time"]
+    assert time_record.astimezone(tz.tzutc()) == datetime(
+        2017, 7, 1, 0, 0, tzinfo=tz.tzutc()
     )
 
     # Dataset has no creation time, but will fall back to index time.


### PR DESCRIPTION
(Fixes summary generation failure in Africa.)

In newer versions of Stac, `datetime` became optional, in which case the start/end time must be specified. When it's converted to eo3 on index we don't do anything about this, so effectively that's true of eo3 too now.

Add support for this case, with an example test dataset from Africa.