### PR TITLE
Fix the missing slashes in locations

### DIFF
--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1,5 +1,4 @@
 import math
-import os
 import re
 from collections import Counter, defaultdict
 from copy import copy
@@ -1803,6 +1802,12 @@ def _summary_to_row(summary: TimePeriodOverview) -> dict:
 def _common_paths_for_uris(
     uri_samples: Iterator[str],
 ) -> Generator[ProductLocationSample, None, None]:
+    """
+    >>> list(_common_paths_for_uris(['file:///a/thing-1.txt', 'file:///a/thing-2.txt', 'file:///a/thing-3.txt']))
+    [ProductLocationSample(uri_scheme='file', common_prefix='file:///a/', example_uris=['file:///a/thing-1.txt', \
+'file:///a/thing-2.txt', 'file:///a/thing-3.txt'])]
+    """
+
     def uri_scheme(uri: str):
         return uri.split(":", 1)[0]
 
@@ -1815,7 +1820,7 @@ def _common_paths_for_uris(
         #              ⮤ we use a set for when len < 3
 
         yield ProductLocationSample(
-            scheme, os.path.commonpath(uris), sorted(example_uris)
+            scheme, _utils.common_uri_prefix(uris), sorted(example_uris)
         )
 
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -875,7 +875,7 @@ class SummaryStore:
 
     @ttl_cache(ttl=DEFAULT_TTL)
     def products_location_samples_all(
-        self, sample_size: int = 100
+        self, sample_size: int = 50
     ) -> Dict[str, List[ProductLocationSample]]:
         """
         Get sample locations of all products

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -163,6 +163,12 @@ def test_eo3_dateless_extents(eo3_index: Index):
     assert dataset_extent_row["region_code"] is None
 
 
+def test_location_sampling(eo3_index: Index):
+    summary_store = SummaryStore.create(eo3_index)
+
+    assert summary_store.product_location_samples("ls8_nbar_albers") == []
+
+
 def test_eo3_doc_download(eo3_index: Index, client: FlaskClient):
     response: Response = client.get(
         "/dataset/9989545f-906d-5090-a38e-cdbfbfc1afca.odc-metadata.yaml"

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -259,6 +259,20 @@ def _change_dataset_product(index: Index, dataset_id: UUID, other_product: Datas
     assert rows_changed == 1
 
 
+def test_location_sampling(run_generate, summary_store: SummaryStore):
+    location_samples = summary_store.product_location_samples("ls8_nbar_albers")
+    assert len(location_samples) == 1
+
+    [sample] = location_samples
+    assert sample.uri_scheme == "file"
+    assert sample.common_prefix == "file://example.com/test_dataset/"
+    assert len(sample.example_uris) == 3
+    assert all(
+        uri.startswith("file://example.com/test_dataset/")
+        for uri in sample.example_uris
+    )
+
+
 def test_has_source_derived_product_links(run_generate, summary_store: SummaryStore):
     run_generate()
 


### PR DESCRIPTION
Our common location calculation has missing slashes:
![Screenshot from 2021-12-08 10-17-26](https://user-images.githubusercontent.com/25688/145120889-646d092c-23e1-4067-a907-1150641d293c.png)

This seems to be the behaviour of Python's `os.path.commonpath`, which was was written for paths, not URLs.

I've added a `common_uri` function, and add regression tests.
