### PR TITLE
Fix minor deployment warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ CMD ["gunicorn", \
      "-k", \
      "gthread", \
      "--timeout", \
-     "60", \
+     "90", \
      "--config", \
      "python:cubedash.gunicorn_config", \
      "cubedash:app"]

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -756,7 +756,7 @@ def dataset_shape(ds: Dataset) -> Tuple[Optional[Polygon], bool]:
     if extent is None:
         log.warn("invalid_dataset.empty_extent")
         return None, False
-    geom = shapely.geometry.asShape(extent.to_crs(CRS(_TARGET_CRS)))
+    geom = shape(extent.to_crs(CRS(_TARGET_CRS)))
 
     if not geom.is_valid:
         log.warn(

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1120,16 +1120,16 @@ class SummaryStore:
                 if len(product_names) == 1:
                     query = query.where(
                         DATASET_SPATIAL.c.dataset_type_ref
-                        == select([ODC_DATASET_TYPE.c.id]).where(
-                            ODC_DATASET_TYPE.c.name == product_names[0]
-                        )
+                        == select([ODC_DATASET_TYPE.c.id])
+                        .where(ODC_DATASET_TYPE.c.name == product_names[0])
+                        .scalar_subquery()
                     )
                 else:
                     query = query.where(
                         DATASET_SPATIAL.c.dataset_type_ref.in_(
-                            select([ODC_DATASET_TYPE.c.id]).where(
-                                ODC_DATASET_TYPE.c.name.in_(product_names)
-                            )
+                            select([ODC_DATASET_TYPE.c.id])
+                            .where(ODC_DATASET_TYPE.c.name.in_(product_names))
+                            .scalar_subquery()
                         )
                     )
 


### PR DESCRIPTION
Fix warnings in the newer versions of Shapely and Sqlalchemy.

(There's still a couple of deprecation warnings coming from inside datacube-core's code, though. [Already reported](https://github.com/opendatacube/datacube-core/issues/1221))

This also fixes the AttributeError coming from shapely during garbage collection. It was caused by the deprecated method not supporting empty geometry collections, which some datasets trigger. (I could reproduce it by viewing `wofs_summary` datasets on the NCI instance.) 

(Fixes #354)