### PR TITLE
Improve derived-dataset querying for dataset with huge numbers

### DIFF
--- a/cubedash/_dataset.py
+++ b/cubedash/_dataset.py
@@ -63,10 +63,10 @@ def dataset_full_page(product_name: str, id_: UUID):
     dataset.metadata.sources = {}
     ordered_metadata = utils.prepare_dataset_formatting(dataset)
 
-    derived_datasets = sorted(index.datasets.get_derived(id_), key=utils.dataset_label)
-    if len(derived_datasets) > PROVENANCE_DISPLAY_LIMIT:
-        derived_dataset_overflow = len(derived_datasets) - PROVENANCE_DISPLAY_LIMIT
-        derived_datasets = derived_datasets[:PROVENANCE_DISPLAY_LIMIT]
+    derived_datasets, derived_dataset_overflow = utils.get_datasets_derived(
+        index, id_, limit=PROVENANCE_DISPLAY_LIMIT
+    )
+    derived_datasets.sort(key=utils.dataset_label)
 
     footprint, region_code = _model.STORE.get_dataset_footprint_region(id_)
     # We only have a footprint in the spatial table above if summarisation has been

--- a/cubedash/templates/about.html
+++ b/cubedash/templates/about.html
@@ -143,6 +143,12 @@
                 </span>
             </li>
             <li>
+                Raw, bulk <a href="{{ url_for('audit.dscount_report_page') }}">dataset counts</a>:
+                <span class="uri-path">
+                    {{ url_for('audit.dsreport_csv', _external=True) }}
+                </span>
+            </li>
+            <li>
                 <a href="{{ url_for('arrivals_page') }}">Arriving data</a> summary:
                 <span class="uri-path">
                     {{ url_for('arrivals_csv', _external=True) }}

--- a/cubedash/templates/dscount-report.html
+++ b/cubedash/templates/dscount-report.html
@@ -5,7 +5,7 @@
 
 {% block content %}
     <div class="panel highlight">
-        <h2 class="followed lonesome">Dataset Count Report</h2>
+        <h2 class="followed lonesome">Bulk Dataset Counts</h2>
         <span class="header-follow">
             <a href="{{ url_for('.dsreport_csv') }}" class="badge header-badge">
                 csv
@@ -14,6 +14,9 @@
         </span>
     </div>
     <div class="panel">
+        <p>
+            An empty value means "all"
+        </p>
         <table class="data-table">
                 <thead>
                     <tr>


### PR DESCRIPTION
Datasets such as DEA's DSM datasets have millions of derived datasets in their provenance. These can be too slow to load.

Add a more efficient derived-dataset query that only loads the displayed limit of downstream datasets.

- Additionally, add the dataset count api to the api docs. (this could be a separate PR, sorry)