### PR TITLE
Validate uuids in URLs

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -436,7 +436,7 @@ def inject_globals():
     # The footer "Last updated" date.
     # The default is the currently-viewed product's summary refresh date.
     last_updated = None
-    if "product_name" in flask.request.view_args:
+    if flask.request.view_args and ("product_name" in flask.request.view_args):
         product_summary = _model.STORE.get_product_summary(
             flask.request.view_args["product_name"]
         )

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -555,7 +555,7 @@ def collection_items(collection: str):
     return _geojson_stac_response(feature_collection)
 
 
-@bp.route("/collections/<collection>/items/<dataset_id>")
+@bp.route("/collections/<collection>/items/<uuid:dataset_id>")
 def item(collection: str, dataset_id: str):
     dataset = _model.STORE.get_item(dataset_id)
     if not dataset:

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -852,6 +852,10 @@ def test_returns_404s(stac_client: FlaskClient):
         f"/stac/collections/does_not_exist/items/{wrong_dataset_id}",
         message_contains="No dataset found",
     )
+    # Should be a 404, not a server or posgres error.
+    expect_404(
+        "/stac/collections/does_not_exist/items/not-a-uuid",
+    )
 
 
 def test_stac_item(stac_client: FlaskClient, populated_index: Index):

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -29,6 +29,7 @@ from integration_tests.asserts import (
     assert_matching_eo3,
     get_geojson,
     get_json,
+    get_text_response,
 )
 
 ALLOW_INTERNET = True
@@ -117,7 +118,6 @@ def _local_reference(schema_location: Path, ref):
 
 
 def load_validator(schema_location: Path) -> jsonschema.Draft7Validator:
-
     if not schema_location.exists():
         raise ValueError(f"No jsonschema file found at {schema_location}")
 
@@ -682,7 +682,7 @@ def test_huge_page_request(stac_client: FlaskClient):
     """Return an error if they try to request beyond max-page-size limit"""
     error_message_json = get_json(
         stac_client,
-        f"/stac/search?&limit={OUR_DATASET_LIMIT+1}",
+        f"/stac/search?&limit={OUR_DATASET_LIMIT + 1}",
         expect_status_code=400,
     )
     assert error_message_json == {
@@ -852,9 +852,11 @@ def test_returns_404s(stac_client: FlaskClient):
         f"/stac/collections/does_not_exist/items/{wrong_dataset_id}",
         message_contains="No dataset found",
     )
-    # Should be a 404, not a server or posgres error.
-    expect_404(
+    # Should be a 404, not a server or postgres error.
+    get_text_response(
+        stac_client,
         "/stac/collections/does_not_exist/items/not-a-uuid",
+        expect_status_code=404,
     )
 
 


### PR DESCRIPTION
 For a friendly front-end response, rather than giving them to the DB and causing a back-end validation error.

Fixes #364