### PR TITLE
Stac browseable catalogs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
   # Normalise all Python code. (Black + isort + pyupgrade + autoflake)
   - repo: https://github.com/Zac-HD/shed
-    rev: 0.8.0
+    rev: 0.9.0
     hooks:
     - id: shed
   # Python Linting

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         "markupsafe",
         "pyorbital",
         "pyproj",
+        "pystac",
         "python-dateutil",
         "orjson>=3",
         "shapely",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         "cachetools",
         "click",
         "datacube>=1.8",
-        "eodatasets3>=0.24.1",
+        "eodatasets3>=0.25.0",
         "fiona",
         "flask",
         "Flask-Caching",


### PR DESCRIPTION
- [x] Separate the stac collections into smaller sub-catalogs. (these can be paged without extreme inefficiencies)
- [x] Use pystac where possible, not dicts.
- [ ] Move `Arrivals` to be a catalog, not collection.
- [ ] Ensure conformance with the newer Stac-API beta