### PR TITLE
remove region from region table if all relating datasets are archived

### DIFF
--- a/integration_tests/test_region_tiles.py
+++ b/integration_tests/test_region_tiles.py
@@ -9,8 +9,6 @@ from datacube.utils import read_documents
 from flask.testing import FlaskClient
 from flask import Response
 
-from cubedash.summary import SummaryStore
-
 from integration_tests.asserts import check_dataset_count, get_html
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
@@ -139,54 +137,19 @@ def test_tmad_region_dataset_count(client: FlaskClient):
     assert len(search_results) == 1
 
 
-def test_tmad_archived_dataset_region(client: FlaskClient, run_generate, summary_store: SummaryStore):
-    rv: Response = client.get(
-            "product/ls5_nbart_tmad_annual/regions/8_-36"
-        )
-    assert rv.status == '200 OK'
-
-    html = get_html(client, "product/ls5_nbart_tmad_annual/regions/8_-36")
-
-    search_results = html.find(".search-result a")
-    assert len(search_results) == 1
-
-    rv: Response = client.get(
-            "product/ls5_nbart_tmad_annual/regions/madeup-36"
-        )
-    assert rv.status == '404 NOT FOUND'
-
-    index = summary_store.index
-
+def test_tmad_archived_dataset_region(client: FlaskClient, run_generate, module_dea_index):
     try:
         # now  index one tile that sole represents a region
-        index.datasets.archive(['867050c5-f854-434b-8b16-498243a5cf24'])
+        module_dea_index.datasets.archive(['867050c5-f854-434b-8b16-498243a5cf24'])
 
         # ... the next generation should catch it and update with one less dataset....
         run_generate("ls5_nbart_tmad_annual")
 
-        html = get_html(client, "product/ls5_nbart_tmad_annual/regions/8_-36")
-
-        search_results = html.find(".search-result a")
-        assert len(search_results) == 0
-
         rv: Response = client.get(
             "product/ls5_nbart_tmad_annual/regions/8_-36"
         )
-        assert rv.status == 404
+        assert rv.status_code == 404
 
     finally:
         # Now let's restore the dataset!
-        index.datasets.restore(['867050c5-f854-434b-8b16-498243a5cf24'])
-
-    # It should be in the count again.
-    # (this change should work because the new 'updated' column will be bumped on restore)
-    run_generate("ls5_nbart_tmad_annual")
-    rv: Response = client.get(
-            "product/ls5_nbart_tmad_annual/regions/8_-36"
-        )
-    assert rv.status == '200 OK'
-
-    html = get_html(client, "product/ls5_nbart_tmad_annual/regions/8_-36")
-
-    search_results = html.find(".search-result a")
-    assert len(search_results) == 1
+        module_dea_index.datasets.restore(['867050c5-f854-434b-8b16-498243a5cf24'])

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -15,8 +15,6 @@ from datacube.utils import read_documents
 from dateutil import tz
 from dateutil.tz import tzutc
 
-from flask.testing import FlaskClient
-
 from cubedash import _utils
 from cubedash._utils import alchemy_engine
 from cubedash.summary import SummaryStore
@@ -160,7 +158,7 @@ def test_generate_scene_all_time(run_generate, summary_store: SummaryStore):
     )
 
 
-def test_generate_incremental_archivals(client: FlaskClient, run_generate, summary_store: SummaryStore):
+def test_generate_incremental_archivals(run_generate, summary_store: SummaryStore):
     run_generate("ls8_nbar_scene")
     index = summary_store.index
 

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -24,7 +24,6 @@ from cubedash.summary._extents import GridRegionInfo
 from cubedash.summary._schema import CUBEDASH_SCHEMA
 
 from .asserts import expect_values as _expect_values
-from integration_tests.asserts import check_dataset_count, get_html
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 
@@ -169,10 +168,6 @@ def test_generate_incremental_archivals(client: FlaskClient, run_generate, summa
     original_summary = summary_store.get("ls8_nbar_scene")
     original_dataset_count = original_summary.dataset_count
 
-    html = get_html(client, "/ls8_nbar_scene")
-
-    check_dataset_count(html, original_dataset_count)
-
     # ... and we archive one dataset ...
     product_name = "ls8_nbar_scene"
     dataset_id = _one_dataset(index, product_name)
@@ -185,10 +180,6 @@ def test_generate_incremental_archivals(client: FlaskClient, run_generate, summa
             summary_store.get("ls8_nbar_scene").dataset_count
             == original_dataset_count - 1
         ), "Expected dataset count to decrease after archival"
-
-        html = get_html(client, "/ls8_nbar_scene")
-
-        check_dataset_count(html, original_dataset_count-1)
     finally:
         # Now let's restore the dataset!
         index.datasets.restore([dataset_id])
@@ -199,9 +190,6 @@ def test_generate_incremental_archivals(client: FlaskClient, run_generate, summa
     assert (
         summary_store.get("ls8_nbar_scene").dataset_count == original_dataset_count
     ), "A dataset that was restored from archival was not refreshed by Explorer"
-    html = get_html(client, "/ls8_nbar_scene")
-
-    check_dataset_count(html, original_dataset_count)
 
 
 def _one_dataset(index: Index, product_name: str):


### PR DESCRIPTION
Fixes #395 

## Scope

- extend existing test case to include  testing for handling of region after all datasets are archived for the region
- extend region SQL to delete the row if no matching region is in `dataset_spatial`