### PR TITLE
Display no matching region product with grey color in product selection 

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -305,7 +305,7 @@ def region_page(
     )
 
     same_region_products = list(
-        _model.STORE.find_products_for_region(
+        product.name for product in _model.STORE.find_products_for_region(
             region_code, year, month, day, limit=limit + 1, offset=offset
         )
     )

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -304,6 +304,12 @@ def region_page(
         )
     )
 
+    same_region_products = list(
+        _model.STORE.find_products_for_region(
+            region_code, year, month, day, limit=limit + 1, offset=offset
+        )
+    )
+
     def url_with_offset(new_offset: int):
         """Currently request url with a different offset."""
         page_args = dict(flask.request.view_args)
@@ -340,6 +346,7 @@ def region_page(
         # Summary for the users' currently selected filters.
         selected_summary=selected_summary,
         datasets=datasets,
+        same_region_products=same_region_products,
         previous_page_url=previous_page_url,
         next_page_url=next_page_url,
         time_selector_summary=time_selector_summary,

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -638,7 +638,7 @@ def products_by_region(
         query = query.where(
             DATASET_SPATIAL.c.center_time > bindparam("from_time", time_range.begin)
         ).where(DATASET_SPATIAL.c.center_time < bindparam("to_time", time_range.end))
-    
+
     query = (
         query.order_by(DATASET_SPATIAL.c.dataset_type_ref)
         .limit(bindparam("limit", limit))
@@ -646,7 +646,7 @@ def products_by_region(
     )
 
     return (
-        index.products.get_by_name(res.dataset_type_ref)
+        index.products.get(res.dataset_type_ref)
         for res in engine.execute(query).fetchall()
     )
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1651,7 +1651,7 @@ class SummaryStore:
         day: int,
         limit: int,
         offset: int = 0,
-    ) -> Iterable[Dataset]:
+    ) -> Iterable[DatasetType]:
 
         time_range = _utils.as_time_range(
             year, month, day, tzinfo=self.grouping_timezone

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1643,6 +1643,28 @@ class SummaryStore:
             offset=offset,
         )
 
+    def find_products_for_region(
+        self,
+        region_code: str,
+        year: int,
+        month: int,
+        day: int,
+        limit: int,
+        offset: int = 0,
+    ) -> Iterable[Dataset]:
+
+        time_range = _utils.as_time_range(
+            year, month, day, tzinfo=self.grouping_timezone
+        )
+        return _extents.products_by_region(
+            self._engine,
+            self.index,
+            region_code,
+            time_range,
+            limit,
+            offset=offset,
+        )
+
     @ttl_cache(ttl=DEFAULT_TTL)
     def _region_summaries(self, product_name: str) -> Dict[str, RegionSummary]:
         dt = self.get_dataset_type(product_name)

--- a/cubedash/templates/layout/product-section.html
+++ b/cubedash/templates/layout/product-section.html
@@ -57,7 +57,7 @@
                                 <h3 class="group-name">{{ group_name or ('&nbsp;'|safe)}}</h3>
                                 <ul class="items">
                                     {% for product_opt, summary in product_summaries %}
-                                        <li class="{% if (not same_region_products and ((not summary) or summary.dataset_count == 0)) or (same_region_products and product_opt.id not in same_region_products) %}empty{% endif %}">
+                                        <li class="{% if (not same_region_products and ((not summary) or summary.dataset_count == 0)) or (same_region_products and product_opt.name not in same_region_products) %}empty{% endif %}">
                                             <a href="{{ url_for(request.url_rule.endpoint, product_name=product_opt.name, **additional_page_args) }}"
                                                title="{{ product_opt.definition.description }}"
                                                class="option-menu-link {% if product_opt.name == product.name %}active{% endif %}">

--- a/cubedash/templates/layout/product-section.html
+++ b/cubedash/templates/layout/product-section.html
@@ -57,7 +57,7 @@
                                 <h3 class="group-name">{{ group_name or ('&nbsp;'|safe)}}</h3>
                                 <ul class="items">
                                     {% for product_opt, summary in product_summaries %}
-                                        <li class="{% if (not summary) or summary.dataset_count == 0 %}empty{% endif %}">
+                                        <li class="{% if (not same_region_products and ((not summary) or summary.dataset_count == 0)) or (same_region_products and product_opt.id not in same_region_products) %}empty{% endif %}">
                                             <a href="{{ url_for(request.url_rule.endpoint, product_name=product_opt.name, **additional_page_args) }}"
                                                title="{{ product_opt.definition.description }}"
                                                class="option-menu-link {% if product_opt.name == product.name %}active{% endif %}">

--- a/integration_tests/data/ls7_nbart_tmad_annual-sample.yaml
+++ b/integration_tests/data/ls7_nbart_tmad_annual-sample.yaml
@@ -1,0 +1,75 @@
+---
+# EO1 Dataset
+# url: https://explorer.dev.dea.ga.gov.au/dataset/ad1619d3-3830-4969-a8f9-7b341c10f942.odc-metadata.yaml
+id: ad1619d3-3830-4969-a8f9-7b341c10f942
+product_type: surface_reflectance_triple_mad
+creation_dt: '2018-12-26T16:48:32.304782'
+platform:
+  code: LANDSAT_7
+instrument:
+  name: ETM+
+format:
+  name: GeoTIFF
+extent:
+  coord:
+    ll:
+      lat: -3.276641070461508e+01
+      lon: 1.4061023025436907e+02
+    lr:
+      lat: -3.2702404943913415e+01
+      lon: 1.4168261970358134e+02
+    ul:
+      lat: -3.1874201521237953e+01
+      lon: 1.405384063667321e+02
+    ur:
+      lat: -3.1810810325945294e+01
+      lon: 1.4160191424847983e+02
+  to_dt: '2010-01-01T00:00:00'
+  from_dt: '2010-01-01T00:00:00'
+  center_dt: '2010-01-01T00:00:00'
+grid_spatial:
+  projection:
+    valid_data:
+      type: Polygon
+      coordinates:
+      - - - 8.e+05
+          - -3.545277379062803e+06
+        - - 8.e+05
+          - -3.5e+06
+        - - 9.e+05
+          - -3.5e+06
+        - - 9.e+05
+          - -3.6e+06
+        - - 8.e+05
+          - -3.6e+06
+        - - 8.e+05
+          - -3.545277379062803e+06
+    geo_ref_points:
+      ll:
+        x: 8.e+05
+        y: -3.6e+06
+      lr:
+        x: 9.e+05
+        y: -3.6e+06
+      ul:
+        x: 8.e+05
+        y: -3.5e+06
+      ur:
+        x: 9.e+05
+        y: -3.5e+06
+    spatial_reference: EPSG:3577
+image:
+  bands:
+    edev:
+      path: ls7_tmad_nbart_8_-36_20100101_edev.tif
+    sdev:
+      path: ls7_tmad_nbart_8_-36_20100101_sdev.tif
+    bcdev:
+      path: ls7_tmad_nbart_8_-36_20100101_bcdev.tif
+lineage:
+  source_datasets: {}
+statistics:
+  step: 1y
+  period: 1y
+location: s3://dea-public-data-dev/tmad-annual/ls7/x_8/y_-36/2010/01/01/ls7_tmad_nbart_8_-36_20100101.yaml
+...

--- a/integration_tests/data/products/ls7_nbart_tmad_annual.odc-product.yaml
+++ b/integration_tests/data/products/ls7_nbart_tmad_annual.odc-product.yaml
@@ -1,0 +1,42 @@
+---
+# Product
+# url: https://explorer.dev.dea.ga.gov.au/products/ls7_nbart_tmad_annual.odc-product.yaml
+name: ls7_nbart_tmad_annual
+metadata_type: eo
+description: Surface Reflectance Triple Median Absolute Deviation 25 metre, 100km
+  tile, Australian Albers Equal Area projection (EPSG:3577)
+metadata:
+  product_type: surface_reflectance_triple_mad
+  platform:
+    code: LANDSAT_7
+  instrument:
+    name: ETM+
+  statistics:
+    period: 1y
+measurements:
+- name: sdev
+  dtype: float32
+  units: '1'
+  nodata: NaN
+- name: edev
+  dtype: float32
+  units: '1'
+  nodata: NaN
+- name: bcdev
+  dtype: float32
+  units: '1'
+  nodata: NaN
+storage:
+  crs: EPSG:3577
+  driver: GeoTIFF
+  tile_size:
+    x: 1.e+05
+    y: 1.e+05
+  resolution:
+    x: 25
+    y: -25
+  dimension_order:
+  - time
+  - y
+  - x
+...


### PR DESCRIPTION
Fixes #57 

## Scope: 
- add a test case for checking the product selection menu while on the region page, only products containing the same region will display in white and every other product display in grey (indicating empty)
- add product `ls7_nbart_tmad_annual` and one dataset sharing the same region_code as a dataset in `ls5_nbart_tmad_annual`
- if on region pages, product selection will grey out all products without matching region_code
- On any other page, only products with empty datasets will be greyed out.

![image](https://user-images.githubusercontent.com/24644475/178188962-2a6f1ab0-45a6-492d-97de-6fb64bc63f44.png)
