### PR TITLE
add cubedash_hide_products_by_name_list config

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ You can alter default [Flask](http://flask.pocoo.org/docs/1.0/config/) or
     CUBEDASH_SISTER_SITES = None
     # CUBEDASH_SISTER_SITES = (('Production - ODC', 'http://prod.odc.example'), ('Production - NCI', 'http://nci.odc.example'), )
 
+    CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST = None
+    # CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST = [
+    #    "ls5_pq_scene",
+    #    "ls7_pq_scene",
+    # ]
+
     # How many days of recent datasets to show on the "/arrivals" page?
     CUBEDASH_DEFAULT_ARRIVALS_DAY_COUNT = 14
 

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -455,6 +455,15 @@ def inject_globals():
         grouped_products=_get_grouped_products(),
         # All products in the datacube, summarised or not.
         datacube_products=list(_model.STORE.index.products.get_all()),
+        hidden_product_list=app.config.get(
+            "CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST", [
+                "ls5_pq_scene",
+                "ls7_pq_scene",
+                "ls8_pq_scene",
+                "ls5_pq_legacy_scene",
+                "ls7_pq_legacy_scene",
+            ]
+        ),
         datacube_metadata_types=list(_model.STORE.index.metadata_types.get_all()),
         current_time=datetime.utcnow(),
         datacube_version=datacube.__version__,

--- a/cubedash/static/base.css
+++ b/cubedash/static/base.css
@@ -149,6 +149,14 @@ ul {
   left: initial;
   right: 0;
 }
+.header #menu-link .ex-menu.is-open > ul li .hide {
+  display: none;
+}
+.header #menu-link .ex-menu.is-open > ul li #show-hidden-product {
+  text-align: right;
+  color: #000;
+  font-size: 12px;
+}
 
 .logo-text, .instance-title {
   display: inline-block;

--- a/cubedash/static/base.sass
+++ b/cubedash/static/base.sass
@@ -201,6 +201,14 @@ ul
             // Above maps etc.
             z-index: 10000
 
+            li
+                .hide
+                    display: none
+                #show-hidden-product
+                    text-align: right
+                    color: #000
+                    font-size:12px
+
 .logo-text, .instance-title
     display: inline-block
     @include box_padding(1, 1, 0)

--- a/cubedash/templates/dscount-report.html
+++ b/cubedash/templates/dscount-report.html
@@ -5,13 +5,16 @@
 
 {% block content %}
     <div class="panel highlight">
-        <h2 class="followed lonesome">Bulk Dataset Counts</h2>
-        <span class="header-follow">
+        <h2 class="followed lonesome">Bulk Dataset Counts - {{ (products_period_dscount | length ) - (hidden_product_list | length) }} Products</h2>
+        <div class="">
+            Total indexed products: <span class="indexed-product-count">{{ products_period_dscount | length }}</span>,
+            hidden products: <span class="hidden-product-count">{{ hidden_product_list | length }}</span> <br/>
+            Download csv for all products dataset count
             <a href="{{ url_for('.dsreport_csv') }}" class="badge header-badge">
                 csv
                 <i class="fa fa-file-excel-o" aria-hidden="true"></i>
             </a>
-        </span>
+        </div>
     </div>
     <div class="panel">
         <p>
@@ -29,6 +32,7 @@
 
                 <tbody>
                     {% for period, count in products_period_dscount.items() %}
+                    {% if period[0] not in hidden_product_list %}
                         <tr id="{{period[0]}}-{{period[1] or ''}}-{{period[2] or ''}}">
                             <td>{{ period[0] }}</td>
                             <td>{{ period[1] or '' }}</td>
@@ -42,8 +46,8 @@
                                     {{ count }}
                                 </a>
                             </td>
-
                         </tr>
+                    {% endif %}
                     {% endfor %}
                 </tbody>
         </table>

--- a/cubedash/templates/layout/base.html
+++ b/cubedash/templates/layout/base.html
@@ -50,11 +50,21 @@
                     </ul>
                 </li>
                 {%- endif -%}
-                <li class="top-menu ex-menu">
+                <li class="top-menu ex-menu" id="products-menu">
                     <span class="ex-menu-title">Products</span>
                     <ul>
                         {% for product in datacube_products %}
-                            <li><a href="{{ url_for('product_page', product_name=product.name) }}">{{ product.name }}</a></li>
+                            {% if product.name not in hidden_product_list %}
+                                <li><a class="datacube-product-name" href="{{ url_for('product_page', product_name=product.name) }}">{{ product.name }}</a></li>
+                            {% endif %}
+                        {% endfor %}
+                        {% if hide_product_list %}
+                        <li><a id="show-hidden-product">Show hidden products</a></li>
+                        {% endif %}
+                        {% for product in datacube_products %}
+                            {% if product.name in hidden_product_list %}
+                                <li><a class="configured-hide-product hide" href="{{ url_for('product_page', product_name=product.name) }}">{{ product.name }}</a></li>
+                            {% endif %}
                         {% endfor %}
                     </ul>
                 </li>
@@ -210,6 +220,21 @@
             });
         }
     );
+
+    var showHiddenProduct = document.getElementById("show-hidden-product");
+    showHiddenProduct.addEventListener("click", function(event) {
+        if (showHiddenProduct.innerHTML === "Show hidden products") {
+            showHiddenProduct.innerHTML = "Show non-hidden products";
+        } else {
+            showHiddenProduct.innerHTML = "Show hidden products";
+        }
+        document.querySelectorAll(".datacube-product-name").forEach(function(el) {
+            el.classList.toggle("hide");
+        });
+        document.querySelectorAll(".configured-hide-product").forEach(function(el) {
+            el.classList.toggle("hide");
+        });
+    });
 
 </script>
 </body>

--- a/cubedash/templates/layout/base.html
+++ b/cubedash/templates/layout/base.html
@@ -58,7 +58,7 @@
                                 <li><a class="datacube-product-name" href="{{ url_for('product_page', product_name=product.name) }}">{{ product.name }}</a></li>
                             {% endif %}
                         {% endfor %}
-                        {% if hide_product_list %}
+                        {% if hidden_product_list %}
                         <li><a id="show-hidden-product">Show hidden products</a></li>
                         {% endif %}
                         {% for product in datacube_products %}

--- a/cubedash/templates/layout/product-section.html
+++ b/cubedash/templates/layout/product-section.html
@@ -57,6 +57,7 @@
                                 <h3 class="group-name">{{ group_name or ('&nbsp;'|safe)}}</h3>
                                 <ul class="items">
                                     {% for product_opt, summary in product_summaries %}
+                                    {% if product_opt.name not in hidden_product_list %}
                                         <li class="{% if (not same_region_products and ((not summary) or summary.dataset_count == 0)) or (same_region_products and product_opt.name not in same_region_products) %}empty{% endif %}">
                                             <a href="{{ url_for(request.url_rule.endpoint, product_name=product_opt.name, **additional_page_args) }}"
                                                title="{{ product_opt.definition.description }}"
@@ -64,6 +65,7 @@
                                                 {{ product_opt.name }}
                                             </a>
                                         </li>
+                                    {% endif %}
                                     {% endfor %}
                                 </ul>
                             </li>

--- a/cubedash/templates/products.html
+++ b/cubedash/templates/products.html
@@ -14,7 +14,8 @@
 
 {% block content %}
     <div class="panel highlight">
-        <h2 class="followed lonesome">{{ datacube_products | count }} Products</h2>
+        <h2 class="followed lonesome">{{ (datacube_products | count ) - (hidden_product_list | length) }} Products</h2>
+        <span class="header-follow">Total products: {{ datacube_products | count }}, Hidden products: {{ hidden_product_list | length }} </span>
         <div class="header-follow">
             <a href="{{ url_for('product.product_list_text') }}"
                class="badge header-badge">
@@ -44,6 +45,7 @@
             {% endif %}
             <tbody>
                 {% for product, summary in product_summaries %}
+                {% if product.name not in hide_product_list %}
                     <tr class="collapse-when-small">
                         <td>
                             <a href="{{ url_for('product_page', product_name=product.name) }}"
@@ -53,6 +55,7 @@
                             {{- product.definition.description -}}
                         </td>
                     </tr>
+                {% endif %}
                 {% else %}
                     <tr><td>No products in index</td></tr>
                 {% endfor %}

--- a/cubedash/templates/products.html
+++ b/cubedash/templates/products.html
@@ -15,7 +15,10 @@
 {% block content %}
     <div class="panel highlight">
         <h2 class="followed lonesome">{{ (datacube_products | count ) - (hidden_product_list | length) }} Products</h2>
-        <span class="header-follow">Total products: {{ datacube_products | count }}, Hidden products: {{ hidden_product_list | length }} </span>
+        <span class="header-follow">
+            Total products: <span class="indexed-product-count">{{ datacube_products | count }}</span>,
+            Hidden products: <span class="hidden-product-count">{{ hidden_product_list | length }}</span>
+        </span>
         <div class="header-follow">
             <a href="{{ url_for('product.product_list_text') }}"
                class="badge header-badge">

--- a/cubedash/templates/storage.html
+++ b/cubedash/templates/storage.html
@@ -27,10 +27,15 @@
 {% endblock %}
 {% block content %}
     <div class="panel highlight">
-        <h2 class="followed lonesome">Storage of {{ product_summary_and_location | length }} products</h2>
+        <h2 class="followed lonesome">Storage of {{ (product_summary_and_location | length) - (hidden_product_list | length) }} products</h2>
         <div class="header-follow">
             Open Data Cube {{ datacube_version }}
             {# TODO: Links to Website, CMI Metadata, DEA, ODC, help? #}
+        </div>
+        <div class="">
+            Total indexed products: <span class="indexed-product-count">{{ product_summary_and_location | length}}</span>,
+            hidden products: <span class="hidden-product-count">{{ hidden_product_list | length }}</span> <br/>
+            Download csv for all products locations:
             <a href="{{ url_for('product.storage_csv') }}" class="badge header-badge">csv <i class="fa fa-file-excel-o" aria-hidden="true"></i></a>
         </div>
     </div>
@@ -50,6 +55,7 @@
             </thead>
             <tbody>
                 {% for product, summary, locations in product_summary_and_location %}
+                {% if product.name not in hidden_product_list %}
                 <tr>
                     <td>{{ product.name | product_link }}</td>
                     <td class="numeric">{{ '{:,d}'.format(summary.dataset_count) }}</td>
@@ -84,6 +90,7 @@
                     {% endif %}
                 </td>
                 </tr>
+                {% endif %}
               {% endfor %}
             </tbody>
         </table>

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -206,6 +206,8 @@ def empty_client(summary_store: SummaryStore) -> FlaskClient:
     _model.cache.clear()
     _model.STORE = summary_store
     cubedash.app.config["TESTING"] = True
+    cubedash.app.config["CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST"] = []
+    cubedash.app.config["CUBEDASH_SISTER_SITES"] = None
     return cubedash.app.test_client()
 
 

--- a/integration_tests/test_configurable_page_elements.py
+++ b/integration_tests/test_configurable_page_elements.py
@@ -63,6 +63,17 @@ def test_hide_products_audit_page_display(app_configured_client: FlaskClient, to
     assert str(total_indexed_products_count - 5) in h2
 
 
+def test_hide_products_product_page_display(app_configured_client: FlaskClient, total_indexed_products_count):
+    html = get_html(app_configured_client, "/products")
+    hidden_product_count = html.find("span.hidden-product-count", first=True).text
+    assert hidden_product_count == '5'
+
+    h2 = html.find("h2", first=True).text
+    indexed_product_count = html.find("span.indexed-product-count", first=True).text
+    assert indexed_product_count == str(total_indexed_products_count)
+    assert str(total_indexed_products_count - 5) in h2
+
+
 def test_hide_products_menu_display(app_configured_client: FlaskClient, total_indexed_products_count):
     html = get_html(app_configured_client, "/about")
 
@@ -70,6 +81,11 @@ def test_hide_products_menu_display(app_configured_client: FlaskClient, total_in
         "#products-menu li a.configured-hide-product"
     )
     assert len(hide_products) == 5
+
+    products_hide_show_switch = html.find(
+        "a#show-hidden-product"
+    )
+    assert products_hide_show_switch
 
     html = get_html(app_configured_client, "/products/dsm1sv10")
     products = html.find(

--- a/integration_tests/test_configurable_page_elements.py
+++ b/integration_tests/test_configurable_page_elements.py
@@ -23,7 +23,7 @@ def app_configured_client(client: FlaskClient):
         "ls5_pq_legacy_scene",
         "ls7_pq_legacy_scene",
     ]
-    return cubedash.app.test_client()
+    return client
 
 
 @pytest.fixture()

--- a/integration_tests/test_configurable_page_elements.py
+++ b/integration_tests/test_configurable_page_elements.py
@@ -2,6 +2,7 @@ import pytest
 
 from flask.testing import FlaskClient
 import cubedash
+from cubedash.summary import SummaryStore
 
 from integration_tests.asserts import (
     get_html
@@ -15,7 +16,21 @@ def app_configured_client(client: FlaskClient):
         ('Production - ODC', 'http://prod.odc.example'),
         ('Production - NCI', 'http://nci.odc.example'),
     )
+    cubedash.app.config["CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST"] = [
+        "ls5_pq_scene",
+        "ls7_pq_scene",
+        "ls8_pq_scene",
+        "ls5_pq_legacy_scene",
+        "ls7_pq_legacy_scene",
+    ]
     return cubedash.app.test_client()
+
+
+@pytest.fixture()
+def total_indexed_products_count(summary_store: SummaryStore):
+    return len(list(
+        summary_store.index.products.get_all()
+    ))
 
 
 def test_instance_title(app_configured_client: FlaskClient):
@@ -26,6 +41,41 @@ def test_instance_title(app_configured_client: FlaskClient):
         first=True
     ).text
     assert instance_title == 'Development - ODC'
+
+
+def test_hide_products_audit_page_display(app_configured_client: FlaskClient, total_indexed_products_count):
+    html = get_html(app_configured_client, "/audit/storage")
+    hidden_product_count = html.find("span.hidden-product-count", first=True).text
+    assert hidden_product_count == '5'
+
+    h2 = html.find("h2", first=True).text
+    indexed_product_count = html.find("span.indexed-product-count", first=True).text
+    assert indexed_product_count == str(total_indexed_products_count)
+    assert str(total_indexed_products_count - 5) in h2
+
+    html = get_html(app_configured_client, "/audit/dataset-counts")
+    hidden_product_count = html.find("span.hidden-product-count", first=True).text
+    assert hidden_product_count == '5'
+
+    h2 = html.find("h2", first=True).text
+    indexed_product_count = html.find("span.indexed-product-count", first=True).text
+    assert indexed_product_count == str(total_indexed_products_count)
+    assert str(total_indexed_products_count - 5) in h2
+
+
+def test_hide_products_menu_display(app_configured_client: FlaskClient, total_indexed_products_count):
+    html = get_html(app_configured_client, "/about")
+
+    hide_products = html.find(
+        "#products-menu li a.configured-hide-product"
+    )
+    assert len(hide_products) == 5
+
+    html = get_html(app_configured_client, "/products/dsm1sv10")
+    products = html.find(
+        ".product-selection-header a.option-menu-link"
+    )
+    assert total_indexed_products_count - len(products) == 5
 
 
 def test_sister_sites(app_configured_client: FlaskClient):


### PR DESCRIPTION
Fixes #404 

## Scope:
### changes to `/audit/dataset-counts` and `/audit/storage` pages
- pages will only display non-hidden products but all products are available for downloading

![image](https://user-images.githubusercontent.com/24644475/178413027-abb6c9ae-9e25-4127-b99c-c517b3185738.png)
![image](https://user-images.githubusercontent.com/24644475/178413062-55ba2f8b-358d-46ff-8c10-d66441ffd9fe.png)

### Changes to `/products` page
- only displaying non-hidden products, but all products are still available from `text`, `stac` and `yaml` download

![image](https://user-images.githubusercontent.com/24644475/178412982-1b020d9d-ba31-4045-b3fb-d0ca5771dbf7.png)

### Changes to `products` top bar menu
- the top bar products drop-down menu is the only UI component with access to hidden products, hidden products are not accessible from the `product selection by date` menu

![image](https://user-images.githubusercontent.com/24644475/178374421-f6871f17-e1f7-4620-8d95-8d1c8df7c1ff.png)
![image](https://user-images.githubusercontent.com/24644475/178374448-1066f806-c9cb-4958-a140-15767bcdc0ef.png)
