### PR TITLE
fix run generate pytest fixture

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -157,8 +157,8 @@ def clirunner(global_integration_cli_args):
 
 
 @pytest.fixture()
-def run_generate(clirunner, summary_store, multi_processed=False):
-    def do(*args, expect_success=True):
+def run_generate(clirunner, summary_store):
+    def do(*args, expect_success=True, multi_processed=False):
         args = args or ("--all",)
         if not multi_processed:
             args = ("-j", "1") + tuple(args)

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -96,7 +96,7 @@ def test_generate_month(run_generate, summary_store: SummaryStore):
 
 
 def test_generate_scene_year(run_generate, summary_store: SummaryStore):
-    run_generate()
+    run_generate(multi_processed=True)
     # One year
     _expect_values(
         summary_store.get("ls8_nbar_scene", year=2017, month=None, day=None),


### PR DESCRIPTION
`multi_processed` need to be passed to `do` function

```
>       run_generate("ls5_fc_albers", multi_processed=True)
E       TypeError: do() got an unexpected keyword argument 'multi_processed'
```