### PR TITLE
fix bulk dataset page total product counts

### DIFF
--- a/cubedash/templates/dscount-report.html
+++ b/cubedash/templates/dscount-report.html
@@ -5,9 +5,9 @@
 
 {% block content %}
     <div class="panel highlight">
-        <h2 class="followed lonesome">Bulk Dataset Counts - {{ (products_period_dscount | length ) - (hidden_product_list | length) }} Products</h2>
+        <h2 class="followed lonesome">Bulk Dataset Counts - {{ (datacube_products | length ) - (hidden_product_list | length) }} Products</h2>
         <div class="">
-            Total indexed products: <span class="indexed-product-count">{{ products_period_dscount | length }}</span>,
+            Total indexed products: <span class="indexed-product-count">{{ datacube_products | length }}</span>,
             hidden products: <span class="hidden-product-count">{{ hidden_product_list | length }}</span> <br/>
             Download csv for all products dataset count
             <a href="{{ url_for('.dsreport_csv') }}" class="badge header-badge">

--- a/integration_tests/test_configurable_page_elements.py
+++ b/integration_tests/test_configurable_page_elements.py
@@ -2,8 +2,11 @@ import pytest
 
 from flask.testing import FlaskClient
 import cubedash
-from cubedash.summary import SummaryStore
+from pathlib import Path
 
+from cubedash.summary import SummaryStore
+from datacube.index.hl import Doc2Dataset
+from datacube.utils import read_documents
 from integration_tests.asserts import (
     get_html
 )
@@ -53,6 +56,36 @@ def test_hide_products_audit_page_display(app_configured_client: FlaskClient, to
     assert indexed_product_count == str(total_indexed_products_count)
     assert str(total_indexed_products_count - 5) in h2
 
+
+TEST_DATA_DIR = Path(__file__).parent / "data"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def populate_index(dataset_loader, module_dea_index):
+    """
+    Index populated with example datasets. Assumes our tests wont modify the data!
+
+    It's module-scoped as it's expensive to populate.
+    """
+    dataset_count = 0
+    create_dataset = Doc2Dataset(module_dea_index)
+    for _, s2_dataset_doc in read_documents(TEST_DATA_DIR / "ls5_fc_albers-sample.yaml"):
+        try:
+            dataset, err = create_dataset(
+                s2_dataset_doc, "file://example.com/test_dataset/"
+            )
+            assert dataset is not None, err
+            created = module_dea_index.datasets.add(dataset)
+            assert created.type.name == "ls5_fc_albers"
+            dataset_count += 1
+        except AttributeError as ae:
+            assert dataset_count == 5
+            print(ae)
+    assert dataset_count == 5
+    return module_dea_index
+
+
+def test_hide_products_audit_bulk_dataset_display(app_configured_client: FlaskClient, total_indexed_products_count):
     html = get_html(app_configured_client, "/audit/dataset-counts")
     hidden_product_count = html.find("span.hidden-product-count", first=True).text
     assert hidden_product_count == '5'


### PR DESCRIPTION
Fixes #416 

- fix bulk dataset page test case with hidden product list by adding some datasets that spans over 2 years summary
- change `products_period_dscount` to `datacube_products` for accurate product count