### PR TITLE
add localised time and utc time on tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ You can alter default [Flask](http://flask.pocoo.org/docs/1.0/config/) or
     # Maximum number of source/derived datasets to show
     CUBEDASH_PROVENANCE_DISPLAY_LIMIT = 20
 
+    CUBEDASH_DEFAULT_TIMEZONE = "Australia/Darwin"
+
     CUBEDASH_SISTER_SITES = None
     # CUBEDASH_SISTER_SITES = (('Production - ODC', 'http://prod.odc.example'), ('Production - NCI', 'http://nci.odc.example'), )
 

--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -10,6 +10,8 @@ from typing import Mapping
 from urllib.parse import quote_plus
 
 import flask
+import pytz
+
 from datacube.index.fields import Field
 from datacube.model import Dataset, DatasetType, Range
 from dateutil import tz
@@ -19,7 +21,7 @@ from orjson import orjson
 from shapely.geometry import MultiPolygon
 
 from . import _utils, _utils as utils
-
+from . import _model
 
 # How far to step the number when the user hits up/down.
 NUMERIC_STEP_SIZE = {
@@ -45,6 +47,11 @@ def _format_datetime(date):
 @bp.app_template_filter("metadata_center_time")
 def _get_metadata_center_time(dataset):
     return utils.center_time_from_metadata(dataset)
+
+
+@bp.app_template_filter("localised_metadata_center_time")
+def _get_localised_metadata_center_time(date):
+    return date.astimezone(pytz.timezone(_model.DEFAULT_GROUPING_TIMEZONE))
 
 
 @bp.app_template_filter("printable_dataset")

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -87,6 +87,8 @@ DEFAULT_START_PAGE_PRODUCTS = app.config.get("CUBEDASH_DEFAULT_PRODUCTS") or (
     "ls5_nbar_scene",
 )
 
+DEFAULT_GROUPING_TIMEZONE = app.config.get("CUBEDASH_DEFAULT_TIMEZONE", "Australia/Darwin")
+
 _LOG = structlog.get_logger()
 
 

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -427,7 +427,7 @@ def center_time_from_metadata(dataset: Dataset) -> datetime:
         center_time = (time.begin + (time.end - time.begin) / 2)
     except AttributeError:
         center_time = dataset.center_time
-    return center_time
+    return default_utc(center_time)
 
 
 def as_rich_json(o):

--- a/cubedash/templates/search.html
+++ b/cubedash/templates/search.html
@@ -110,12 +110,12 @@
             </p>
             <table class="data-table">
                 <thead>
-                <th>Time</th>
+                <th>Time (local)</th>
                 <th>Label</th>
                 </thead>
                 {% for dataset in datasets %}
                     <tr class="search-result">
-                        <td>{{ dataset | metadata_center_time | printable_time }}</td>
+                        <td title="Time UTC: {{ dataset | metadata_center_time | printable_time }}">{{ dataset | metadata_center_time | localised_metadata_center_time | printable_time }}</td>
                         <td>
                             <a href='{{ url_for('dataset.dataset_page', id_=dataset.id) }}'>{{ dataset | printable_dataset }}</a>
                         </td>

--- a/integration_tests/test_center_datetime_logic.py
+++ b/integration_tests/test_center_datetime_logic.py
@@ -60,8 +60,8 @@ def test_datestring_on_datasets_search_page(client: FlaskClient):
     html = get_html(client, "/products/rainfall_chirps_daily/datasets")
 
     assert (
-        "2019-05-15 00:00:00" in [
-            a.find("td", first=True).text.strip() for a in html.find(".search-result")
+        "Time UTC: 2019-05-15 00:00:00" in [
+            a.find("td", first=True).attrs["title"] for a in html.find(".search-result")
         ]
     ), "datestring does not match expected center_time recorded in dataset_spatial table"
 

--- a/integration_tests/test_utc_tst.py
+++ b/integration_tests/test_utc_tst.py
@@ -51,3 +51,27 @@ def test_yearly_dataset_count(client: FlaskClient):
 
     html = get_html(client, "/ls5_fc_albers/2011")
     check_dataset_count(html, 3)
+
+
+def test_dataset_search_page_localised_time(client: FlaskClient):
+    html = get_html(client, "/products/ls5_fc_albers/datasets/2011")
+
+    assert (
+        "2011-01-01 09:03:13" in [
+            a.find("td", first=True).text.strip() for a in html.find(".search-result")
+        ]
+    ), "datestring does not match expected center_time recorded in dataset_spatial table"
+
+    assert (
+        "Time UTC: 2010-12-31 23:33:13" in [
+            a.find("td", first=True).attrs["title"] for a in html.find(".search-result")
+        ]
+    ), "datestring does not match expected center_time recorded in dataset_spatial table"
+
+    html = get_html(client, "/products/ls5_fc_albers/datasets/2010")
+
+    assert (
+        "2010-12-31 09:56:02" in [
+            a.find("td", first=True).text.strip() for a in html.find(".search-result")
+        ]
+    ), "datestring does not match expected center_time recorded in dataset_spatial table"

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "datacube>=1.8",
         "eodatasets3>=0.24.1",
         "fiona",
-        "flask",
+        "flask==2.1.3",
         "Flask-Caching",
         "flask-cors",
         "flask-themer>=1.4.3",


### PR DESCRIPTION
fixes #419, #420 

## Scope
- add tooltip for displaying time in UTC equiv
- make search page for datasets display in local time
- add flask app config for `CUBEDASH_DEFAULT_TIMEZONE`
- add `CUBEDASH_DEFAULT_TIMEZONE` config to README
- make `center_time_from_metadata` filter to always return time in `default_utc`
- Change column name `Time` to `Time (local)` for clarity
- add test case for checking both localised time and UTC time on tooltip 

## build fix
latest flask library is broken, pin to `2.1.3`

## Visual change

![image](https://user-images.githubusercontent.com/24644475/182515292-2552680c-8fb2-4ba4-a95b-4d4e408161b6.png)
