### PR TITLE
add instruction to deploy explorer with helm

### DIFF
--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -110,3 +110,46 @@ created your datacube without permissions, a stand-alone creator of the ``agdc_u
 role is available as a prerequisite in the same `roles`_
 
 .. _roles: https://github.com/opendatacube/datacube-explorer/tree/develop/cubedash/summary/roles
+
+
+Deploying with Helm Chart
+--------------------------
+
+Prerequisites
+^^^^^^^^^^^^^
+
+Make sure you have Helm `installed <https://helm.sh/docs/using_helm/#installing-helm>`_.
+
+Get Repo Info
+^^^^^^^^^^^^^^
+
+.. code::
+
+    helm repo add datacube-charts https://opendatacube.github.io/datacube-charts/charts/
+    helm repo update
+
+
+See `helm repo <https://helm.sh/docs/helm/helm_repo/>`_ for command documentation.
+
+
+Deploy with default config
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    helm upgrade --install datacube-explorer datacube-charts/datacube-explorer
+
+
+Deploy in a custom namespace
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code::
+
+    helm upgrade --install datacube-explorer --namespace=web datacube-charts/datacube-explorer
+
+Chart values
+^^^^^^^^^^^^
+
+.. code::
+
+    helm show values datacube-charts/datacube-explorer


### PR DESCRIPTION
fixes #481 

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--485.org.readthedocs.build/en/485/

<!-- readthedocs-preview datacube-explorer end -->