### PR TITLE
Make it easier to browse dataset s3 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ You can alter default [Flask](http://flask.pocoo.org/docs/1.0/config/) or
     default_map_zoom = 3
     default_map_center = [-26.2756326, 134.9387844]
 
+    # S3 buckets for which data browser url should be returned
+    SHOW_DATA_LOCATION = { "dea-public-data": "data.dea.ga.gov.au" }
 
 [Sentry](https://sentry.io/) error reporting is supported by adding a `SENTRY_CONFIG` section.
 See [their documentation](https://docs.sentry.io/clients/python/integrations/flask/#settings).

--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -125,13 +125,8 @@ def _dataset_file_paths(dataset: Dataset):
 @bp.app_template_filter("dataset_thumbnail_url")
 def _dataset_thumbnail_url(dataset: Dataset):
     file_paths = _dataset_file_paths(dataset)
-    if "thumbnail:nbart" in file_paths:
-        offset = file_paths["thumbnail:nbart"]
-    elif "thumbnail" in file_paths:
-        offset = file_paths["thumbnail"]
-    else:
-        return ""
-    return _to_remote_url(offset, dataset.uris[0])
+    offset = file_paths.get("thumbnail:nbart") or file_paths.get("thumbnail")
+    return "" if not offset else _to_remote_url(offset, dataset.uris[0])
 
 
 @bp.app_template_filter("resolve_remote_url")

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -136,7 +136,7 @@ def get_dataset_file_offsets(dataset: Dataset) -> Dict[str, str]:
 
 def as_resolved_remote_url(location: str, offset: str) -> str:
     """
-    Convert a dataset location and file offset to a full remote URL. 
+    Convert a dataset location and file offset to a full remote URL.
     """
     return as_external_url(
         urljoin(location, offset),
@@ -145,7 +145,9 @@ def as_resolved_remote_url(location: str, offset: str) -> str:
     )
 
 
-def as_external_url(url: str, s3_region: str = None, is_base: bool = False) -> Optional[str]:
+def as_external_url(
+    url: str, s3_region: str = None, is_base: bool = False
+) -> Optional[str]:
     """
     Convert a URL to an externally-visible one.
 
@@ -170,7 +172,7 @@ def as_external_url(url: str, s3_region: str = None, is_base: bool = False) -> O
             path = parsed.path[1:]
             if is_base:
                 # if it's the folder url, get the directory path
-                path = path[:path.rindex("/")+1]
+                path = path[: path.rindex("/") + 1]
                 path = f"?prefix={path}"
             return f"https://{data_location.get(parsed.netloc)}/{path}"
 

--- a/cubedash/static/base.css
+++ b/cubedash/static/base.css
@@ -1151,6 +1151,11 @@ details > summary {
   max-height: none !important;
 }
 
+/* Unset image overlay width to preserve correct image aspect ratio */
+.leaflet-container img.leaflet-image-layer {
+  width: unset !important;
+}
+
 .leaflet-container.leaflet-touch-zoom {
   -ms-touch-action: pan-x pan-y;
   touch-action: pan-x pan-y;

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -122,7 +122,7 @@ The following configuration values are used internally by Datacube-explorer:
 .. py:data:: SHOW_DATA_LOCATION
 
     S3 buckets for which to return a browseable bucket link instead of the plain S3 link
-    
+
     Default: ``{}``
     Example: ``{ 'dea-public-data': 'data.dea.ga.gov.au'}``
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -119,6 +119,13 @@ The following configuration values are used internally by Datacube-explorer:
 
     Default: ``odc``
 
+.. py:data:: SHOW_DATA_LOCATION
+
+    S3 buckets for which to return a browseable bucket link instead of the plain S3 link
+    
+    Default: ``{}``
+    Example: ``{ 'dea-public-data': 'data.dea.ga.gov.au'}``
+
 .. py:data:: default_map_center
 
     Leaflet map https://leafletjs.com/reference.html#map-center, variates by explorer theme.

--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -88,6 +88,8 @@ You can alter default config values, all the Explorer application config setting
     default_map_zoom = 3
     default_map_center = [-26.2756326, 134.9387844]
 
+    # S3 buckets for which data browser url should be returned
+    SHOW_DATA_LOCATION = { "dea-public-data": "data.dea.ga.gov.au" }
 
 Sentry error reporting is supported and can be setup as per :any:`sentry-env`
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -241,6 +241,7 @@ def empty_client(summary_store: SummaryStore) -> FlaskClient:
     cubedash.app.config["TESTING"] = True
     cubedash.app.config["CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST"] = []
     cubedash.app.config["CUBEDASH_SISTER_SITES"] = None
+    cubedash.app.config["SHOW_DATA_LOCATION"] = { "dea-public-data": "data.dea.ga.gov.au"}
     return cubedash.app.test_client()
 
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -241,7 +241,9 @@ def empty_client(summary_store: SummaryStore) -> FlaskClient:
     cubedash.app.config["TESTING"] = True
     cubedash.app.config["CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST"] = []
     cubedash.app.config["CUBEDASH_SISTER_SITES"] = None
-    cubedash.app.config["SHOW_DATA_LOCATION"] = { "dea-public-data": "data.dea.ga.gov.au"}
+    cubedash.app.config["SHOW_DATA_LOCATION"] = {
+        "dea-public-data": "data.dea.ga.gov.au"
+    }
     return cubedash.app.test_client()
 
 

--- a/integration_tests/test_resolved_uri.py
+++ b/integration_tests/test_resolved_uri.py
@@ -24,6 +24,7 @@ def app_s3_region_none():
 def app_s3_region_string_none():
     app = Flask(__name__)
     app.config["CUBEDASH_DATA_S3_REGION"] = "None"
+    app.config["SHOW_DATA_LOCATION"] = { "dea-public-data": "data.dea.ga.gov.au"}
     return app
 
 
@@ -34,30 +35,31 @@ def app_s3_region_empty_string():
     return app
 
 
-def test_as_external_url():
-    assert (
-        as_external_url(
-            "s3://some-data/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml",
-            "",
+def test_as_external_url(app_s3_region_unset):
+    with app_s3_region_unset.app_context():
+        assert (
+            as_external_url(
+                "s3://some-data/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml",
+                "",
+            )
+            == "s3://some-data/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml"
         )
-        == "s3://some-data/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml"
-    )
 
-    assert (
-        as_external_url(
-            "s3://some-data/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml",
-            "None",
+        assert (
+            as_external_url(
+                "s3://some-data/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml",
+                "None",
+            )
+            == "https://some-data.s3.None.amazonaws.com/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml"
         )
-        == "https://some-data.s3.None.amazonaws.com/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml"
-    )
 
-    assert (
-        as_external_url(
-            "s3://some-data/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml",
-            None,
+        assert (
+            as_external_url(
+                "s3://some-data/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml",
+                None,
+            )
+            == "s3://some-data/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml"
         )
-        == "s3://some-data/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml"
-    )
 
 
 def test_resolved_remote_url_s3_region_unset(app_s3_region_unset):
@@ -118,3 +120,16 @@ def test_resolved_remote_url_empty_string_s3_region(app_s3_region_empty_string):
             as_resolved_remote_url(None, "s3://example.com/test_dataset/")
             == "s3://example.com/test_dataset/"
         )
+
+def test_resolved_remote_url_data_browser(app_s3_region_string_none):
+    with app_s3_region_string_none.app_context():
+        assert current_app.config.get("SHOW_DATA_LOCATION") == { "dea-public-data": "data.dea.ga.gov.au" }
+        
+        assert (
+            as_resolved_remote_url(None, "s3://dea-public-data/example/product/filepath")
+        ) == "https://data.dea.ga.gov.au/?prefix=example/product/"
+
+        assert (
+            as_resolved_remote_url("s3://dea-public-data/example/product/filepath", "offset")
+        ) == "https://data.dea.ga.gov.au/example/product/offset"
+

--- a/integration_tests/test_resolved_uri.py
+++ b/integration_tests/test_resolved_uri.py
@@ -24,7 +24,7 @@ def app_s3_region_none():
 def app_s3_region_string_none():
     app = Flask(__name__)
     app.config["CUBEDASH_DATA_S3_REGION"] = "None"
-    app.config["SHOW_DATA_LOCATION"] = { "dea-public-data": "data.dea.ga.gov.au"}
+    app.config["SHOW_DATA_LOCATION"] = {"dea-public-data": "data.dea.ga.gov.au"}
     return app
 
 
@@ -121,15 +121,21 @@ def test_resolved_remote_url_empty_string_s3_region(app_s3_region_empty_string):
             == "s3://example.com/test_dataset/"
         )
 
+
 def test_resolved_remote_url_data_browser(app_s3_region_string_none):
     with app_s3_region_string_none.app_context():
-        assert current_app.config.get("SHOW_DATA_LOCATION") == { "dea-public-data": "data.dea.ga.gov.au" }
-        
+        assert current_app.config.get("SHOW_DATA_LOCATION") == {
+            "dea-public-data": "data.dea.ga.gov.au"
+        }
+
         assert (
-            as_resolved_remote_url(None, "s3://dea-public-data/example/product/filepath")
+            as_resolved_remote_url(
+                None, "s3://dea-public-data/example/product/filepath"
+            )
         ) == "https://data.dea.ga.gov.au/?prefix=example/product/"
 
         assert (
-            as_resolved_remote_url("s3://dea-public-data/example/product/filepath", "offset")
+            as_resolved_remote_url(
+                "s3://dea-public-data/example/product/filepath", "offset"
+            )
         ) == "https://data.dea.ga.gov.au/example/product/offset"
-


### PR DESCRIPTION
As per issue #480 

Config should now include `SHOW_DATASET_LOCATION`, which is a dict that maps an s3 bucket to its browseable url. For now, that is just `dea-public-data` mapping to `data.dea.ga.gov.au`. The first 'location' link for the dataset links to the browseable folder, and all offsets to their respective links from that page.

Added test to `test_resolved_uris` to verify functionality, including that other links or s3 buckets are unaffected by this change. 

Also took the chance to clean up thumbnail work a little: made filter code more pythonic, and updated css to make image width unset so that image ratio is conserved, allowing for proper overlay even if the dataset is irregularly-shaped.
Ex:
![image](https://user-images.githubusercontent.com/40238244/202956445-e2c042ab-4962-403a-826a-542bf9f885ae.png)
vs
![image](https://user-images.githubusercontent.com/40238244/202956692-50014e1a-f050-41b6-8090-2862111ba1b0.png)


<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--488.org.readthedocs.build/en/488/

<!-- readthedocs-preview datacube-explorer end -->