### PR TITLE
Fix replace(tzinfo) bug

### DIFF
--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -131,14 +131,14 @@ class Summariser:
 
         # Initialise all requested days as zero
         day_counts = Counter(
-            {d.date(): 0 for d in pd.date_range(begin_time, end_time, closed="left")}
+            {d.to_pydatetime(): 0 for d in pd.date_range(begin_time, end_time, inclusive="left")}
         )
         region_counts = Counter()
         if has_data:
             day_counts.update(
                 Counter(
                     {
-                        day.date(): count
+                        day: count
                         for day, count in self._engine.execute(
                             select(
                                 [

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -131,7 +131,10 @@ class Summariser:
 
         # Initialise all requested days as zero
         day_counts = Counter(
-            {d.to_pydatetime(): 0 for d in pd.date_range(begin_time, end_time, inclusive="left")}
+            {
+                d.to_pydatetime(): 0
+                for d in pd.date_range(begin_time, end_time, inclusive="left")
+            }
         )
         region_counts = Counter()
         if has_data:

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -693,6 +693,11 @@ def test_api_returns_timelines(client: FlaskClient):
         "2017-04-30T00:00:00": 0,
     }
 
+    doc = get_json(client, "/api/dataset-timeline/wofs_albers/2017/04/24")
+    assert doc == {
+        "2017-04-24T00:00:00": 1,
+    }
+
 
 def test_undisplayable_product(client: FlaskClient):
     """


### PR DESCRIPTION
Have timeline dataset counter convert `day` to `datetime` instead of `date` to make `replace(tzinfo=None)` valid.

Testing locally, localhost:8080/api/dataset-timeline/ga_ls5t_ard_3/1991/11/21 now downloads a json instead of throwing a server error.

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--489.org.readthedocs.build/en/489/

<!-- readthedocs-preview datacube-explorer end -->