### PR TITLE
Fix datetime comparison error

### DIFF
--- a/cubedash/_api.py
+++ b/cubedash/_api.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import date, datetime
 
 import flask
 from flask import Blueprint, abort, request
@@ -8,7 +9,6 @@ from cubedash import _utils
 from . import _model
 from ._utils import as_geojson, as_json
 from .summary import ItemSort
-from datetime import date, datetime
 
 _LOG = logging.getLogger(__name__)
 bp = Blueprint("api", __name__, url_prefix="/api")

--- a/cubedash/_api.py
+++ b/cubedash/_api.py
@@ -8,6 +8,7 @@ from cubedash import _utils
 from . import _model
 from ._utils import as_geojson, as_json
 from .summary import ItemSort
+from datetime import date, datetime
 
 _LOG = logging.getLogger(__name__)
 bp = Blueprint("api", __name__, url_prefix="/api")
@@ -107,6 +108,8 @@ def dataset_timeline(
 
     def _datekey(k):
         # The timezone is the global grouping timezone: we don't want it in json.
+        if type(k) is date:
+            k = datetime(k.year, k.month, k.day)
         return k.replace(tzinfo=None).isoformat()
 
     return as_json(

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -131,10 +131,7 @@ class Summariser:
 
         # Initialise all requested days as zero
         day_counts = Counter(
-            {
-                d.date(): 0
-                for d in pd.date_range(begin_time, end_time, inclusive="left")
-            }
+            {d.date(): 0 for d in pd.date_range(begin_time, end_time, inclusive="left")}
         )
         region_counts = Counter()
         if has_data:

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -132,7 +132,7 @@ class Summariser:
         # Initialise all requested days as zero
         day_counts = Counter(
             {
-                d.to_pydatetime(): 0
+                d.date(): 0
                 for d in pd.date_range(begin_time, end_time, inclusive="left")
             }
         )
@@ -141,7 +141,7 @@ class Summariser:
             day_counts.update(
                 Counter(
                     {
-                        day: count
+                        day.date(): count
                         for day, count in self._engine.execute(
                             select(
                                 [


### PR DESCRIPTION
Issue #492 
Revert datetime conversion in summariser and do it directly in the api endpoint instead, to fix tzinfo issue without causing others

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--494.org.readthedocs.build/en/494/

<!-- readthedocs-preview datacube-explorer end -->