### PR TITLE
add canonical ref to item links

### DIFF
--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -232,6 +232,16 @@ def as_stac_item(dataset: DatasetItem) -> pystac.Item:
     #  many more products.
     item.properties["cubedash:region_code"] = dataset.region_code
 
+    # add canonical ref pointing to the JSON file on s3
+    if ds.uris:
+        item.links.append(
+            Link(
+                rel="canonical",
+                media_type="application/json",
+                target=_utils.as_resolved_remote_url(None, ds.uris[0]),
+            )
+        )
+
     return item
 
 

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -233,7 +233,7 @@ def as_stac_item(dataset: DatasetItem) -> pystac.Item:
     item.properties["cubedash:region_code"] = dataset.region_code
 
     # add canonical ref pointing to the JSON file on s3
-    if ds.uris:
+    if ds is not None and ds.uris:
         media_type = "application/json" if ds.uris[0].endswith("json") else "text/yaml"
         item.links.append(
             Link(

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -234,10 +234,11 @@ def as_stac_item(dataset: DatasetItem) -> pystac.Item:
 
     # add canonical ref pointing to the JSON file on s3
     if ds.uris:
+        media_type = "application/json" if ds.uris[0].endswith("json") else "text/yaml"
         item.links.append(
             Link(
                 rel="canonical",
-                media_type="application/json",
+                media_type=media_type,
                 target=_utils.as_resolved_remote_url(None, ds.uris[0]),
             )
         )

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -993,7 +993,7 @@ def test_eo3_stac_item(eo3_index, client: FlaskClient):
                 "href": "http://localhost/dataset/5b2f2c50-e618-4bef-ba1f-3d436d9aed14",
             },
             {
-                "type": "application/json",
+                "type": "text/yaml",
                 "rel": "canonical",
                 "href": "file://example.com/test_dataset/5b2f2c50-e618-4bef-ba1f-3d436d9aed14",
             },

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -998,6 +998,11 @@ def test_eo3_stac_item(eo3_index, client: FlaskClient):
                 "rel": "root",
                 "href": "http://localhost/stac",
             },
+            {
+                "type": "application/json",
+                "rel": "canonical",
+                "href": "file://example.com/test_dataset/5b2f2c50-e618-4bef-ba1f-3d436d9aed14",
+            },
         ],
     }
     assert_matching_eo3(response, expected)

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -993,15 +993,15 @@ def test_eo3_stac_item(eo3_index, client: FlaskClient):
                 "href": "http://localhost/dataset/5b2f2c50-e618-4bef-ba1f-3d436d9aed14",
             },
             {
+                "type": "application/json",
+                "rel": "canonical",
+                "href": "file://example.com/test_dataset/5b2f2c50-e618-4bef-ba1f-3d436d9aed14",
+            },
+            {
                 "title": "Default ODC Explorer instance",
                 "type": "application/json",
                 "rel": "root",
                 "href": "http://localhost/stac",
-            },
-            {
-                "type": "application/json",
-                "rel": "canonical",
-                "href": "file://example.com/test_dataset/5b2f2c50-e618-4bef-ba1f-3d436d9aed14",
             },
         ],
     }

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -880,6 +880,11 @@ def test_stac_item(stac_client: FlaskClient, odc_test_db):
                 "href": explorer_url("dataset/0c5b625e-5432-4911-9f7d-f6b894e27f3c"),
             },
             {
+                "rel": "canonical",
+                "type": "text/yaml",
+                "href": dataset_uri,
+            },
+            {
                 "title": "Default ODC Explorer instance",
                 "rel": "root",
                 "type": "application/json",

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         "python-dateutil",
         "orjson>=3",
         "sentry-sdk[flask]",
-        "shapely",
+        "shapely<2.0.0",
         "simplekml",
         "sqlalchemy>=1.4",
         "structlog>=20.2.0",


### PR DESCRIPTION
See #228

Add another item link that points to the location of the stac json file on S3 as the 'canonical' reference. 

Pin shapely version < 2.0.0.

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--510.org.readthedocs.build/en/510/

<!-- readthedocs-preview datacube-explorer end -->