### PR TITLE
update shapely version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         "python-dateutil",
         "orjson>=3",
         "sentry-sdk[flask]",
-        "shapely<2.0.0",
+        "shapely>=2.0.0",
         "simplekml",
         "sqlalchemy>=1.4",
         "structlog>=20.2.0",


### PR DESCRIPTION
Update shapely version pin to >= 2.0.0 to be compatible with datacube-core

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--511.org.readthedocs.build/en/511/

<!-- readthedocs-preview datacube-explorer end -->