### PR TITLE
Add basic /queryables endpoints

### DIFF
--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -836,6 +836,10 @@ def _stac_collection(collection: str) -> Collection:
                 rel="items",
                 target=url_for(".collection_items", collection=collection),
             ),
+            Link(
+                rel="http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                target=url_for(".collection_queryables", collection=collection),
+            ),
         ]
     )
     if all_time_summary.timeline_dataset_counts:
@@ -931,6 +935,12 @@ def root():
                 media_type="application/json",
                 target=url_for(".stac_search"),
             ),
+            Link(
+                title="Queryables",
+                rel="http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                media_type="application/json",
+                target=url_for(".queryables"),
+            ),
             # Individual Product Collections
             *(
                 Link(
@@ -1022,7 +1032,7 @@ def queryables():
     return _utils.as_json(
         {
             "$schema": "http://json-schema.org/draft-07/schema#",
-            "$id": "https://example.org/queryables",
+            "$id": flask.request.base_url,
             "type": "object",
             "title": "",
             "properties": {
@@ -1031,8 +1041,23 @@ def queryables():
                     "description": "Item identifier",
                     "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/"
                     "item.json#/definitions/core/allOf/2/properties/id",
-                }
+                },
+                "collection": {
+                    "description": "Collection",
+                    "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/"
+                    "item.json#/collection",
+                },
+                "geometry": {
+                    "description": "Geometry",
+                    "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/geometry",
+                },
+                "datetime": {
+                    "description": "Datetime",
+                    "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/"
+                    "datetime.json#/properties/datetime",
+                },
             },
+            "additionalProperties": True,
         }
     )
 
@@ -1051,7 +1076,7 @@ def collection_queryables(collection: str):
     return _utils.as_json(
         {
             "$schema": "http://json-schema.org/draft-07/schema#",
-            "$id": "https://example.org/queryables",
+            "$id": flask.request.base_url,
             "type": "object",
             "title": f"Queryables for {collection_title}",
             "properties": {
@@ -1065,6 +1090,10 @@ def collection_queryables(collection: str):
                     "description": "Collection",
                     "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/"
                     "item.json#/collection",
+                },
+                "geometry": {
+                    "description": "Geometry",
+                    "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/geometry",
                 },
                 "datetime": {
                     "description": "Datetime",

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -1012,6 +1012,71 @@ def collections():
     )
 
 
+@bp.route("/queryables")
+def queryables():
+    """
+    Define what terms are available for use when writing filter expressions for the entire catalog
+    Part of basic CQL2 conformance for stac-api filter implementation.
+    See: https://github.com/stac-api-extensions/filter#queryables
+    """
+    return _utils.as_json(
+        {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": "https://example.org/queryables",
+            "type": "object",
+            "title": "",
+            "properties": {
+                "id": {
+                    "title": "Item ID",
+                    "description": "Item identifier",
+                    "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/"
+                    "item.json#/definitions/core/allOf/2/properties/id",
+                }
+            },
+        }
+    )
+
+
+@bp.route("/collections/<collection>/queryables")
+def collection_queryables(collection: str):
+    """
+    The queryables resources for a given collection (barebones implementation)
+    """
+    try:
+        dataset_type = _model.STORE.get_dataset_type(collection)
+    except KeyError:
+        abort(404, f"Unknown collection {collection!r}")
+
+    collection_title = dataset_type.definition.get("description")
+    return _utils.as_json(
+        {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": "https://example.org/queryables",
+            "type": "object",
+            "title": f"Queryables for {collection_title}",
+            "properties": {
+                "id": {
+                    "title": "Item ID",
+                    "description": "Item identifier",
+                    "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/"
+                    "item.json#/definitions/core/allOf/2/properties/id",
+                },
+                "collection": {
+                    "description": "Collection",
+                    "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/"
+                    "item.json#/collection",
+                },
+                "datetime": {
+                    "description": "Datetime",
+                    "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/"
+                    "datetime.json#/properties/datetime",
+                },
+            },
+            "additionalProperties": True,
+        }
+    )
+
+
 @bp.route("/collections/<collection>")
 def collection(collection: str):
     """

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -587,6 +587,12 @@ def test_stac_links(stac_client: FlaskClient):
             "type": "application/json",
             "title": "Item Search",
         },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+            "href": "http://localhost/stac/queryables",
+            "type": "application/json",
+            "title": "Queryables",
+        },
     ]
 
     # All expected products and their dataset counts.
@@ -681,6 +687,10 @@ def test_stac_collection(stac_client: FlaskClient):
             {
                 "rel": "items",
                 "href": stac_url("collections/high_tide_comp_20p/items"),
+            },
+            {
+                "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                "href": stac_url("collections/high_tide_comp_20p/queryables"),
             },
             {
                 "rel": "child",

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -525,12 +525,7 @@ def test_returns_404s(stac_client: FlaskClient):
             "/collections/ls7_nbar_scene/items"
             "?datetime=2000-01-01/2000-01-01&bbox=-48.206,-14.195,-45.067,-12.272",
             "/stac/collections/ls7_nbar_scene/items"
-            + (
-                "?datetime=2000-01-01/2000-01-01&bbox=-48.206,-14.195,-45.067,-12.272"
-                # Flask will auto-escape parameters
-                # .replace(",", "%2C")
-                .replace("/", "%2F")
-            ),
+            "?datetime=2000-01-01/2000-01-01&bbox=-48.206,-14.195,-45.067,-12.272",
         ),
         (
             "/collections/ls7_nbar_scene/items/0c5b625e-5432-4911-9f7d-f6b894e27f3c",


### PR DESCRIPTION
Add barebones `/queryables` endpoints for stac api catalog and collections as part of Filter implementation.

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--515.org.readthedocs.build/en/515/

<!-- readthedocs-preview datacube-explorer end -->