### PR TITLE
added stac title if in metadata

### DIFF
--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -807,9 +807,13 @@ def _stac_collection(collection: str) -> Collection:
         (summary.time_earliest, summary.time_latest) if summary else (None, None)
     )
     footprint = all_time_summary.footprint_wgs84
+    if "title" in dataset_type.definition.get("metadata"):
+        title = dataset_type.definition.get("metadata")["title"]
+    else:
+        title = summary.name
     stac_collection = Collection(
         id=summary.name,
-        title=summary.name,
+        title=title,
         license=_utils.product_license(dataset_type),
         description=dataset_type.definition.get("description"),
         providers=[],


### PR DESCRIPTION
Currently the title field was just a replica of the id field in the STAC metadata.
This PR would add the possibility to define a title for a ODC product and view it in the STAC metadata.

Sample product/dataset definition showing how to include a title:

product.yaml
```yaml
name: vhi_clone
description: The Vegetation Health Index (VHI) is based on a combination of products extracted from vegetation signals, namely the Normalized Difference Vegetation Index (NDVI) and the land surface temperature, both derived from MODIS satellite data. The NDVI is based on 8 day maximum value composite MOD09Q1 (v006) reflectance and the land surface temperature (LST) on 8 day MOD11A2 (v006) LST products. The spatial resolution is 231 m, therefore the original 1000 m resolution of the MOD11A2 LST is downscaled to 231 m of the MOD09Q1 reflectance. Both products are masked to the highest quality standards using the provided quality layers. Missing pixel values in the time series are linearly interpolated. Non-vegetated areas are masked using the most recent Corine Land Cover product version for the according year. The final product is regridded to the LAEA Projection (EPSG:3035). The VHI relies on a strong inverse correlation between NDVI and land surface temperature, since increasing land temperatures are assumed to act negatively on vegetation vigour and consequently to cause stress. The data is provided as 8 day measures. The time series is starting from 2001. The VHI values range from 0-100, whereas high values correspond to healthy vegetation and low values indicate stressed vegetation.
metadata_type: eo3

license: CC-BY-4.0

metadata:
  product:
    name: 8d_vhi
  title: Vegetation Health Index - 231 m 8 days
    
load:
  crs: EPSG:3035
  resolution: 
    x: 231.656358262999987
    y: -231.656358263001010
  align:
    x: 212.31067014019936
    y: 140.55886972369626
measurements:
  - name: 8d_vhi
    dtype: "uint8"
    units: "1"
    nodata: 255
```

dataset.yaml

```yaml
$schema: https://schemas.opendatacube.org/dataset
crs: EPSG:3035
grids:
  default:
    shape: [3606, 4430]
    transform: [231.656358263, 0.0, 3829491.91275753, 0.0, -231.656358263001, 3051286.45355171,
      0.0, 0.0, 1.0]
id: fe9c2536-4b99-4011-b2e0-b00844f9c62f
lineage: {}
measurements:
  8d_vhi: {path: vhi_8d_doy2016321_231m_laea.tif}
product: {name: 8d_vhi}
title: Vegetation Health Index - 231 m 8 days
properties: {datetime: 2016-11-16 00:00:00+00:00, odc:file_format: GeoTIFF}
```

output stac metadata from the explorer:

```json
{
  "type": "Collection",
  "id": "vhi_clone",
  "stac_version": "1.0.0",
  "description": "The Vegetation Health Index (VHI) is based on a combination of products extracted from vegetation signals, namely the Normalized Difference Vegetation Index (NDVI) and the land surface temperature, both derived from MODIS satellite data. The NDVI is based on 8 day maximum value composite MOD09Q1 (v006) reflectance and the land surface temperature (LST) on 8 day MOD11A2 (v006) LST products. The spatial resolution is 231 m, therefore the original 1000 m resolution of the MOD11A2 LST is downscaled to 231 m of the MOD09Q1 reflectance. Both products are masked to the highest quality standards using the provided quality layers. Missing pixel values in the time series are linearly interpolated. Non-vegetated areas are masked using the most recent Corine Land Cover product version for the according year. The final product is regridded to the LAEA Projection (EPSG:3035). The VHI relies on a strong inverse correlation between NDVI and land surface temperature, since increasing land temperatures are assumed to act negatively on vegetation vigour and consequently to cause stress. The data is provided as 8 day measures. The time series is starting from 2001. The VHI values range from 0-100, whereas high values correspond to healthy vegetation and low values indicate stressed vegetation.",
  "links": [
    {
      "rel": "root",
      "href": "http://0.0.0.0:9000/stac",
      "type": "application/json",
      "title": "Default ODC Explorer instance"
    },
    {
      "rel": "self",
      "href": "http://0.0.0.0:9000/stac/collections/vhi_clone"
    },
    {
      "rel": "items",
      "href": "http://0.0.0.0:9000/stac/collections/vhi_clone/items"
    },
    {
      "rel": "child",
      "href": "http://0.0.0.0:9000/stac/catalogs/vhi_clone/2016-11"
    }
  ],
  "stac_extensions": [],
  "title": "Vegetation Health Index - 231 m 8 days",
  "extent": {
    "spatial": {
      "bbox": [
        [
          3.080800333295437,
          42.841014591998366,
          17.523924303829347,
          50.36459883616284
        ]
      ]
    },
    "temporal": {
      "interval": [
        [
          "2016-11-16T00:00:00Z",
          "2016-11-16T00:00:00Z"
        ]
      ]
    }
  },
  "license": "CC-BY-4.0",
  "providers": []
}
```
