### PR TITLE
Reverse dataset order

### DIFF
--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -615,7 +615,7 @@ def datasets_by_region(
             DATASET_SPATIAL.c.center_time > bindparam("from_time", time_range.begin)
         ).where(DATASET_SPATIAL.c.center_time < bindparam("to_time", time_range.end))
     query = (
-        query.order_by(DATASET_SPATIAL.c.center_time)
+        query.order_by(DATASET_SPATIAL.c.center_time.desc())
         .limit(bindparam("limit", limit))
         .offset(bindparam("offset", offset))
     )


### PR DESCRIPTION
Reverse the order datasets are displayed on the `regions` page, so that they appear newest-first instead of oldest-first.

![image](https://user-images.githubusercontent.com/40238244/220220679-543af202-4019-42c3-bd0a-494b89c06891.png)

I could also make the order toggle-able, similarly to the [dataset-counts page](https://explorer.dev.dea.ga.gov.au/audit/dataset-counts).

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--518.org.readthedocs.build/en/518/

<!-- readthedocs-preview datacube-explorer end -->