### PR TITLE
Updated scanning pipeline

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout git
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           branch: develop
@@ -35,11 +35,16 @@ jobs:
 
       - name: Run vulnerability scanner
         if: github.event_name != 'release'
-        uses: aquasecurity/trivy-action@0.7.1
+        uses: aquasecurity/trivy-action@master
         with:
           image-ref: "${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}"
-          format: "table"
-          exit-code: "1"
+          format: 'sarif'
+          output: 'trivy-results.sarif'
           ignore-unfixed: true
-          vuln-type: 'os,library'
+          vuln-type: 'library'
           severity: "CRITICAL,HIGH"
+      
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -43,7 +43,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'library'
           severity: "CRITICAL,HIGH"
-      
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:


### PR DESCRIPTION
Does small refreshes on scanning pipeline and closes #525 

- [x] Update github checkout action to v3 to fix warnings.
- [x] Update trivy action to master
- [x] Do not fail on vulnerabilities, push these to GitHub security tab instead.

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--526.org.readthedocs.build/en/526/

<!-- readthedocs-preview datacube-explorer end -->