### PR TITLE
make default timezone configurable and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ You can always see which environment/settings will be used by running `datacube 
 
 See the ODC documentation for config and [datacube environments](https://datacube-core.readthedocs.io/en/latest/user/config.html#runtime-config)
 
+### How can I set different timezone
+
+Datacube-explorer default timezone is configured to: `Australia/Darwin`.
+
+To configure the instance to a different timezone, the following configuration needs to be applied:
+
+- `os.environment` variable `CUBEDASH_DEFAULT_TIMEZONE`
+- `app.config` variable `CUBEDASH_DEFAULT_TIMEZONE`
+
 ### Can I add custom scripts or text to the page (such as analytics)?
 
 Create one of the following `*.env.html` files:
@@ -141,94 +150,7 @@ Git)
 
 ### How can I configure the deployment?
 
-Add a file to the current directory called `settings.env.py` and run the explorer with `export FLASK_APP=cubedash:app; flask run`
-
-You can alter default [Flask](http://flask.pocoo.org/docs/1.0/config/) or
-[Flask Cache](https://pythonhosted.org/Flask-Caching/#configuring-flask-caching) settings
-(default "CACHE_TYPE: NullCache"), as well as some cubedash-specific settings:
-
-    # Default product to display (picks first available)
-    CUBEDASH_DEFAULT_PRODUCTS = ('ls8_nbar_albers', 'ls7_nbar_albers')
-
-    # Optional title for this Explorer instance to put at the top of every page.
-    # Eg. "NCI"
-    # If the STAC_ENDPOINT_TITLE is set (below), it will be the default for this value.
-    CUBEDASH_INSTANCE_TITLE = None
-
-    # Specify product grouping in the top menu.
-    # Expects a series of `(regex, group_label)` pairs. Each product will be grouped into the first regexp that matches
-    # anywhere in its name. Unmatched products have their own group see CUBEDASH_DEFAULT_GROUP_NAME, group names shouldn't include the default name.
-    # eg "(('^usgs_','USGS products'), ('_albers$','C2 Albers products'), ('level1','Level 1 products'), )"
-    CUBEDASH_PRODUCT_GROUP_BY_REGEX = None
-    # CUBEDASH_PRODUCT_GROUP_BY_REGEX = (r'^usgs_','USGS products'), (r'_albers$','C2 Albers products'), (r'level1','Level 1 products'), )
-    # Otherwise, group by a single metadata field in the products:
-    CUBEDASH_PRODUCT_GROUP_BY_FIELD = 'product_type'
-    # Ungrouped products will be grouped together in this size.
-    CUBEDASH_PRODUCT_GROUP_SIZE = 5
-    # Ungrouped products will be grouped together using this name
-    CUBEDASH_DEFAULT_GROUP_NAME = 'Other Products'
-    # Maximum search results
-    CUBEDASH_HARD_SEARCH_LIMIT = 100
-    # Dataset records returned by '/api'
-    CUBEDASH_DEFAULT_API_LIMIT = 500
-    CUBEDASH_HARD_API_LIMIT = 4000
-    # Maximum number of source/derived datasets to show
-    CUBEDASH_PROVENANCE_DISPLAY_LIMIT = 20
-
-    CUBEDASH_DEFAULT_TIMEZONE = "Australia/Darwin"
-
-    CUBEDASH_SISTER_SITES = None
-    # CUBEDASH_SISTER_SITES = (('Production - ODC', 'http://prod.odc.example'), ('Production - NCI', 'http://nci.odc.example'), )
-
-    CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST = None
-    # CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST = [
-    #    "ls5_pq_scene",
-    #    "ls7_pq_scene",
-    # ]
-
-    # How many days of recent datasets to show on the "/arrivals" page?
-    CUBEDASH_DEFAULT_ARRIVALS_DAY_COUNT = 14
-
-    # Include load performance metrics in http response.
-    CUBEDASH_SHOW_PERF_TIMES = False
-
-    # Which theme to use (in the cubedash/themes folder)
-    CUBEDASH_THEME = 'odc'
-
-    # The default license to show for products that don't have one.
-    #     license is optional, but the stac API collections will not pass validation if it's null)
-    #     Either a SPDX License identifier, 'various' or 'proprietary'
-    #     Example value: "CC-BY-SA-4.0"
-    CUBEDASH_DEFAULT_LICENSE = None
-
-    # Customise '/stac' endpoint information
-    STAC_ENDPOINT_ID = 'my-odc-explorer'
-    STAC_ENDPOINT_TITLE = 'My ODC Explorer'
-    STAC_ENDPOINT_DESCRIPTION = 'Optional Longer description of this endpoint'
-
-    STAC_DEFAULT_PAGE_SIZE = 20
-    STAC_PAGE_SIZE_LIMIT = 1000
-
-    # Should search results include the full properties of every Stac Item by default?
-    # Full searches are much slower because they use ODC's own raw metadata table.
-    # (Users can append "_full=true" to requests to manually ask for full metadata.
-    #  Or preferrably, follow the `self` link of the Item record to get the whole record)
-    STAC_DEFAULT_FULL_ITEM_INFORMATION = True
-
-    # If you'd like S3 URIs to be transformed to HTTPS links then
-    # set this to a valid AWS region string. Otherwise set it to None to not do this.
-    CUBEDASH_DATA_S3_REGION = "ap-southeast-2"
-
-    # Default map view when no data is loaded.
-    # The default values will depend on the CUBEDASH_THEME (eg. 'africa' theme defults to Africa)
-    default_map_zoom = 3
-    default_map_center = [-26.2756326, 134.9387844]
-
-    # S3 buckets for which data browser url should be returned
-    SHOW_DATA_LOCATION = { "dea-public-data": "data.dea.ga.gov.au" }
-
-[Sentry](https://sentry.io/) error reporting is supported by adding a `SENTRY_CONFIG` section.
-See [their documentation](https://docs.sentry.io/clients/python/integrations/flask/#settings).
+refer to [deployment instructions](https://datacube-explorer.readthedocs.io/en/latest/deploying.html) and [app-config](https://datacube-explorer.readthedocs.io/en/latest/config.html)
 
 ### How do I modify the CSS/Javascript?
 

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -1,5 +1,6 @@
 from collections import Counter
 from datetime import datetime
+from os import environ
 from typing import Optional, Tuple
 
 import pandas as pd
@@ -27,7 +28,7 @@ _LOG = structlog.get_logger()
 
 _NEWER_SQLALCHEMY = not sqlalchemy.__version__.startswith("1.3")
 
-DEFAULT_TIMEZONE = "Australia/Darwin"
+DEFAULT_TIMEZONE = environ.get("CUBEDASH_DEFAULT_TIMEZONE", "Australia/Darwin")
 
 
 def _scalar_subquery(selectable):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - FLASK_ENV=development
       - FLASK_APP=cubedash
       - FLASK_DEBUG=1
+      - CUBEDASH_DEFAULT_TIMEZONE=Australia/Darwin
       # - VIRTUAL_HOST=datacube.explorer
     depends_on:
       - postgres

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -199,5 +199,6 @@ server:
 
          $ export FLASK_ENV=development
          $ export FLASK_APP=cubedash
+         $ export CUBEDASH_DEFAULT_TIMEZONE=Australia/Darwin
          $ cubedash-run
           * Running on http://localhost:8080/ (Press CTRL+C to quit)


### PR DESCRIPTION
closes #381 

- Due to loading order, flask application is loaded after the summarise code, the timezone configuration needs to be from `os` level.

# Scope
- add doc
- make _summarise timezone configurable

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--529.org.readthedocs.build/en/529/

<!-- readthedocs-preview datacube-explorer end -->