### PR TITLE
Dockerfile: clean /code directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR $APPDIR
 # want to delete the stuff in the /code folder to keep it simple.
 RUN if [ "$ENVIRONMENT" = "deployment" ] ; then\
         pip install .[$ENVIRONMENT]; \
-        rm -rf /code/* ; \
+        rm -rf /code/* /code/.??* ; \
     else \
         pip install --editable .[$ENVIRONMENT]; \
     fi


### PR DESCRIPTION
The /code directory in the image
is 38M because it contains .git,
.docker, and various other
configuration files.

Clean out the directory completely
to make the image slightly smaller.