### PR TITLE
readthedocs: update config to current format

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,13 +1,13 @@
 ---
 version: 2
 build:
-  image: latest
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
   apt_packages:
     - libgdal-dev
     - gdal-bin
 python:
-  version: 3.8
   install:
     - requirements: docs/rtd-requirements.txt
     - requirements: docs/requirements.txt
-  system_packages: true


### PR DESCRIPTION
The image tag has been renamed to os and
the python version goes under build.tools.python.
   
The support for system_packages has been dropped,
for more details, see:
    
https://blog.readthedocs.com/drop-support-system-packages/
