### PR TITLE
pre-commit-config: do not reformat schemas

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,18 +49,20 @@ repos:
       - id: check-docstring-first # Avoid common error of code before docstring.
       - id: check-json # Check json file syntax
         # (Exclude Typescript config: it uses json5 extensions)
-        exclude: 'tsconfig.json'
+        exclude: 'tsconfig.json|^integration_tests/schemas/'
       - id: check-merge-conflict # Don't commit merge-conflicts
       - id: check-symlinks # Symlinks that don't point to anything?
       - id: check-yaml # Check Yaml file syntax
         args: [--allow-multiple-documents]
       - id: debug-statements # Avoid commiting debug/breakpoints
       - id: end-of-file-fixer # Normalise on exactly one newline
+        exclude: '^integration_tests/schemas/'
       - id: fix-byte-order-marker # No UTF-8 byte order marks
       - id: mixed-line-ending # Don't allow mixed line endings
       - id: pretty-format-json
         args: ['--no-sort-keys', '--indent=4', '--autofix']
         # (Exclude Typescript config: it uses json5 extensions)
-        exclude: 'tsconfig.json'
+        exclude: 'tsconfig.json|^integration_tests/schemas/'
       - id: requirements-txt-fixer # Keep requirements files sorted.
       - id: trailing-whitespace # Auto remove trailing whitespace
+        exclude: '^integration_tests/schemas/'


### PR DESCRIPTION
Reformatting will give spurious differences
after running the update.sh script.

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--548.org.readthedocs.build/en/548/

<!-- readthedocs-preview datacube-explorer end -->