### PR TITLE
schemas/update.sh: auto-update STAC version

### DIFF
--- a/integration_tests/schemas/update.sh
+++ b/integration_tests/schemas/update.sh
@@ -44,6 +44,7 @@ ln -s "../schemas.stacspec.org/${stac_api_tag}" "stac-api/"
 # The ItemCollection was removed from core stac, but is used by stac-api.
 cd "stac/${stac_version}/item-spec/json-schema"
 wget https://raw.githubusercontent.com/radiantearth/stac-spec/568a04821935cc92de7b4b05ea6fa9f6bf8a0592/item-spec/json-schema/itemcollection.json
+perl -pi -e 's#"const": "0.9.0"#"const": "1.0.0"#g' itemcollection.json
 
 echo "Success"
 echo "If git status shows any changes, rerun tests, and commit them"

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -200,7 +200,6 @@ def load_schema_doc(
 
 
 # Run `./update.sh` in the schema dir to check for newer versions of these.
-# NOTE: you will need to manually update the stac version for the itemcollection schema.
 _CATALOG_SCHEMA = load_validator(
     _STAC_SCHEMA_BASE / "catalog-spec/json-schema/catalog.json"
 )


### PR DESCRIPTION
Make the update script fix the STAC version
instead of having a comment inside the test
file.

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--549.org.readthedocs.build/en/549/

<!-- readthedocs-preview datacube-explorer end -->