### PR TITLE
docker-compose: add healthcheck for postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
 
   postgres:
     image: postgis/postgis:13-3.1
+    hostname: postgres
     environment:
       - POSTGRES_DB=opendatacube
       - POSTGRES_PASSWORD=opendatacubepassword
@@ -32,6 +33,11 @@ services:
     ports:
       - 5432:5432
     restart: always
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "postgres", "-q", "-d", "opendatacube", "-U", "opendatacube"]
+      timeout: 45s
+      interval: 10s
+      retries: 10
 
   # Needed for testing HTTPS
   # nginx-proxy:


### PR DESCRIPTION
This makes "docker compose up --wait" return
when the database can be connected to through
the hostname.

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--555.org.readthedocs.build/en/555/

<!-- readthedocs-preview datacube-explorer end -->