### PR TITLE
CI: fix docpreview permissions

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -2,7 +2,7 @@
 name: Docs QA
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - "**"
 


### PR DESCRIPTION
According to

https://stackoverflow.com/questions/74957218/what-is-the-difference-between-pull-request-and-pull-request-target-event-in-git

there is something with permissions of tokens
that differ between pull_request and pull_request_target, so switch to pull_request_target which is
what the action documentation suggests.