### PR TITLE
Dockerfile: restore missing env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,11 @@ RUN python3.10 -m pip --disable-pip-version-check -q wheel --no-binary psycopg2 
 
 FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.1
 
+ENV DEBIAN_FRONTEND=noninteractive \
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8 \
+    PYTHONFAULTHANDLER=1
+
 # Apt installation
 RUN apt-get update && \
     apt-get upgrade -y && \


### PR DESCRIPTION
Commit 88780f74791 accidentally removed
the environment variables from the production
container, so restore them.

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--563.org.readthedocs.build/en/563/

<!-- readthedocs-preview datacube-explorer end -->