### PR TITLE
Update eodatasets3 min version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "cachetools",
         "click",
         "datacube>=1.8.10",
-        "eodatasets3>=0.25.0",
+        "eodatasets3>=0.30.1",
         "fiona",
         "flask",
         "Flask-Caching",


### PR DESCRIPTION
Require eodatasets3>=0.30.1 to incorporate stac api fix

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--567.org.readthedocs.build/en/567/

<!-- readthedocs-preview datacube-explorer end -->