### PR TITLE
setup.py: depend on lxml_html_clean

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ tests_require = [
     "deepdiff",
     "flake8",
     "jsonschema >= 4.18",
+    "lxml_html_clean",
     "pre-commit",
     "pytest",
     "pytest-benchmark",


### PR DESCRIPTION
This has been split out to a separate
package according to the error message
from the CI.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--584.org.readthedocs.build/en/584/

<!-- readthedocs-preview datacube-explorer end -->