### PR TITLE
Remove pip&git for deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,13 +31,15 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      git \
       # For Psycopg2
       libpq5 \
       tini \
       postgresql-client \
       python3-pip \
-    && apt-get autoclean && \
+    && ([ "$ENVIRONMENT" = "deployment" ] || \
+         apt-get install -y --no-install-recommends \
+           git) && \
+    apt-get autoclean && \
     apt-get autoremove && \
     rm -rf /var/lib/{apt,dpkg,cache,log}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,10 @@ RUN if [ "$ENVIRONMENT" = "deployment" ] ; then\
     else \
         pip install --editable .[$ENVIRONMENT]; \
     fi && \
-    pip freeze
+    pip freeze && \
+    ([ "$ENVIRONMENT" != "deployment" ] || \
+        apt-get remove -y \
+            python3-pip)
 
 ENTRYPOINT ["/bin/tini", "--"]
 


### PR DESCRIPTION
This avoids a couple of vulnerabilities for the deployed image.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--585.org.readthedocs.build/en/585/

<!-- readthedocs-preview datacube-explorer end -->