### PR TITLE
Update to latest postgis 13 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,10 @@ clean:  ## Clean all working/temporary files
 
 # DOCKER STUFF
 up: ## Start server using Docker
-	docker-compose up
+	docker-compose up --quiet-pull
 
 up-d: ## Start server using Docker in background
-	docker-compose up -d
+	docker-compose up -d --quiet-pull
 
 build: ## Build the dev Docker image
 	docker-compose build
@@ -107,7 +107,7 @@ build-prod: ## Build the prod Docker image
 up-prod: ## Start using the prod Docker image
 	docker-compose \
 		--file docker-compose.yml \
-		up -d
+		up -d --quiet-pull
 
 init-odc: ## Initialise ODC Database
 	docker-compose exec -T explorer \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - postgres
 
   postgres:
-    image: postgis/postgis:13-3.1
+    image: postgis/postgis:13-3.4
     hostname: postgres
     environment:
       - POSTGRES_DB=opendatacube


### PR DESCRIPTION
I don't know to what extent explorer is affected by database bugs, but this bumps to the most recent version of the same major.

Also throw in a commit that avoids the download progress bar from docker compose since that floods the CI logs with noise.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--586.org.readthedocs.build/en/586/

<!-- readthedocs-preview datacube-explorer end -->