### PR TITLE
Revert previous auto-modernise commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,11 @@
 ---
 repos:
-  # Normalise all Python code. (Black + isort + pyupgrade + autoflake)
-  - repo: https://github.com/Zac-HD/shed
-    rev: 2024.3.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.5
     hooks:
-    - id: shed
-  # Python Linting
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
-    hooks:
-      - id: flake8
-        exclude: ^docs/
-        additional_dependencies:
-          - flake8-bugbear # Lint-checks too opinionated for flake8 proper
-          - flake8-builtins # Don't allow built-in names like list
-          - flake8-coding # Only UTF-8
-          - flake8-debugger # Don't commit debugger calls
-          - flake8-executable # Check shebangs and executable permissions
-          - flake8-logging-format # Use log arguments, not string format
-          - flake8-pep3101 # Don't use old string % formatting
-          - flake8-pytest-style # Avoid common pytest mistakes
-          - flake8-pytest # Use plain assert, not unittest assertions
-          - flake8-rst-docstrings # docstring should be valid ReST
-          - pep8-naming # Follow pep8 naming rules (eg. function names lowercase)
+    - id: ruff
+      args: [--fix, --show-fixes, --output-format, grouped]
+    - id: ruff-format
   # Lint Python snippets embedded in Markdown (using flake8)
   - repo: https://github.com/johnfraney/flake8-markdown
     rev: v0.5.0
@@ -41,7 +24,7 @@ repos:
         args: ['-c', '.yamllint']
   # Common pre-commit checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files # We don't want huge files. (Cut down test data!)
         args: ['--maxkb=2000']

--- a/cubedash/_api.py
+++ b/cubedash/_api.py
@@ -33,9 +33,9 @@ def datasets_geojson(
     time = _utils.as_time_range(year, month, day, tzinfo=_model.STORE.grouping_timezone)
 
     return as_geojson(
-        {
-            "type": "FeatureCollection",
-            "features": [
+        dict(
+            type="FeatureCollection",
+            features=[
                 s.as_geojson()
                 for s in _model.STORE.search_items(
                     product_names=[product_name],
@@ -45,7 +45,7 @@ def datasets_geojson(
                 )
                 if s.geom_geojson is not None
             ],
-        },
+        ),
         downloadable_filename_prefix=_utils.api_path_as_filename_prefix(),
     )
 

--- a/cubedash/_audit.py
+++ b/cubedash/_audit.py
@@ -8,7 +8,8 @@ import flask
 from datacube.model import Range
 from flask import Blueprint, Response, redirect, url_for
 
-from . import _model, _utils as utils
+from . import _model
+from . import _utils as utils
 
 _LOG = logging.getLogger(__name__)
 bp = Blueprint(

--- a/cubedash/_dataset.py
+++ b/cubedash/_dataset.py
@@ -4,7 +4,8 @@ from uuid import UUID
 import flask
 from flask import Blueprint, abort, url_for
 
-from . import _model, _utils as utils
+from . import _model
+from . import _utils as utils
 
 _LOG = logging.getLogger(__name__)
 bp = Blueprint(

--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -18,7 +18,8 @@ from markupsafe import Markup, escape
 from orjson import orjson
 from shapely.geometry import MultiPolygon
 
-from . import _model, _utils, _utils as utils
+from . import _model, _utils
+from . import _utils as utils
 
 # How far to step the number when the user hits up/down.
 NUMERIC_STEP_SIZE = {
@@ -173,9 +174,7 @@ _NULL_VALUE = Markup('<span class="null-value" title="Unspecified">•</span>')
 @bp.app_template_filter("query_value")
 def _format_query_value(val):
     if isinstance(val, Range):
-        return "{} to {}".format(
-            _format_query_value(val.begin), _format_query_value(val.end)
-        )
+        return f"{_format_query_value(val.begin)} to {_format_query_value(val.end)}"
     if isinstance(val, datetime):
         return _format_datetime(val)
     if val is None:

--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -173,7 +173,9 @@ _NULL_VALUE = Markup('<span class="null-value" title="Unspecified">•</span>')
 @bp.app_template_filter("query_value")
 def _format_query_value(val):
     if isinstance(val, Range):
-        return f"{_format_query_value(val.begin)} to {_format_query_value(val.end)}"
+        return "{} to {}".format(
+            _format_query_value(val.begin), _format_query_value(val.end)
+        )
     if isinstance(val, datetime):
         return _format_datetime(val)
     if val is None:

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -76,10 +76,10 @@ app.config.setdefault("CACHE_TYPE", "NullCache")
 
 # Global defaults
 app.config.from_mapping(
-    {
-        "CUBEDASH_DEFAULT_API_LIMIT": 500,
-        "CUBEDASH_HARD_API_LIMIT": 4000,
-    }
+    dict(
+        CUBEDASH_DEFAULT_API_LIMIT=500,
+        CUBEDASH_HARD_API_LIMIT=4000,
+    )
 )
 
 cache = Cache(app=app, config=app.config)
@@ -187,15 +187,15 @@ def get_footprint_geojson(
     if not footprint:
         return None
 
-    return {
-        "type": "Feature",
-        "geometry": footprint.__geo_interface__,
-        "properties": {
-            "dataset_count": period.footprint_count,
-            "product_name": product_name,
-            "time_spec": [year, month, day],
-        },
-    }
+    return dict(
+        type="Feature",
+        geometry=footprint.__geo_interface__,
+        properties=dict(
+            dataset_count=period.footprint_count,
+            product_name=product_name,
+            time_spec=[year, month, day],
+        ),
+    )
 
 
 @cache.memoize(timeout=60)
@@ -302,4 +302,4 @@ if os.environ.get("PROMETHEUS_MULTIPROC_DIR", False):
     from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 
     metrics = GunicornInternalPrometheusMetrics(app, group_by="endpoint")
-    _LOG.info("Prometheus metrics enabled : {metrics}", extra={"metrics": metrics})
+    _LOG.info("Prometheus metrics enabled : {metrics}", extra=dict(metrics=metrics))

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -230,7 +230,7 @@ def search_page(  # noqa: C901
 
     if request_wants_json():
         return as_rich_json(
-            {"datasets": [build_dataset_info(_model.STORE.index, d) for d in datasets]}
+            dict(datasets=[build_dataset_info(_model.STORE.index, d) for d in datasets])
         )
 
     # For display on the page (and future searches).
@@ -329,12 +329,12 @@ def region_page(
         )
     )
 
-    same_region_products = [
+    same_region_products = list(
         product.name
         for product in _model.STORE.find_products_for_region(
             region_code, year, month, day, limit=limit + 1, offset=offset
         )
-    ]
+    )
 
     def url_with_offset(new_offset: int):
         """Currently request url with a different offset."""
@@ -356,7 +356,7 @@ def region_page(
 
     if request_wants_json():
         return as_rich_json(
-            {"datasets": [build_dataset_info(_model.STORE.index, d) for d in datasets]}
+            dict(datasets=[build_dataset_info(_model.STORE.index, d) for d in datasets])
         )
 
     return utils.render(
@@ -404,10 +404,10 @@ def region_geojson(
 
     geojson = region_info.region(region_code).footprint_geojson
     geojson["properties"].update(
-        {
-            "product_name": product_name,
-            "year_month_day_filter": [year, month, day],
-        }
+        dict(
+            product_name=product_name,
+            year_month_day_filter=[year, month, day],
+        )
     )
     return utils.as_geojson(
         geojson,
@@ -474,27 +474,25 @@ def inject_globals():
         if product_summary:
             last_updated = product_summary.last_successful_summary_time
 
-    return {
+    return dict(
         # Only the known, summarised products in groups.
-        "grouped_products": _get_grouped_products(),
+        grouped_products=_get_grouped_products(),
         # All products in the datacube, summarised or not.
-        "datacube_products": list(_model.STORE.index.products.get_all()),
-        "hidden_product_list": app.config.get(
-            "CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST", []
-        ),
-        "datacube_metadata_types": list(_model.STORE.index.metadata_types.get_all()),
-        "current_time": datetime.utcnow(),
-        "datacube_version": datacube.__version__,
-        "app_version": cubedash.__version__,
-        "grouping_timezone": tz.gettz(_model.DEFAULT_GROUPING_TIMEZONE),
-        "last_updated_time": last_updated,
-        "explorer_instance_title": app.config.get(
+        datacube_products=list(_model.STORE.index.products.get_all()),
+        hidden_product_list=app.config.get("CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST", []),
+        datacube_metadata_types=list(_model.STORE.index.metadata_types.get_all()),
+        current_time=datetime.utcnow(),
+        datacube_version=datacube.__version__,
+        app_version=cubedash.__version__,
+        grouping_timezone=tz.gettz(_model.DEFAULT_GROUPING_TIMEZONE),
+        last_updated_time=last_updated,
+        explorer_instance_title=app.config.get(
             "CUBEDASH_INSTANCE_TITLE",
         )
         or app.config.get("STAC_ENDPOINT_TITLE", ""),
-        "explorer_sister_instances": app.config.get("CUBEDASH_SISTER_SITES", None),
-        "breadcrumb": _get_breadcrumbs(request.path, request.script_root),
-    }
+        explorer_sister_instances=app.config.get("CUBEDASH_SISTER_SITES", None),
+        breadcrumb=_get_breadcrumbs(request.path, request.script_root),
+    )
 
 
 HREF = str

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -28,6 +28,8 @@ from . import (
     _product,
     _stac,
     _stac_legacy,
+)
+from . import (
     _utils as utils,
 )
 from ._utils import as_rich_json, get_sorted_product_summaries
@@ -160,7 +162,7 @@ def legacy_search_page(
 @app.route("/products/<product_name>/datasets/<int:year>")
 @app.route("/products/<product_name>/datasets/<int:year>/<int:month>")
 @app.route("/products/<product_name>/datasets/<int:year>/<int:month>/<int:day>")
-def search_page(  # noqa: C901
+def search_page(
     product_name: str = None, year: int = None, month: int = None, day: int = None
 ):
     (
@@ -427,7 +429,9 @@ def timeline_page(product_name: str):
     return redirect(url_for("product_page", product_name=product_name))
 
 
-def _load_product(product_name, year, month, day) -> Tuple[
+def _load_product(
+    product_name, year, month, day
+) -> Tuple[
     DatasetType,
     ProductSummary,
     TimePeriodOverview,

--- a/cubedash/_product.py
+++ b/cubedash/_product.py
@@ -3,7 +3,8 @@ from datetime import timedelta
 
 from flask import Blueprint, Response, abort, redirect, url_for
 
-from cubedash import _model, _utils, _utils as utils
+from cubedash import _model, _utils
+from cubedash import _utils as utils
 
 _LOG = logging.getLogger(__name__)
 bp = Blueprint("product", __name__)

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -414,7 +414,9 @@ def _list_arg(arg: list):
     """
     if isinstance(arg, str):
         arg = list(arg)
-    return [json.loads(a.replace("'", '"')) if isinstance(a, str) else a for a in arg]
+    return list(
+        map(lambda a: json.loads(a.replace("'", '"')) if isinstance(a, str) else a, arg)
+    )
 
 
 # Search
@@ -506,20 +508,20 @@ def _handle_search_request(
 
     feature_collection.extra_fields["links"].extend(
         (
-            {
-                "href": url_for(".stac_search"),
-                "rel": "search",
-                "title": "Search",
-                "type": "application/geo+json",
-                "method": "GET",
-            },
-            {
-                "href": url_for(".stac_search"),
-                "rel": "search",
-                "title": "Search",
-                "type": "application/geo+json",
-                "method": "POST",
-            },
+            dict(
+                href=url_for(".stac_search"),
+                rel="search",
+                title="Search",
+                type="application/geo+json",
+                method="GET",
+            ),
+            dict(
+                href=url_for(".stac_search"),
+                rel="search",
+                title="Search",
+                type="application/geo+json",
+                method="POST",
+            ),
         )
     )
     return feature_collection
@@ -747,18 +749,18 @@ def search_stac_items(
     page = 0
     if limit != 0:
         page = offset // limit
-    extra_properties = {
-        "links": [],
+    extra_properties = dict(
+        links=[],
         # Stac standard
-        "numberReturned": len(returned),
+        numberReturned=len(returned),
         # Compatibility with older implementation. Was removed from stac-api standard.
         # (page numbers + limits are not ideal as they prevent some big db optimisations.)
-        "context": {
-            "page": page,
-            "limit": limit,
-            "returned": len(returned),
-        },
-    }
+        context=dict(
+            page=page,
+            limit=limit,
+            returned=len(returned),
+        ),
+    )
     if include_total_count:
         count_matching = _model.STORE.get_count(
             product_names=product_names, time=time, bbox=bbox, dataset_ids=dataset_ids
@@ -775,34 +777,34 @@ def search_stac_items(
     result = ItemCollection(items, extra_fields=extra_properties)
 
     if there_are_more:
-        next_link = {
-            "rel": "next",
-            "title": "Next page of Items",
-            "type": "application/geo+json",
-        }
+        next_link = dict(
+            rel="next",
+            title="Next page of Items",
+            type="application/geo+json",
+        )
         if use_post_request:
             next_link.update(
-                {
-                    "method": "POST",
-                    "merge": True,
+                dict(
+                    method="POST",
+                    merge=True,
                     # Unlike GET requests, we can tell them to repeat their same request args
                     # themselves.
                     #
                     # Same URL:
-                    "href": flask.request.url,
+                    href=flask.request.url,
                     # ... with a new offset.
-                    "body": {
-                        "_o": offset + limit,
-                    },
-                }
+                    body=dict(
+                        _o=offset + limit,
+                    ),
+                )
             )
         else:
             # Otherwise, let the route create the next url.
             next_link.update(
-                {
-                    "method": "GET",
-                    "href": get_next_url(offset + limit),
-                }
+                dict(
+                    method="GET",
+                    href=get_next_url(offset + limit),
+                )
             )
 
         result.extra_fields["links"].append(next_link)
@@ -904,10 +906,10 @@ def _geojson_stac_response(doc: Union[STACObject, ItemCollection]) -> flask.Resp
 
 def stac_endpoint_information() -> Dict:
     config = _model.app.config
-    o = {
-        "id": config.get("STAC_ENDPOINT_ID", "odc-explorer"),
-        "title": config.get("STAC_ENDPOINT_TITLE", "Default ODC Explorer instance"),
-    }
+    o = dict(
+        id=config.get("STAC_ENDPOINT_ID", "odc-explorer"),
+        title=config.get("STAC_ENDPOINT_TITLE", "Default ODC Explorer instance"),
+    )
     description = config.get(
         "STAC_ENDPOINT_DESCRIPTION",
         "Configure stac endpoint information in your Explorer `settings.env.py` file",
@@ -995,7 +997,7 @@ def root():
         "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
         "https://api.stacspec.org/v1.0.0-rc.1/collections",
     ]
-    c.extra_fields = {"conformsTo": conformance_classes}
+    c.extra_fields = dict(conformsTo=conformance_classes)
 
     return _stac_response(c)
 
@@ -1033,18 +1035,18 @@ def collections():
      an array (instead of just a link to each collection).
     """
     return _utils.as_json(
-        {
-            "links": [
-                {"rel": "self", "type": "application/json", "href": request.url},
-                {"rel": "root", "type": "application/json", "href": url_for(".root")},
-                {"rel": "parent", "type": "application/json", "href": url_for(".root")},
+        dict(
+            links=[
+                dict(rel="self", type="application/json", href=request.url),
+                dict(rel="root", type="application/json", href=url_for(".root")),
+                dict(rel="parent", type="application/json", href=url_for(".root")),
             ],
-            "collections": [
+            collections=[
                 # TODO: This has a root link, right?
                 _stac_collection(product.name).to_dict()
                 for product, product_summary in _model.get_products_with_summaries()
             ],
-        }
+        )
     )
 
 

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -1,7 +1,8 @@
 import json
 import logging
 import uuid
-from datetime import datetime, time as dt_time, timedelta
+from datetime import datetime, timedelta
+from datetime import time as dt_time
 from functools import partial
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -10,7 +11,8 @@ import pystac
 from datacube.model import Dataset, Range
 from datacube.utils import DocReader, parse_time
 from dateutil.tz import tz
-from eodatasets3 import serialise, stac as eo3stac
+from eodatasets3 import serialise
+from eodatasets3 import stac as eo3stac
 from eodatasets3.model import AccessoryDoc, DatasetDoc, MeasurementDoc, ProductDoc
 from eodatasets3.properties import Eo3Dict
 from eodatasets3.utils import is_doc_eo3
@@ -288,7 +290,7 @@ def field_path_row(key, value):
     elif key == "sat_row":
         kind = "landsat:wrs_row"
     else:
-        raise ValueError(f"Path/row kind {repr(key)}")
+        raise ValueError(f"Path/row kind {key!r}")
 
     # If there's only one value in the range, return it.
     if isinstance(value, Range):
@@ -623,7 +625,7 @@ def _handle_fields_extension(
                 keys=inc.split("."),
                 # get corresponding field from item
                 # disallow default to avoid None values being inserted
-                func=lambda _: _get_property(inc, item, no_default=True),  # noqa: B023
+                func=lambda _: _get_property(inc, item, no_default=True),
             )
 
         for exc in fields.get("exclude") or []:

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -18,7 +18,7 @@ from uuid import UUID
 import datacube.drivers.postgres._schema
 import eodatasets3.serialise
 import flask
-import numpy
+import numpy as np
 import shapely.geometry
 import shapely.validation
 import structlog
@@ -578,7 +578,7 @@ def as_yaml(*o, content_type="text/yaml", downloadable_filename_prefix: str = No
 
     # TODO: remove the two functions once eo-datasets fix is released
     def _represent_float(self, value):
-        text = numpy.format_float_scientific(value)
+        text = np.format_float_scientific(value)
         return self.represent_scalar("tag:yaml.org,2002:float", text)
 
     def dumps_yaml(yml, stream, *docs) -> None:

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -52,6 +52,7 @@ Drop all of Explorer’s additions to the database:
 
 
 """
+
 import collections
 import multiprocessing
 import re
@@ -64,7 +65,8 @@ from typing import List, Optional, Sequence, Tuple
 
 import click
 import structlog
-from click import secho as click_secho, style
+from click import secho as click_secho
+from click import style
 from datacube.config import LocalConfig
 from datacube.index import Index, index_connect
 from datacube.model import DatasetType
@@ -75,7 +77,7 @@ from cubedash.summary import (
     GenerateResult,
     SummaryStore,
     TimePeriodOverview,
-    UnsupportedWKTProductCRS,
+    UnsupportedWKTProductCRSError,
 )
 from cubedash.summary._stores import DEFAULT_EPSG
 from cubedash.summary._summarise import DEFAULT_TIMEZONE
@@ -132,7 +134,7 @@ def generate_report(
             minimum_change_scan_window=settings.minimum_change_scan_window,
         )
         return product_name, result, updated_summary
-    except UnsupportedWKTProductCRS as e:
+    except UnsupportedWKTProductCRSError as e:
         log.warning("product.unsupported", reason=e.reason)
         return product_name, GenerateResult.UNSUPPORTED, None
     except Exception:
@@ -230,7 +232,7 @@ def _load_products(index: Index, product_names) -> List[DatasetType]:
                 p.name for p in index.products.get_all()
             )
             raise click.BadParameter(
-                f"Unknown product {repr(product_name)}.\n\n"
+                f"Unknown product {product_name!r}.\n\n"
                 f"Possibilities:\n\t{possible_product_names}",
                 param_hint="product_names",
             )

--- a/cubedash/gunicorn_config.py
+++ b/cubedash/gunicorn_config.py
@@ -1,5 +1,4 @@
-"""Gunicorn config for Prometheus internal metrics
-"""
+"""Gunicorn config for Prometheus internal metrics"""
 
 import os
 

--- a/cubedash/summary/__init__.py
+++ b/cubedash/summary/__init__.py
@@ -1,4 +1,4 @@
-from ._extents import RegionInfo, UnsupportedWKTProductCRS
+from ._extents import RegionInfo, UnsupportedWKTProductCRSError
 from ._model import TimePeriodOverview
 from ._stores import (
     DatasetItem,
@@ -18,5 +18,5 @@ __all__ = (
     "RegionInfo",
     "SummaryStore",
     "TimePeriodOverview",
-    "UnsupportedWKTProductCRS",
+    "UnsupportedWKTProductCRSError",
 )

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -83,7 +83,7 @@ def get_dataset_extent_alchemy_expression(md: MetadataType, default_crs: str = N
                 [
                     # If we have geometry, use it as the polygon.
                     (
-                        doc[["geometry"]] is not None,
+                        doc[["geometry"]] != None,
                         func.ST_GeomFromGeoJSON(doc[["geometry"]], type_=Geometry),
                     )
                 ],
@@ -99,7 +99,7 @@ def get_dataset_extent_alchemy_expression(md: MetadataType, default_crs: str = N
                 [
                     # If we have valid_data offset, use it as the polygon.
                     (
-                        doc[valid_data_offset] is not None,
+                        doc[valid_data_offset] != None,
                         func.ST_GeomFromGeoJSON(doc[valid_data_offset], type_=Geometry),
                     )
                 ],
@@ -409,9 +409,9 @@ def refresh_spatial_extents(
                         .where(DATASET_SPATIAL.c.id == bindparam("dataset_id"))
                         .values(footprint=bindparam("footprint")),
                         [
-                            {
-                                "dataset_id": id_,
-                                "footprint": from_shape(
+                            dict(
+                                dataset_id=id_,
+                                footprint=from_shape(
                                     shapely.ops.unary_union(
                                         [
                                             shapes[(int(sat_path.lower), row)]
@@ -424,7 +424,7 @@ def refresh_spatial_extents(
                                     srid=4326,
                                     extended=True,
                                 ),
-                            }
+                            )
                             for id_, sat_path, sat_row in rows
                         ],
                     )
@@ -926,7 +926,7 @@ def get_sample_dataset(*product_names: str, index: Index = None) -> Iterable[Dic
                         DATASET.c.dataset_type_ref
                         == bindparam("product_ref", product.id, type_=SmallInteger)
                     )
-                    .where(DATASET.c.archived is None)
+                    .where(DATASET.c.archived == None)
                     .limit(1)
                 )
                 .fetchone()
@@ -968,7 +968,7 @@ def get_mapped_crses(*product_names: str, index: Index = None) -> Iterable[Dict]
                         ]
                     )
                     .where(DATASET.c.dataset_type_ref == product.id)
-                    .where(DATASET.c.archived is None)
+                    .where(DATASET.c.archived == None)
                     .limit(1)
                 )
                 .fetchone()

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -40,6 +40,8 @@ from sqlalchemy.sql.elements import ClauseElement, Label
 
 from cubedash._utils import (
     ODC_DATASET as DATASET,
+)
+from cubedash._utils import (
     alchemy_engine,
     expects_eo3_metadata_type,
     infer_crs,
@@ -54,7 +56,7 @@ _WRS_PATH_ROW = [
 ]
 
 
-class UnsupportedWKTProductCRS(NotImplementedError):
+class UnsupportedWKTProductCRSError(NotImplementedError):
     """We can't, within Postgis, support arbitrary WKT CRSes at the moment."""
 
     def __init__(self, reason: str) -> None:
@@ -83,7 +85,7 @@ def get_dataset_extent_alchemy_expression(md: MetadataType, default_crs: str = N
                 [
                     # If we have geometry, use it as the polygon.
                     (
-                        doc[["geometry"]] != None,
+                        doc[["geometry"]].is_not(None),
                         func.ST_GeomFromGeoJSON(doc[["geometry"]], type_=Geometry),
                     )
                 ],
@@ -99,7 +101,7 @@ def get_dataset_extent_alchemy_expression(md: MetadataType, default_crs: str = N
                 [
                     # If we have valid_data offset, use it as the polygon.
                     (
-                        doc[valid_data_offset] != None,
+                        doc[valid_data_offset].is_not(None),
                         func.ST_GeomFromGeoJSON(doc[valid_data_offset], type_=Geometry),
                     )
                 ],
@@ -168,7 +170,7 @@ def get_dataset_srid_alchemy_expression(md: MetadataType, default_crs: str = Non
             # HACK: Change default CRS with inference
             inferred_crs = infer_crs(default_crs)
             if inferred_crs is None:
-                raise UnsupportedWKTProductCRS(
+                raise UnsupportedWKTProductCRSError(
                     f"WKT Product CRSes are not currently well supported, and "
                     f"we can't infer this product's one. "
                     f"(Ideally use an auth-name format for CRS, such as 'EPSG:1234') "
@@ -319,7 +321,8 @@ def refresh_spatial_extents(
             "spatial_deletion_full_scan",
         )
         changed += engine.execute(
-            DATASET_SPATIAL.delete().where(
+            DATASET_SPATIAL.delete()
+            .where(
                 DATASET_SPATIAL.c.dataset_type_ref == product.id,
             )
             # Where it doesn't exist in the ODC dataset table.
@@ -926,7 +929,7 @@ def get_sample_dataset(*product_names: str, index: Index = None) -> Iterable[Dic
                         DATASET.c.dataset_type_ref
                         == bindparam("product_ref", product.id, type_=SmallInteger)
                     )
-                    .where(DATASET.c.archived == None)
+                    .where(DATASET.c.archived.is_(None))
                     .limit(1)
                 )
                 .fetchone()
@@ -968,7 +971,7 @@ def get_mapped_crses(*product_names: str, index: Index = None) -> Iterable[Dict]
                         ]
                     )
                     .where(DATASET.c.dataset_type_ref == product.id)
-                    .where(DATASET.c.archived == None)
+                    .where(DATASET.c.archived.is_(None))
                     .limit(1)
                 )
                 .fetchone()

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -281,6 +281,8 @@ def is_compatible_generate_schema(engine: Engine) -> bool:
 class SchemaNotRefreshable(Exception):
     """The schema is not set-up for running product refreshes"""
 
+    ...
+
 
 class PleaseRefresh(Enum):
     """

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -12,7 +12,6 @@ from sqlalchemy import (
     Column,
     Date,
     DateTime,
-    Enum as SqlEnum,
     ForeignKey,
     Index,
     Integer,
@@ -25,6 +24,9 @@ from sqlalchemy import (
     bindparam,
     func,
     select,
+)
+from sqlalchemy import (
+    Enum as SqlEnum,
 )
 from sqlalchemy.dialects import postgresql as postgres
 from sqlalchemy.engine import Engine
@@ -278,7 +280,7 @@ def is_compatible_generate_schema(engine: Engine) -> bool:
     return is_latest and pg_column_exists(engine, ODC_DATASET.fullname, "updated")
 
 
-class SchemaNotRefreshable(Exception):
+class SchemaNotRefreshableError(Exception):
     """The schema is not set-up for running product refreshes"""
 
     ...
@@ -368,7 +370,7 @@ def check_or_update_odc_schema(engine: Engine):
             _utils.install_timestamp_trigger(engine)
     except ProgrammingError as e:
         # We don't have permission.
-        raise SchemaNotRefreshable(
+        raise SchemaNotRefreshableError(
             dedent(
                 """
             Missing update triggers.

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -185,18 +185,18 @@ class DatasetItem:
         return self.geometry.__geo_interface__
 
     def as_geojson(self):
-        return {
-            "id": self.dataset_id,
-            "type": "Feature",
-            "bbox": self.bbox,
-            "geometry": self.geom_geojson,
-            "properties": {
+        return dict(
+            id=self.dataset_id,
+            type="Feature",
+            bbox=self.bbox,
+            geometry=self.geom_geojson,
+            properties={
                 "datetime": self.center_time,
                 "odc:product": self.product_name,
                 "odc:processing_datetime": self.creation_time,
                 "cubedash:region_code": self.region_code,
             },
-        }
+        )
 
 
 @dataclass
@@ -784,7 +784,7 @@ class SummaryStore:
 
         _LOG.info(
             "product.links.{kind}",
-            extra={"kind": kind},
+            extra=dict(kind=kind),
             product=product.name,
             linked=linked_product_names,
             sample_percentage=round(sample_percentage, 2),
@@ -991,7 +991,7 @@ class SummaryStore:
 
         Returns one row for each uri scheme found (http, file etc).
         """
-        search_args = {}
+        search_args = dict()
         if year or month or day:
             search_args["time"] = _utils.as_time_range(year, month, day)
 
@@ -1034,15 +1034,15 @@ class SummaryStore:
             self.index.products.get_by_name(name).id
             for name in product.derived_products
         ]
-        fields = {
-            "dataset_count": product.dataset_count,
-            "time_earliest": product.time_earliest,
-            "time_latest": product.time_latest,
-            "source_product_refs": source_product_ids,
-            "derived_product_refs": derived_product_ids,
-            "fixed_metadata": product.fixed_metadata,
-            "last_refresh": product.last_refresh_time,
-        }
+        fields = dict(
+            dataset_count=product.dataset_count,
+            time_earliest=product.time_earliest,
+            time_latest=product.time_latest,
+            source_product_refs=source_product_ids,
+            derived_product_refs=derived_product_ids,
+            fixed_metadata=product.fixed_metadata,
+            last_refresh=product.last_refresh_time,
+        )
 
         # Dear future reader. This section used to use an 'UPSERT' statement (as in,
         # insert, on_conflict...) and while this works, it triggers the sequence
@@ -1866,30 +1866,30 @@ def _summary_to_row(
         raise ValueError("Geometry without srid", summary)
     if summary.product_refresh_time is None:
         raise ValueError("Product has no refresh time??", summary)
-    return {
-        "dataset_count": summary.dataset_count,
-        "timeline_dataset_start_days": day_values,
-        "timeline_dataset_counts": day_counts,
+    return dict(
+        dataset_count=summary.dataset_count,
+        timeline_dataset_start_days=day_values,
+        timeline_dataset_counts=day_counts,
         # TODO: SQLAlchemy needs a bit of type help for some reason. Possible PgGridCell bug?
-        "regions": func.cast(region_values, type_=postgres.ARRAY(String)),
-        "region_dataset_counts": region_counts,
-        "timeline_period": summary.timeline_period,
-        "time_earliest": begin.astimezone(grouping_timezone) if begin else begin,
-        "time_latest": end.astimezone(grouping_timezone) if end else end,
-        "size_bytes": summary.size_bytes,
-        "product_refresh_time": summary.product_refresh_time,
-        "footprint_geometry": (
+        regions=func.cast(region_values, type_=postgres.ARRAY(String)),
+        region_dataset_counts=region_counts,
+        timeline_period=summary.timeline_period,
+        time_earliest=begin.astimezone(grouping_timezone) if begin else begin,
+        time_latest=end.astimezone(grouping_timezone) if end else end,
+        size_bytes=summary.size_bytes,
+        product_refresh_time=summary.product_refresh_time,
+        footprint_geometry=(
             None
             if summary.footprint_geometry is None
             else geo_shape.from_shape(
                 summary.footprint_geometry, summary.footprint_srid
             )
         ),
-        "footprint_count": summary.footprint_count,
-        "generation_time": func.now(),
-        "newest_dataset_creation_time": summary.newest_dataset_creation_time,
-        "crses": summary.crses,
-    }
+        footprint_count=summary.footprint_count,
+        generation_time=func.now(),
+        newest_dataset_creation_time=summary.newest_dataset_creation_time,
+        crses=summary.crses,
+    )
 
 
 def _common_paths_for_uris(

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -25,7 +25,8 @@ import pytz
 import structlog
 from cachetools.func import lru_cache, ttl_cache
 from dateutil import tz
-from geoalchemy2 import WKBElement, shape as geo_shape
+from geoalchemy2 import WKBElement
+from geoalchemy2 import shape as geo_shape
 from geoalchemy2.shape import from_shape, to_shape
 from shapely.geometry.base import BaseGeometry
 from sqlalchemy import DDL, String, and_, exists, func, literal, or_, select, union_all
@@ -713,7 +714,7 @@ class SummaryStore:
                 ]
             )
             .select_from(ODC_DATASET)
-            .where(ODC_DATASET.c.id.in_([r for r, in dataset_samples]))
+            .where(ODC_DATASET.c.id.in_([r for (r,) in dataset_samples]))
         ).fetchall()
         assert len(result) == 1
 
@@ -1633,7 +1634,7 @@ class SummaryStore:
         )
         self._product.cache_clear()
 
-    @lru_cache()  # noqa: B019
+    @lru_cache()
     def _get_srid_name(self, srid: int):
         """
         Convert an internal postgres srid key to a string auth code: eg: 'EPSG:1234'

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -9,7 +9,8 @@ import structlog
 from cachetools.func import lru_cache
 from datacube.model import Range
 from dateutil import tz
-from geoalchemy2 import Geometry, shape as geo_shape
+from geoalchemy2 import Geometry
+from geoalchemy2 import shape as geo_shape
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.dialects.postgresql import TSTZRANGE
 from sqlalchemy.sql import ColumnElement
@@ -238,7 +239,7 @@ class Summariser:
         )
         return begin_time, end_time, where_clause
 
-    @lru_cache()  # noqa: B019
+    @lru_cache()
     def _get_srid_name(self, srid: int):
         """
         Convert an internal postgres srid key to a string auth code: eg: 'EPSG:1234'

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -167,8 +167,9 @@ class Summariser:
                 )
             )
             region_counts = Counter(
-                dict(
-                    self._engine.execute(
+                {
+                    item: count
+                    for item, count in self._engine.execute(
                         select(
                             [
                                 DATASET_SPATIAL.c.region_code.label("region_code"),
@@ -178,7 +179,7 @@ class Summariser:
                         .where(where_clause)
                         .group_by("region_code")
                     )
-                )
+                }
             )
 
         if product_refresh_time is None:

--- a/cubedash/warmup.py
+++ b/cubedash/warmup.py
@@ -153,11 +153,9 @@ def cli(
         def handle_failure():
             nonlocal consecutive_failures
             consecutive_failures += 1
-            failures.append(url)  # noqa: B023
+            failures.append(url)
             # Back off slightly for network hiccups.
-            time.sleep(
-                max(throttle_seconds, 1) * (consecutive_failures + 1)
-            )  # noqa: B023
+            time.sleep(max(throttle_seconds, 1) * (consecutive_failures + 1))
 
         try:
             start_time = time.time()

--- a/integration_tests/asserts.py
+++ b/integration_tests/asserts.py
@@ -231,10 +231,10 @@ def expect_values(
         dataset_count {s.dataset_count}
         footprint_count {s.footprint_count}
         time range:
-            - {repr(s.time_range.begin.astimezone(tzutc()))}
-            - {repr(s.time_range.end.astimezone(tzutc()))}
-        newest: {repr(s.newest_dataset_creation_time.astimezone(tzutc()))}
-        crses: {repr(s.crses)}
+            - {s.time_range.begin.astimezone(tzutc())!r}
+            - {s.time_range.end.astimezone(tzutc())!r}
+        newest: {s.newest_dataset_creation_time.astimezone(tzutc())!r}
+        crses: {s.crses!r}
         size_bytes: {s.size_bytes}
         timeline
             period: {s.timeline_period}
@@ -244,12 +244,12 @@ def expect_values(
         if was_timeline_error:
             print("timeline keys:")
             for day, count in s.timeline_dataset_counts.items():
-                print(f"\t{repr(day)}: {count}")
+                print(f"\t{day!r}: {count}")
 
         if was_regions_error:
             print("region keys:")
             for region, count in s.region_dataset_counts.items():
-                print(f"\t{repr(region)}: {count}")
+                print(f"\t{region!r}: {count}")
         raise
 
 

--- a/integration_tests/test_center_datetime_logic.py
+++ b/integration_tests/test_center_datetime_logic.py
@@ -43,17 +43,21 @@ def test_datestring_on_dataset_page(client: FlaskClient):
 def test_datestring_on_datasets_search_page(client: FlaskClient):
     html = get_html(client, "/products/rainfall_chirps_daily/datasets")
 
-    assert "Time UTC: 2019-05-15 00:00:00" in [
-        a.find("td", first=True).attrs["title"] for a in html.find(".search-result")
-    ], "datestring does not match expected center_time recorded in dataset_spatial table"
+    assert (
+        "Time UTC: 2019-05-15 00:00:00"
+        in [
+            a.find("td", first=True).attrs["title"] for a in html.find(".search-result")
+        ]
+    ), "datestring does not match expected center_time recorded in dataset_spatial table"
 
 
 def test_datestring_on_regions_page(client: FlaskClient):
     html = get_html(client, "/product/rainfall_chirps_daily/regions/x210y106")
 
-    assert "2019-05-15 00:00:00" in [
-        a.find("td", first=True).text.strip() for a in html.find(".search-result")
-    ], "datestring does not match expected center_time recorded in dataset_spatial table"
+    assert (
+        "2019-05-15 00:00:00"
+        in [a.find("td", first=True).text.strip() for a in html.find(".search-result")]
+    ), "datestring does not match expected center_time recorded in dataset_spatial table"
 
 
 def test_summary_center_datetime(client: FlaskClient):

--- a/integration_tests/test_dataset_listing.py
+++ b/integration_tests/test_dataset_listing.py
@@ -48,10 +48,9 @@ def test_parse_query_args(odc_test_db: Datacube):
         product,
     )
 
-    assert res == {
-        "time": Range(datetime(2017, 8, 8), datetime(2017, 8, 9)),
-        "gqa": Range(-3, 3),
-    }
+    assert res == dict(
+        time=Range(datetime(2017, 8, 8), datetime(2017, 8, 9)), gqa=Range(-3, 3)
+    )
 
 
 @pytest.mark.skip(
@@ -71,7 +70,7 @@ def test_default_args(dea_index: Index):
     res = query_to_search(MultiDict(()), product)
 
     # The last month of LANDSAT_5 for this product
-    assert res == {
+    assert res == dict(
         # time=Range(datetime(2011, 10, 30), datetime(2011, 11, 30)),
         # product=product.name
-    }
+    )

--- a/integration_tests/test_dataset_listing.py
+++ b/integration_tests/test_dataset_listing.py
@@ -70,7 +70,10 @@ def test_default_args(dea_index: Index):
     res = query_to_search(MultiDict(()), product)
 
     # The last month of LANDSAT_5 for this product
-    assert res == dict(
-        # time=Range(datetime(2011, 10, 30), datetime(2011, 11, 30)),
-        # product=product.name
+    assert (
+        res
+        == dict(
+            # time=Range(datetime(2011, 10, 30), datetime(2011, 11, 30)),
+            # product=product.name
+        )
     )

--- a/integration_tests/test_filter_geom.py
+++ b/integration_tests/test_filter_geom.py
@@ -61,7 +61,7 @@ def test_nested_exception(testing_polygon):
         )
 
     polygonlist = _polygon_chain(testing_polygon)
-    assert type(polygonlist) is list
+    assert isinstance(polygonlist, list)
     assert len(polygonlist) == 262
     filtered_geom = _filter_geom(polygonlist)
     assert len(filtered_geom) == 199

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -227,7 +227,7 @@ def get_extension(url: str) -> jsonschema.Draft7Validator:
 def get_collection(client: FlaskClient, url: str, validate=True) -> Dict:
     """
     Get a URL, expecting a valid stac collection document to be there"""
-    with DebugContext(f"Requested {repr(url)}"):
+    with DebugContext(f"Requested {url!r}"):
         data = get_json(client, url)
         if validate:
             assert_collection(data)
@@ -237,7 +237,7 @@ def get_collection(client: FlaskClient, url: str, validate=True) -> Dict:
 def get_items(client: FlaskClient, url: str) -> Dict:
     """
     Get a URL, expecting a valid stac item collection document to be there"""
-    with DebugContext(f"Requested {repr(url)}"):
+    with DebugContext(f"Requested {url!r}"):
         data = get_geojson(client, url)
         assert_item_collection(data)
     return data
@@ -247,7 +247,7 @@ def get_item(client: FlaskClient, url: str) -> Dict:
     """
     Get a URL, expecting a single valid Stac Item to be there
     """
-    with DebugContext(f"Requested {repr(url)}"):
+    with DebugContext(f"Requested {url!r}"):
         data = get_json(client, url)
         validate_item(data)
     return data
@@ -342,7 +342,7 @@ def validate_items(
     product_counts = Counter()
     for item in items:
         id_ = item["id"]
-        with DebugContext(f"Invalid item {i}, id {repr(str(id_))}"):
+        with DebugContext(f"Invalid item {i}, id {str(id_)!r}"):
             validate_item(item)
         product_counts[item["properties"].get("odc:product", item["collection"])] += 1
 
@@ -601,7 +601,7 @@ def test_stac_links(stac_client: FlaskClient):
         href: str = child_link["href"]
         # ignore child links corresponding to catalogs
         if "catalogs" not in href:
-            print(f"Loading collection page for {product_name}: {repr(href)}")
+            print(f"Loading collection page for {product_name}: {href!r}")
 
             collection_data = get_collection(stac_client, href, validate=True)
             assert collection_data["id"] == product_name
@@ -1255,7 +1255,7 @@ def test_stac_search_by_post(stac_client: FlaskClient):
             # TODO: These are the same file in a NetCDF. They should probably be one asset?
             assert len(feature["assets"]) == len(
                 bands
-            ), f"Expected an asset per band, got {repr(feature['assets'])}"
+            ), f"Expected an asset per band, got {feature['assets']!r}"
             assert set(feature["assets"].keys()) == set(bands)
             while bands:
                 band = bands.pop()

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -437,20 +437,20 @@ def test_stac_loading_all_pages(stac_client: FlaskClient):
     )
     validate_items(
         all_items,
-        expect_count={
-            "wofs_albers": 11,
-            "ls8_nbar_scene": 7,
-            "ls8_level1_scene": 7,
-            "ls8_nbart_scene": 7,
-            "ls8_pq_legacy_scene": 7,
-            "ls8_nbart_albers": 7,
-            "ls8_satellite_telemetry_data": 6,
-            "ls7_nbart_albers": 4,
-            "ls7_nbart_scene": 4,
-            "ls7_nbar_scene": 4,
-            "ls7_pq_legacy_scene": 4,
-            "ls7_level1_scene": 4,
-        },
+        expect_count=dict(
+            wofs_albers=11,
+            ls8_nbar_scene=7,
+            ls8_level1_scene=7,
+            ls8_nbart_scene=7,
+            ls8_pq_legacy_scene=7,
+            ls8_nbart_albers=7,
+            ls8_satellite_telemetry_data=6,
+            ls7_nbart_albers=4,
+            ls7_nbart_scene=4,
+            ls7_nbar_scene=4,
+            ls7_pq_legacy_scene=4,
+            ls7_level1_scene=4,
+        ),
     )
 
 
@@ -1275,7 +1275,7 @@ def test_stac_search_by_post(stac_client: FlaskClient):
 
 
 def test_stac_query_extension(stac_client: FlaskClient):
-    query = {"properties.dea:dataset_maturity": {"eq": "nrt"}}
+    query = {"properties.dea:dataset_maturity": dict(eq="nrt")}
     rv: Response = stac_client.post(
         "/stac/search",
         data=json.dumps(

--- a/integration_tests/test_utc_tst.py
+++ b/integration_tests/test_utc_tst.py
@@ -62,19 +62,24 @@ def test_yearly_dataset_count(client: FlaskClient):
 def test_dataset_search_page_localised_time(client: FlaskClient):
     html = get_html(client, "/products/ls5_fc_albers/datasets/2011")
 
-    assert "2011-01-01 09:03:13" in [
-        a.find("td", first=True).text.strip() for a in html.find(".search-result")
-    ], "datestring does not match expected center_time recorded in dataset_spatial table"
+    assert (
+        "2011-01-01 09:03:13"
+        in [a.find("td", first=True).text.strip() for a in html.find(".search-result")]
+    ), "datestring does not match expected center_time recorded in dataset_spatial table"
 
-    assert "Time UTC: 2010-12-31 23:33:13" in [
-        a.find("td", first=True).attrs["title"] for a in html.find(".search-result")
-    ], "datestring does not match expected center_time recorded in dataset_spatial table"
+    assert (
+        "Time UTC: 2010-12-31 23:33:13"
+        in [
+            a.find("td", first=True).attrs["title"] for a in html.find(".search-result")
+        ]
+    ), "datestring does not match expected center_time recorded in dataset_spatial table"
 
     html = get_html(client, "/products/ls5_fc_albers/datasets/2010")
 
-    assert "2010-12-31 09:56:02" in [
-        a.find("td", first=True).text.strip() for a in html.find(".search-result")
-    ], "datestring does not match expected center_time recorded in dataset_spatial table"
+    assert (
+        "2010-12-31 09:56:02"
+        in [a.find("td", first=True).text.strip() for a in html.find(".search-result")]
+    ), "datestring does not match expected center_time recorded in dataset_spatial table"
 
 
 def test_clirunner_generate_grouping_timezone(odc_test_db, run_generate):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,31 @@ exclude = '''
   | cubedash/_version\.py
 )/
 '''
+
+[tool.ruff]
+target-version = "py38"
+
+[tool.ruff.lint]
+# Which checkers to enable?
+select = [
+    "A",  # Don't shadow built-ins
+    "E",  # pycodestyle
+    "EXE",  # Shebangs+Executable permisssions should match
+    "F",  # pyflakes
+    "G",  # Use logging formatter, not manual string concat
+    "I",  # Auto-sort imports
+    "ICN",  # Use standard import names, like np for numpy
+    "N",  # pep8-naming
+    "NPY",  # Numpy
+    # "RUF",  # Ruf-specific python rules?
+    # "S",  # Bandit (security) -- explore warnings and enable in future?
+]
+
+[tool.ruff.lint.per-file-ignores]
+# The file deliberately doesn't put the import at the top, and we can't avoid global overrides
+"docs/conf.py" = ["E402", "A001", "EXE001"]
+
+# Matching old behaviour: We auto-format with the smaller line default
+# ...  but only enforce line length to be under this larger 120 limit.
+[tool.ruff.lint.pycodestyle]
+max-line-length = 120


### PR DESCRIPTION
Some changes by shed have broken the semantics of sqlalchemy queries (see https://github.com/opendatacube/datacube-explorer/issues/581)

- Revert the original, offending commit that breaks result iteration.
- Also update our usage of `== None`, which has a better equivalent in modern sqlalchemy (and was also broken by it)
- Move from shed to ruff. Most of our newer repositories used ruff anyway, so it seems a good reason to switch.

I haven't retested the original issues, this is a just reverting some clear errors.

**Note** that ruff has made some changes of its own to match its black-like formatting, but they're minor

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--587.org.readthedocs.build/en/587/

<!-- readthedocs-preview datacube-explorer end -->