### PR TITLE
Dockerfile: remove git after use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,18 +28,17 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONFAULTHANDLER=1
 
 # Apt installation
+# git: required by setuptools_scm.
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
+      git \
       # For Psycopg2
       libpq5 \
       tini \
       postgresql-client \
       python3-pip \
-    && ([ "$ENVIRONMENT" = "deployment" ] || \
-         apt-get install -y --no-install-recommends \
-           git) && \
-    apt-get autoclean && \
+    && apt-get autoclean && \
     apt-get autoremove && \
     rm -rf /var/lib/{apt,dpkg,cache,log}
 
@@ -73,6 +72,8 @@ RUN if [ "$ENVIRONMENT" = "deployment" ] ; then\
     pip freeze && \
     ([ "$ENVIRONMENT" != "deployment" ] || \
         apt-get remove -y \
+            git \
+            git-man \
             python3-pip)
 
 ENTRYPOINT ["/bin/tini", "--"]


### PR DESCRIPTION
I shifted some things around to simplify
before pushing, but missed that the check
on ENVIRONMENT ended up before
the declaration of the argument.

Even the deployment container needs git
since setuptools_scm requires it, so
remove git and git-man after the
installation has completed.

This avoids CVE-2018-1000021.
<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--588.org.readthedocs.build/en/588/

<!-- readthedocs-preview datacube-explorer end -->