### PR TITLE
Dockerfile: disable pip cache in deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ ARG ENVIRONMENT=deployment
 # ARG ENVIRONMENT=test
 
 RUN echo "Environment is: $ENVIRONMENT" && \
-    [ "$ENVIRONMENT" = "deployment" ] || pip install pip-tools pytest-cov
+    [ "$ENVIRONMENT" = "deployment" ] || \
+      pip install --disable-pip-version-check pip-tools pytest-cov
 
 # Set up a nice workdir and add the live code
 ENV APPDIR=/code
@@ -64,10 +65,10 @@ RUN python3.10 -m pip --disable-pip-version-check -q install *.whl && \
 # then we want to link the source (with the -e flag) and if we're in prod, we
 # want to delete the stuff in the /code folder to keep it simple.
 RUN if [ "$ENVIRONMENT" = "deployment" ] ; then\
-        pip install .[$ENVIRONMENT]; \
+        pip --no-cache-dir --disable-pip-version-check install .[$ENVIRONMENT]; \
         rm -rf /code/* /code/.git* ; \
     else \
-        pip install --editable .[$ENVIRONMENT]; \
+        pip --disable-pip-version-check install --editable .[$ENVIRONMENT]; \
     fi && \
     pip freeze && \
     ([ "$ENVIRONMENT" != "deployment" ] || \


### PR DESCRIPTION
Tell pip to not write the cache when
in the deployment image.

Also disable the version check on
the remaining uses of pip, this saves
some time since it avoids a HTTP
request on startup.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--589.org.readthedocs.build/en/589/

<!-- readthedocs-preview datacube-explorer end -->