### PR TITLE
Update to setuptools>=61

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]>=8"]
 
 [tool.setuptools_scm]
 write_to = "cubedash/_version.py"


### PR DESCRIPTION
I don't know anything about setuptools_scm,
but a failed CI run output this in the log:

```
ERROR: setuptools==59.6.0 is used in combination with setuptools_scm>=8.x

Your build configuration is incomplete and previously worked by accident! setuptools_scm requires setuptools>=61

       Suggested workaround if applicable:
        - migrating from the deprecated setup_requires mechanism to pep517/518 and using a pyproject.toml to declare build dependencies which are reliably pre-installed before running the build tools
```
so require setuptools>=61 and setuptools_scm >=8.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--590.org.readthedocs.build/en/590/

<!-- readthedocs-preview datacube-explorer end -->