### PR TITLE
Update to gunicorn 22.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ extras_require = {
         "ciso8601",
         "bottleneck",
         # The default run.sh and docs use gunicorn+meinheld
-        "gunicorn",
+        "gunicorn>=22.0.0",
         "setproctitle",
         "gevent",
         # Monitoring


### PR DESCRIPTION
This fixes CVE-2024-1135.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--593.org.readthedocs.build/en/593/

<!-- readthedocs-preview datacube-explorer end -->