### PR TITLE
Replace func.agdc.common_timestamp with hardcoded conversion

### DIFF
--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -534,7 +534,7 @@ def _dataset_creation_expression(md: MetadataType) -> ClauseElement:
         doc = md.dataset_fields["metadata_doc"].alchemy_expression
         creation_dt = md.definition["dataset"].get("creation_dt") or ["creation_dt"]
         creation_expression = text(
-            str(doc[creation_dt]) + "::timestamp at time zone 'utc'"
+            str(doc[creation_dt].astext) + "::timestamp at time zone 'utc'"
         )
 
     # If they're missing a dataset-creation time, fall back to the time it was indexed.

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -533,7 +533,9 @@ def _dataset_creation_expression(md: MetadataType) -> ClauseElement:
     else:
         doc = md.dataset_fields["metadata_doc"].alchemy_expression
         creation_dt = md.definition["dataset"].get("creation_dt") or ["creation_dt"]
-        creation_expression = text(doc[creation_dt].astext + "::timestamp at time zone 'utc'")
+        creation_expression = text(
+            doc[creation_dt].astext + "::timestamp at time zone 'utc'"
+        )
 
     # If they're missing a dataset-creation time, fall back to the time it was indexed.
     return func.coalesce(creation_expression, DATASET.c.added)

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -532,7 +532,9 @@ def _dataset_creation_expression(md: MetadataType) -> ClauseElement:
     else:
         doc = md.dataset_fields["metadata_doc"].alchemy_expression
         creation_dt = md.definition["dataset"].get("creation_dt") or ["creation_dt"]
-        creation_expression = doc[creation_dt].astext.join("::timestamp at time zone 'utc'")
+        creation_expression = doc[creation_dt].astext.join(
+            "::timestamp at time zone 'utc'"
+        )
 
     # If they're missing a dataset-creation time, fall back to the time it was indexed.
     return func.coalesce(creation_expression, DATASET.c.added)

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -534,7 +534,7 @@ def _dataset_creation_expression(md: MetadataType) -> ClauseElement:
         doc = md.dataset_fields["metadata_doc"].alchemy_expression
         creation_dt = md.definition["dataset"].get("creation_dt") or ["creation_dt"]
         creation_expression = text(
-            doc[creation_dt].astext + "::timestamp at time zone 'utc'"
+            str(doc[creation_dt]) + "::timestamp at time zone 'utc'"
         )
 
     # If they're missing a dataset-creation time, fall back to the time it was indexed.

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -532,7 +532,7 @@ def _dataset_creation_expression(md: MetadataType) -> ClauseElement:
     else:
         doc = md.dataset_fields["metadata_doc"].alchemy_expression
         creation_dt = md.definition["dataset"].get("creation_dt") or ["creation_dt"]
-        creation_expression = func.agdc.common_timestamp(doc[creation_dt].astext)
+        creation_expression = doc[creation_dt].astext.join("::timestamp at time zone 'utc'")
 
     # If they're missing a dataset-creation time, fall back to the time it was indexed.
     return func.coalesce(creation_expression, DATASET.c.added)

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -33,6 +33,7 @@ from sqlalchemy import (
     literal,
     null,
     select,
+    text,
 )
 from sqlalchemy.dialects import postgresql as postgres
 from sqlalchemy.engine import Engine
@@ -532,9 +533,7 @@ def _dataset_creation_expression(md: MetadataType) -> ClauseElement:
     else:
         doc = md.dataset_fields["metadata_doc"].alchemy_expression
         creation_dt = md.definition["dataset"].get("creation_dt") or ["creation_dt"]
-        creation_expression = str(doc[creation_dt]).join(
-            "::timestamp at time zone 'utc'"
-        )
+        creation_expression = text(doc[creation_dt].astext + "::timestamp at time zone 'utc'")
 
     # If they're missing a dataset-creation time, fall back to the time it was indexed.
     return func.coalesce(creation_expression, DATASET.c.added)

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -532,9 +532,7 @@ def _dataset_creation_expression(md: MetadataType) -> ClauseElement:
     else:
         doc = md.dataset_fields["metadata_doc"].alchemy_expression
         creation_dt = md.definition["dataset"].get("creation_dt") or ["creation_dt"]
-        creation_expression = doc[creation_dt].astext.join(
-            "::timestamp at time zone 'utc'"
-        )
+        creation_expression = str(doc[creation_dt]).join("::timestamp at time zone 'utc'")
 
     # If they're missing a dataset-creation time, fall back to the time it was indexed.
     return func.coalesce(creation_expression, DATASET.c.added)

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -532,7 +532,9 @@ def _dataset_creation_expression(md: MetadataType) -> ClauseElement:
     else:
         doc = md.dataset_fields["metadata_doc"].alchemy_expression
         creation_dt = md.definition["dataset"].get("creation_dt") or ["creation_dt"]
-        creation_expression = str(doc[creation_dt]).join("::timestamp at time zone 'utc'")
+        creation_expression = str(doc[creation_dt]).join(
+            "::timestamp at time zone 'utc'"
+        )
 
     # If they're missing a dataset-creation time, fall back to the time it was indexed.
     return func.coalesce(creation_expression, DATASET.c.added)


### PR DESCRIPTION
Current use of postgresql function agdc.common_timestamp is adding significant time (4x) to query execution, causing postgresql to queue queries and become unresponsive whilst waiting for database to return.  
Function currently returns `select ($1)::timestamp at time zone 'utc';` 
Rather than call a function to complete this, I've hardcoded this timstamp cast directly in the query expression.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--595.org.readthedocs.build/en/595/

<!-- readthedocs-preview datacube-explorer end -->