### PR TITLE
Dockerfile: fail on errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,14 +55,13 @@ ENV APPDIR=/code
 WORKDIR $APPDIR
 COPY . $APPDIR
 
-COPY --from=builder --link /build/*.whl ./
-RUN python3.10 -m pip --disable-pip-version-check -q install *.whl && \
-    rm *.whl
-
 # These ENVIRONMENT flags make this a bit complex, but basically, if we are in dev
 # then we want to link the source (with the -e flag) and if we're in prod, we
 # want to delete the stuff in the /code folder to keep it simple.
-RUN if [ "$ENVIRONMENT" = "deployment" ] ; then\
+COPY --from=builder --link /build/*.whl ./
+RUN python3.10 -m pip --disable-pip-version-check -q install *.whl && \
+    rm *.whl && \
+    if [ "$ENVIRONMENT" = "deployment" ] ; then\
         pip --no-cache-dir --disable-pip-version-check install .[$ENVIRONMENT]; \
         rm -rf /code/* /code/.git* ; \
     else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,12 +61,11 @@ COPY . $APPDIR
 COPY --from=builder --link /build/*.whl ./
 RUN python3.10 -m pip --disable-pip-version-check -q install *.whl && \
     rm *.whl && \
-    if [ "$ENVIRONMENT" = "deployment" ] ; then\
-        pip --no-cache-dir --disable-pip-version-check install .[$ENVIRONMENT]; \
-        rm -rf /code/* /code/.git* ; \
-    else \
-        pip --disable-pip-version-check install --editable .[$ENVIRONMENT]; \
-    fi && \
+    ([ "$ENVIRONMENT" = "deployment" ] || \
+        pip --disable-pip-version-check install --editable .[$ENVIRONMENT]) && \
+    ([ "$ENVIRONMENT" != "deployment" ] || \
+        (pip --no-cache-dir --disable-pip-version-check install .[$ENVIRONMENT] && \
+         rm -rf /code/* /code/.git*)) && \
     pip freeze && \
     ([ "$ENVIRONMENT" != "deployment" ] || \
         apt-get remove -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
     PYTHONFAULTHANDLER=1
 
+# Environment can be whatever is supported by setup.py
+# so, either deployment, test
+ARG ENVIRONMENT=deployment
+# ARG ENVIRONMENT=test
+
 # Apt installation
 # git: required by setuptools_scm.
 RUN apt-get update && \
@@ -40,16 +45,10 @@ RUN apt-get update && \
       python3-pip \
     && apt-get autoclean && \
     apt-get autoremove && \
-    rm -rf /var/lib/{apt,dpkg,cache,log}
-
-# Environment can be whatever is supported by setup.py
-# so, either deployment, test
-ARG ENVIRONMENT=deployment
-# ARG ENVIRONMENT=test
-
-RUN echo "Environment is: $ENVIRONMENT" && \
-    [ "$ENVIRONMENT" = "deployment" ] || \
-      pip install --disable-pip-version-check pip-tools pytest-cov
+    rm -rf /var/lib/{apt,dpkg,cache,log} && \
+    echo "Environment is: $ENVIRONMENT" && \
+    ([ "$ENVIRONMENT" = "deployment" ] || \
+      pip install --disable-pip-version-check pip-tools pytest-cov)
 
 # Set up a nice workdir and add the live code
 ENV APPDIR=/code


### PR DESCRIPTION
Merge a couple of layers to slightly
reduce the image size, and
rewrite the if-then-else into
short-circuiting tests followed
by commands chained together
with &&. This makes building
the image fail if something is wrong,
instead of giving strange errors
when running the tests.

The issue was discovered in the initial push of #588 
that passed the build phase, but failed the tests.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--596.org.readthedocs.build/en/596/

<!-- readthedocs-preview datacube-explorer end -->