### PR TITLE
Add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/.pytest_cache/
+
+# Unit test / coverage reports
+**/htmlcov/
+**/.tox/
+**/.coverage
+**/.coverage.*
+**/.cache
+**/nosetests.xml
+**/coverage.xml
+**/*.cover
+**/.hypothesis
+
+# Translations
+**/*.mo
+**/*.pot
+
+# Django stuff:
+**/*.log
+
+# Sphinx documentation
+**/docs/_build/
+
+# PyBuilder
+**/target/
+**/.idea/
+
+# iPython Notebook
+**/.ipynb_checkpoints
+
+# Mac OS X
+**/.DS_Store
+
+# Environment-specific templates
+**/*.env.html
+**/settings.env.py
+
+# Ignore vscode
+**/.vscode
+
+.dockerignore

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
 .hypothesis
 
 # Translations


### PR DESCRIPTION
This avoids bringing in various
local files into the docker build
context, so the docker cache will
be tainted less often, improving
the performance of image rebuilds.

If the docker cache gets in the way,
one can still use docker build --no-cache.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--597.org.readthedocs.build/en/597/

<!-- readthedocs-preview datacube-explorer end -->