### PR TITLE
Don't double run GitHub Actions Docker build on Release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ on:
       - "**"
 
   release:
-    types: [created, edited, published]
+    types: [published]
 
 env:
   IMAGE_NAME: opendatacube/explorer


### PR DESCRIPTION


<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--606.org.readthedocs.build/en/606/

<!-- readthedocs-preview datacube-explorer end -->