### PR TITLE
Add robots.txt

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -8,7 +8,7 @@ import structlog
 from datacube.model import DatasetType, Range
 from datacube.scripts.dataset import build_dataset_info
 from dateutil import tz
-from flask import abort, redirect, request, send_from_directory, url_for
+from flask import abort, redirect, request, url_for
 from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import HTTPException
 
@@ -50,6 +50,10 @@ _HARD_SEARCH_LIMIT = app.config.get("CUBEDASH_HARD_SEARCH_LIMIT", 150)
 _DEFAULT_GROUP_NAME = app.config.get("CUBEDASH_DEFAULT_GROUP_NAME", "Other Products")
 
 _DEFAULT_ARRIVALS_DAYS: int = app.config.get("CUBEDASH_DEFAULT_ARRIVALS_DAY_COUNT", 14)
+
+_ROBOTS_TXT_DEFAULT = (
+    "User-Agent: *\nAllow: /\nDisallow: /products/*/*\nDisallow: /stac/**"
+)
 
 # Add server timings to http headers.
 if app.config.get("CUBEDASH_SHOW_PERF_TIMES", False):
@@ -676,7 +680,9 @@ def about_page():
 
 @app.route("/robots.txt")
 def robots_txt():
-    return send_from_directory("static", "robots.txt")
+    return utils.as_json(
+        flask.current_app.config.get("ROBOTS_TXT", _ROBOTS_TXT_DEFAULT)
+    )
 
 
 @app.route("/")

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -8,7 +8,7 @@ import structlog
 from datacube.model import DatasetType, Range
 from datacube.scripts.dataset import build_dataset_info
 from dateutil import tz
-from flask import abort, redirect, request, url_for
+from flask import abort, redirect, request, send_from_directory, url_for
 from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import HTTPException
 
@@ -672,6 +672,11 @@ def about_page():
         stac_endpoint_config=_stac.stac_endpoint_information(),
         explorer_root_url=url_for("default_redirect", _external=True),
     )
+
+
+@app.route("/robots.txt")
+def robots_txt():
+    return send_from_directory("static", "robots.txt")
 
 
 @app.route("/")

--- a/cubedash/static/robots.txt
+++ b/cubedash/static/robots.txt
@@ -1,0 +1,4 @@
+User-Agent: *
+Allow: /
+Disallow: /products/*/*
+Disallow: /stac/**

--- a/cubedash/static/robots.txt
+++ b/cubedash/static/robots.txt
@@ -1,4 +1,0 @@
-User-Agent: *
-Allow: /
-Disallow: /products/*/*
-Disallow: /stac/**

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -961,6 +961,14 @@ def test_raw_documents(client: FlaskClient):
     )
 
 
+def test_get_robots(client: FlaskClient):
+    """
+    Check that robots.txt is correctly served from root
+    """
+    text, rv = get_text_response(client, "/robots.txt")
+    assert "User-Agent: *" in text
+
+
 def test_all_give_404s(client: FlaskClient):
     """
     We should get 404 messages, not exceptions, for missing things.


### PR DESCRIPTION
As per #522
As suggested by @omad, provide the contents of `robots.txt` via deployment config instead of a static file to make updates easier.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--607.org.readthedocs.build/en/607/

<!-- readthedocs-preview datacube-explorer end -->