### PR TITLE
Give 400 error for invalid query values

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -11,6 +11,7 @@ from datacube.model import DatasetType, Range
 from datacube.scripts.dataset import build_dataset_info
 from dateutil import tz
 from flask import abort, redirect, request, url_for
+from sqlalchemy.exc import DataError
 from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import HTTPException
 
@@ -229,10 +230,13 @@ def search_page(
     _LOG.info("query", query=query)
 
     # TODO: Add sort option to index API
-    datasets = sorted(
-        _model.STORE.index.datasets.search(**query, limit=_HARD_SEARCH_LIMIT + 1),
-        key=lambda d: default_utc(d.center_time),
-    )
+    try:
+        datasets = sorted(
+            _model.STORE.index.datasets.search(**query, limit=_HARD_SEARCH_LIMIT + 1),
+            key=lambda d: default_utc(d.center_time),
+        )
+    except DataError:
+        abort(400, "Invalid field value provided in query")
 
     more_datasets_exist = False
     if len(datasets) > _HARD_SEARCH_LIMIT:

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -999,3 +999,20 @@ def test_all_give_404s(client: FlaskClient):
 
     expect_404(f"/dataset/{dataset_id}")
     expect_404(f"/dataset/{dataset_id}.odc-metadata.yaml")
+
+
+def test_invalid_query_gives_400(client: FlaskClient):
+    """
+    We should get 400 errors, not errors, for an invalid field values in a query
+    """
+
+    def expect_400(url: str):
+        __tracebackhide__ = True
+        get_text_response(client, url, expect_status_code=400)
+
+    # errors that are caught when parsing query args
+    expect_400("/products/ga_ls8c_ard_3/datasets?time=asdf")
+    expect_400("/products/ga_ls8c_ard_3/datasets?lat=asdf")
+    # errors that aren't caught until the db query
+    expect_400("/products/ga_ls8c_ard_3/datasets?indexed_time=asdf")
+    expect_400("/products/ga_ls8c_ard_3/datasets?id=asdf")


### PR DESCRIPTION
If a user provides an invalid value in the search query, return a 400 status rather than 500.
Hopefully resolves #605.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--610.org.readthedocs.build/en/610/

<!-- readthedocs-preview datacube-explorer end -->