### PR TITLE
Use Flask application factory 

### DIFF
--- a/.github/workflows/deployment_test.yaml
+++ b/.github/workflows/deployment_test.yaml
@@ -29,10 +29,9 @@ jobs:
           make build-prod
           make up-prod
 
-      - name: Sleep for 10 seconds
-        uses: whatnick/wait-action@master
-        with:
-          time: '5s'
+      - name: Sleep for 30 seconds
+        run: sleep 30s
+        shell: bash
 
       - name: Prepare explorer schema
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,4 +88,4 @@ CMD ["gunicorn", \
      "90", \
      "--config", \
      "python:cubedash.gunicorn_config", \
-     "cubedash:app"]
+     "cubedash:create_app()"]

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ build-prod: ## Build the prod Docker image
 up-prod: ## Start using the prod Docker image
 	docker compose \
 		--file docker-compose.yml \
-		up -d --quiet-pull
+		up -d --wait --quiet-pull
 
 init-odc: ## Initialise ODC Database
 	docker compose exec -T explorer \

--- a/Makefile
+++ b/Makefile
@@ -88,55 +88,55 @@ clean:  ## Clean all working/temporary files
 
 # DOCKER STUFF
 up: ## Start server using Docker
-	docker-compose up --quiet-pull
+	docker compose up --quiet-pull
 
 up-d: ## Start server using Docker in background
-	docker-compose up -d --quiet-pull
+	docker compose up -d --quiet-pull
 
 build: ## Build the dev Docker image
-	docker-compose build
+	docker compose build
 
 docker-clean: ## Get rid of the local docker env and DB
-	docker-compose down
+	docker compose down
 
 build-prod: ## Build the prod Docker image
-	docker-compose \
+	docker compose \
 		--file docker-compose.yml \
 		build
 
 up-prod: ## Start using the prod Docker image
-	docker-compose \
+	docker compose \
 		--file docker-compose.yml \
 		up -d --quiet-pull
 
 init-odc: ## Initialise ODC Database
-	docker-compose exec -T explorer \
+	docker compose exec -T explorer \
 		datacube system init
 
 docker-shell: ## Get a shell into local Docker environ
-	docker-compose exec -T explorer \
+	docker compose exec -T explorer \
 		bash
 
 schema: ## Initialise Explorer DB using Docker
-	docker-compose exec -T explorer \
+	docker compose exec -T explorer \
 		cubedash-gen -v --init
 
 index: ## Update Explorer DB using Docker
-	docker-compose exec -T explorer \
+	docker compose exec -T explorer \
 		cubedash-gen --all
 
 force-refresh: ## Entirely refresh the Explorer tables in Docker
-	docker-compose exec -T explorer \
+	docker compose exec -T explorer \
 		cubedash-gen --force-refresh --refresh-stats --all
 
 create-test-db-docker: ## Create a test database inside Docker
-	docker-compose run --rm -T explorer \
+	docker compose run --rm -T explorer \
 		bash /code/.docker/create_db.sh
 
 lint-docker: ## Run linting inside inside Docker
-	docker-compose run --rm explorer \
+	docker compose run --rm explorer \
 		make lint
 
 test-docker: ## Run tests inside Docker
-	docker-compose run --rm explorer \
+	docker compose run --rm explorer \
 		pytest --cov=cubedash --cov-report=xml -r sx --durations=5

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A `cubedash-run` command is available to run Explorer locally:
 But Explorer can be run using any typical Python WSGI server, for example [gunicorn](https://gunicorn.org/):
 
     pip install gunicorn
-    gunicorn -b '127.0.0.1:8080' -w 4 cubedash:app
+    gunicorn -b '127.0.0.1:8080' -w 4 cubedash:create_app()
 
 Products will begin appearing one-by-one as the summaries are generated in the
 background.  If impatient, you can manually navigate to a product using

--- a/README.md
+++ b/README.md
@@ -130,8 +130,7 @@ Datacube-explorer default timezone is configured to: `Australia/Darwin`.
 
 To configure the instance to a different timezone, the following configuration needs to be applied:
 
-- `os.environment` variable `CUBEDASH_DEFAULT_TIMEZONE`
-- `app.config` variable `CUBEDASH_DEFAULT_TIMEZONE`
+- `app.config` variable `CUBEDASH_DEFAULT_TIMEZONE` (via environment variable `CUBEDASH_SETTINGS`, which points to a `.env.py` file)
 
 ### Can I add custom scripts or text to the page (such as analytics)?
 

--- a/cubedash/__init__.py
+++ b/cubedash/__init__.py
@@ -3,6 +3,6 @@ try:
 except ImportError:
     __version__ = "Unknown/Not Installed"
 
-from ._pages import app
+from ._model import create_app
 
-__all__ = ("app", "__version__")
+__all__ = ("create_app", "__version__")

--- a/cubedash/_api.py
+++ b/cubedash/_api.py
@@ -2,6 +2,7 @@ import logging
 from datetime import date, datetime
 
 import flask
+from dateutil import tz
 from flask import Blueprint, abort, request
 
 from cubedash import _utils
@@ -31,7 +32,7 @@ def datasets_geojson(
         limit = hard_limit
 
     time = _utils.as_time_range(
-        year, month, day, tzinfo=_model.DEFAULT_GROUPING_TIMEZONE
+        year, month, day, tzinfo=tz.gettz(_model.DEFAULT_GROUPING_TIMEZONE)
     )
 
     return as_geojson(

--- a/cubedash/_api.py
+++ b/cubedash/_api.py
@@ -30,7 +30,9 @@ def datasets_geojson(
     if limit > hard_limit:
         limit = hard_limit
 
-    time = _utils.as_time_range(year, month, day, tzinfo=_model.STORE.grouping_timezone)
+    time = _utils.as_time_range(
+        year, month, day, tzinfo=_model.DEFAULT_GROUPING_TIMEZONE
+    )
 
     return as_geojson(
         dict(

--- a/cubedash/_dataset.py
+++ b/cubedash/_dataset.py
@@ -2,7 +2,7 @@ import logging
 from uuid import UUID
 
 import flask
-from flask import Blueprint, abort, url_for
+from flask import Blueprint, abort, current_app, url_for
 
 from . import _model
 from . import _utils as utils
@@ -13,7 +13,7 @@ bp = Blueprint(
     __name__,
 )
 
-PROVENANCE_DISPLAY_LIMIT = _model.app.config.get(
+PROVENANCE_DISPLAY_LIMIT = current_app.config.get(
     "CUBEDASH_PROVENANCE_DISPLAY_LIMIT", 25
 )
 

--- a/cubedash/_dataset.py
+++ b/cubedash/_dataset.py
@@ -13,9 +13,7 @@ bp = Blueprint(
     __name__,
 )
 
-PROVENANCE_DISPLAY_LIMIT = current_app.config.get(
-    "CUBEDASH_PROVENANCE_DISPLAY_LIMIT", 25
-)
+PROVENANCE_DISPLAY_LIMIT = 25
 
 
 @bp.route("/dataset/<uuid:id_>")
@@ -54,8 +52,11 @@ def dataset_full_page(product_name: str, id_: UUID):
             f"Perhaps you meant to visit {actual_url!r}",
         )
 
+    provenance_display_limit = current_app.config.get(
+        "CUBEDASH_PROVENANCE_DISPLAY_LIMIT", PROVENANCE_DISPLAY_LIMIT
+    )
     source_datasets, source_dataset_overflow = utils.get_dataset_sources(
-        index, id_, limit=PROVENANCE_DISPLAY_LIMIT
+        index, id_, limit=provenance_display_limit
     )
 
     archived_location_times = index.datasets.get_archived_location_times(id_)
@@ -64,7 +65,7 @@ def dataset_full_page(product_name: str, id_: UUID):
     ordered_metadata = utils.prepare_dataset_formatting(dataset)
 
     derived_datasets, derived_dataset_overflow = utils.get_datasets_derived(
-        index, id_, limit=PROVENANCE_DISPLAY_LIMIT
+        index, id_, limit=provenance_display_limit
     )
     derived_datasets.sort(key=utils.dataset_label)
 

--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -108,7 +108,7 @@ def _dataset_geojson(dataset):
 
 @bp.app_template_filter("product_link")
 def _product_link(product_name):
-    url = flask.url_for("product_page", product_name=product_name)
+    url = flask.url_for("pages.product_page", product_name=product_name)
     return Markup(f"<a href='{url}' class='product-name'>{product_name}</a>")
 
 
@@ -147,7 +147,7 @@ def _dataset_day_link(dataset: Dataset, timezone=None):
     if timezone:
         t = utils.default_utc(t).astimezone(timezone)
     url = flask.url_for(
-        "product_page",
+        "pages.product_page",
         product_name=dataset.type.name,
         year=t.year,
         month=t.month,

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -22,6 +22,7 @@ from werkzeug.exceptions import HTTPException
 # from https://stackoverflow.com/questions/23347387/x-forwarded-proto-and-flask
 from werkzeug.middleware.proxy_fix import ProxyFix
 
+from cubedash import _monitoring
 from cubedash.summary import SummaryStore, TimePeriodOverview
 from cubedash.summary._extents import RegionInfo
 from cubedash.summary._stores import ProductSummary
@@ -144,6 +145,11 @@ def create_app(test_config=None):
 
         metrics = GunicornInternalPrometheusMetrics(app, group_by="endpoint")
         _LOG.info("Prometheus metrics enabled : {metrics}", extra=dict(metrics=metrics))
+
+    # Add server timings to http headers.
+    if app.config.get("CUBEDASH_SHOW_PERF_TIMES", False):
+        _monitoring.init_app_monitoring()
+
     with app.app_context():
         from . import (
             _api,

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -148,7 +148,7 @@ def create_app(test_config=None):
 
     # Add server timings to http headers.
     if app.config.get("CUBEDASH_SHOW_PERF_TIMES", False):
-        _monitoring.init_app_monitoring()
+        _monitoring.init_app_monitoring(app)
 
     with app.app_context():
         from . import (

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -73,16 +73,18 @@ STORE: SummaryStore = SummaryStore.create(
 )
 
 
-def create_app():
+def create_app(test_config=None):
     app = flask.Flask(NAME)
 
     # Also part of the fix from ^
     app.wsgi_app = ProxyFix(app.wsgi_app)
 
     # Optional environment settings file or variable
-    app.config.from_pyfile(BASE_DIR / "settings.env.py", silent=True)
-    app.config.from_envvar("CUBEDASH_SETTINGS", silent=True)
-
+    if test_config is None:
+        app.config.from_pyfile(BASE_DIR / "settings.env.py", silent=True)
+        app.config.from_envvar("CUBEDASH_SETTINGS", silent=True)
+    else:
+        app.config.from_mapping(test_config)
     # Enable do template extension
     app.jinja_env.add_extension("jinja2.ext.do")
 

--- a/cubedash/_monitoring.py
+++ b/cubedash/_monitoring.py
@@ -4,7 +4,6 @@ import sys
 import time
 
 import flask
-from flask import current_app
 from sqlalchemy import event
 
 from . import _model
@@ -14,7 +13,7 @@ _INITIALISED = False
 
 
 # Add server timings to http headers.
-def init_app_monitoring():
+def init_app_monitoring(app: flask.Flask):
     # This affects global flask app settings.
     # pylint: disable=global-statement
     global _INITIALISED
@@ -24,7 +23,7 @@ def init_app_monitoring():
 
     _INITIALISED = True
 
-    @current_app.before_request
+    @app.before_request
     def time_start():
         flask.g.start_render = time.time()
         flask.g.datacube_query_time = 0
@@ -45,7 +44,7 @@ def init_app_monitoring():
             flask.g.datacube_query_count += 1
         # print(f"===== {flask.g.datacube_query_time*1000} ===: {repr(statement)}")
 
-    @current_app.after_request
+    @app.after_request
     def time_end(response: flask.Response):
         render_time = time.time() - flask.g.start_render
         response.headers.add_header(

--- a/cubedash/_monitoring.py
+++ b/cubedash/_monitoring.py
@@ -4,6 +4,7 @@ import sys
 import time
 
 import flask
+from flask import current_app
 from sqlalchemy import event
 
 from . import _model
@@ -23,7 +24,7 @@ def init_app_monitoring():
 
     _INITIALISED = True
 
-    @_model.app.before_request
+    @current_app.before_request
     def time_start():
         flask.g.start_render = time.time()
         flask.g.datacube_query_time = 0
@@ -44,7 +45,7 @@ def init_app_monitoring():
             flask.g.datacube_query_count += 1
         # print(f"===== {flask.g.datacube_query_time*1000} ===: {repr(statement)}")
 
-    @_model.app.after_request
+    @current_app.after_request
     def time_end(response: flask.Response):
         render_time = time.time() - flask.g.start_render
         response.headers.add_header(

--- a/cubedash/_monitoring.py
+++ b/cubedash/_monitoring.py
@@ -18,31 +18,11 @@ def init_app_monitoring(app: flask.Flask):
     # pylint: disable=global-statement
     global _INITIALISED
 
-    if _INITIALISED:
-        return
-
-    _INITIALISED = True
-
     @app.before_request
     def time_start():
         flask.g.start_render = time.time()
         flask.g.datacube_query_time = 0
         flask.g.datacube_query_count = 0
-
-    @event.listens_for(alchemy_engine(_model.STORE.index), "before_cursor_execute")
-    def before_cursor_execute(
-        conn, cursor, statement, parameters, context, executemany
-    ):
-        conn.info.setdefault("query_start_time", []).append(time.time())
-
-    @event.listens_for(alchemy_engine(_model.STORE.index), "after_cursor_execute")
-    def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
-        if flask.has_app_context():
-            flask.g.datacube_query_time += time.time() - conn.info[
-                "query_start_time"
-            ].pop(-1)
-            flask.g.datacube_query_count += 1
-        # print(f"===== {flask.g.datacube_query_time*1000} ===: {repr(statement)}")
 
     @app.after_request
     def time_end(response: flask.Response):
@@ -55,6 +35,26 @@ def init_app_monitoring(app: flask.Flask):
             f'desc="{flask.g.datacube_query_count} ODC queries"',
         )
         return response
+
+    if _INITIALISED:
+        return
+
+    _INITIALISED = True
+
+    @event.listens_for(alchemy_engine(_model.STORE.index), "before_cursor_execute")
+    def before_cursor_execute(
+        conn, cursor, statement, parameters, context, executemany
+    ):
+        conn.info.setdefault("query_start_time", []).append(time.time())
+
+    @event.listens_for(alchemy_engine(_model.STORE.index), "after_cursor_execute")
+    def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        if flask.has_app_context() and hasattr(flask.g, "datacube_query_time"):
+            flask.g.datacube_query_time += time.time() - conn.info[
+                "query_start_time"
+            ].pop(-1)
+            flask.g.datacube_query_count += 1
+        # print(f"===== {flask.g.datacube_query_time*1000} ===: {repr(statement)}")
 
     def decorate_all_methods(cls, decorator):
         """

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -452,7 +452,7 @@ def request_wants_json():
     )
 
 
-@current_app.context_processor
+@bp.app_context_processor
 def inject_globals():
     # The footer "Last updated" date.
     # The default is the currently-viewed product's summary refresh date.

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -32,18 +32,16 @@ from .summary import ItemSort
 _LOG = logging.getLogger(__name__)
 bp = flask.Blueprint("stac", __name__, url_prefix="/stac")
 
-PAGE_SIZE_LIMIT = current_app.config.get("STAC_PAGE_SIZE_LIMIT", 1000)
-DEFAULT_PAGE_SIZE = current_app.config.get("STAC_DEFAULT_PAGE_SIZE", 20)
-DEFAULT_CATALOG_SIZE = current_app.config.get("STAC_DEFAULT_CATALOG_SIZE", 500)
+DEFAULT_PAGE_SIZE_LIMIT = 1000
+DEFAULT_PAGE_SIZE = 20
+DEFAULT_CATALOG_SIZE = 500
 
 # Should we force all URLs to include the full hostname?
-FORCE_ABSOLUTE_LINKS = current_app.config.get("STAC_ABSOLUTE_HREFS", True)
+DEFAULT_FORCE_ABSOLUTE_LINKS = True
 
 # Should searches return the full properties for every stac item by default?
 # These searches are much slower we're forced us to use ODC's own metadata table.
-DEFAULT_RETURN_FULL_ITEMS = current_app.config.get(
-    "STAC_DEFAULT_FULL_ITEM_INFORMATION", True
-)
+DEFAULT_RETURN_FULL_ITEMS = True
 
 STAC_VERSION = "1.0.0"
 
@@ -52,6 +50,22 @@ ItemLike = Union[pystac.Item, dict]
 ############################
 #  Helpers
 ############################
+
+
+def get_default_limit() -> int:
+    return current_app.config.get("STAC_DEFAULT_PAGE_SIZE", DEFAULT_PAGE_SIZE)
+
+
+def check_page_limit(limit: int):
+    page_size_limit = current_app.config.get(
+        "STAC_PAGE_SIZE_LIMIT", DEFAULT_PAGE_SIZE_LIMIT
+    )
+    if limit > page_size_limit:
+        abort(
+            400,
+            f"Max page size is {page_size_limit}. "
+            f"Use the next links instead of a large limit.",
+        )
 
 
 def dissoc_in(d: dict, key: str):
@@ -136,7 +150,10 @@ def _unparse_time_range(time: Tuple[datetime, datetime]) -> str:
 
 
 def url_for(*args, **kwargs):
-    if FORCE_ABSOLUTE_LINKS:
+    force_absolute_links = current_app.config.get(
+        "STAC_ABSOLUTE_HREFS", DEFAULT_FORCE_ABSOLUTE_LINKS
+    )
+    if force_absolute_links:
         kwargs["_external"] = True
     return flask.url_for(*args, **kwargs)
 
@@ -520,7 +537,7 @@ def _handle_search_request(
     # Stac-api <=0.7.0 used 'time', later versions use 'datetime'
     time = request_args.get("datetime") or request_args.get("time")
 
-    limit = request_args.get("limit", default=DEFAULT_PAGE_SIZE, type=int)
+    limit = request_args.get("limit", default=get_default_limit(), type=int)
     ids = request_args.get(
         "ids", default=None, type=partial(_array_arg, expect_type=uuid.UUID)
     )
@@ -529,8 +546,11 @@ def _handle_search_request(
 
     # Request the full Item information. This forces us to go to the
     # ODC dataset table for every record, which can be extremely slow.
+    default_full_items = current_app.config.get(
+        "STAC_DEFAULT_FULL_ITEM_INFORMATION", DEFAULT_RETURN_FULL_ITEMS
+    )
     full_information = request_args.get(
-        "_full", default=DEFAULT_RETURN_FULL_ITEMS, type=_bool_argument
+        "_full", default=default_full_items, type=_bool_argument
     )
 
     intersects = request_args.get("intersects", default=None, type=_geojson_arg)
@@ -576,12 +596,7 @@ def _handle_search_request(
     if filter_cql:
         _validate_filter(filter_lang, filter_cql)
 
-    if limit > PAGE_SIZE_LIMIT:
-        abort(
-            400,
-            f"Max page size is {PAGE_SIZE_LIMIT}. "
-            f"Use the next links instead of a large limit.",
-        )
+    check_page_limit(limit)
 
     if bbox is not None and len(bbox) != 4:
         abort(400, "Expected bbox of size 4. [min lon, min lat, max long, max lat]")
@@ -736,7 +751,7 @@ def _handle_fields_extension(items: List[ItemLike], fields: dict) -> List[ItemLi
 
 def search_stac_items(
     get_next_url: Callable[[int], str],
-    limit: int = DEFAULT_PAGE_SIZE,
+    limit: int = 0,
     offset: int = 0,
     dataset_ids: Optional[str] = None,
     product_names: Optional[List[str]] = None,
@@ -757,6 +772,9 @@ def search_stac_items(
 
     :param get_next_url: A function that calculates a page url for the given offset.
     """
+    if limit < 1:
+        limit = get_default_limit()
+
     offset = offset or 0
     if sortby is not None:
         order = sortby
@@ -1227,8 +1245,11 @@ def collection_month(collection: str, year: int, month: int):
     if not all_time_summary:
         abort(404, f"No data for {collection!r} {year} {month}")
 
+    default_catalog_size = current_app.config.get(
+        "STAC_DEFAULT_CATALOG_SIZE", DEFAULT_CATALOG_SIZE
+    )
     request_args = request.args
-    limit = request_args.get("limit", default=DEFAULT_CATALOG_SIZE, type=int)
+    limit = request_args.get("limit", default=default_catalog_size, type=int)
     offset = request_args.get("_o", default=0, type=int)
 
     items = list(
@@ -1319,14 +1340,9 @@ def arrivals_items():
 
     This returns a Stac FeatureCollection of complete Stac Items, with paging links.
     """
-    limit = request.args.get("limit", default=DEFAULT_PAGE_SIZE, type=int)
+    limit = request.args.get("limit", default=get_default_limit(), type=int)
     offset = request.args.get("_o", default=0, type=int)
-    if limit > PAGE_SIZE_LIMIT:
-        abort(
-            400,
-            f"Max page size is {PAGE_SIZE_LIMIT}. "
-            f"Use the next links instead of a large limit.",
-        )
+    check_page_limit(limit)
 
     def next_page_url(next_offset):
         return url_for(

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -16,7 +16,7 @@ from eodatasets3 import stac as eo3stac
 from eodatasets3.model import AccessoryDoc, DatasetDoc, MeasurementDoc, ProductDoc
 from eodatasets3.properties import Eo3Dict
 from eodatasets3.utils import is_doc_eo3
-from flask import abort, request
+from flask import abort, current_app, request
 from pystac import Catalog, Collection, Extent, ItemCollection, Link, STACObject
 from shapely.geometry import shape
 from shapely.geometry.base import BaseGeometry
@@ -32,16 +32,16 @@ from .summary import ItemSort
 _LOG = logging.getLogger(__name__)
 bp = flask.Blueprint("stac", __name__, url_prefix="/stac")
 
-PAGE_SIZE_LIMIT = _model.app.config.get("STAC_PAGE_SIZE_LIMIT", 1000)
-DEFAULT_PAGE_SIZE = _model.app.config.get("STAC_DEFAULT_PAGE_SIZE", 20)
-DEFAULT_CATALOG_SIZE = _model.app.config.get("STAC_DEFAULT_CATALOG_SIZE", 500)
+PAGE_SIZE_LIMIT = current_app.config.get("STAC_PAGE_SIZE_LIMIT", 1000)
+DEFAULT_PAGE_SIZE = current_app.config.get("STAC_DEFAULT_PAGE_SIZE", 20)
+DEFAULT_CATALOG_SIZE = current_app.config.get("STAC_DEFAULT_CATALOG_SIZE", 500)
 
 # Should we force all URLs to include the full hostname?
-FORCE_ABSOLUTE_LINKS = _model.app.config.get("STAC_ABSOLUTE_HREFS", True)
+FORCE_ABSOLUTE_LINKS = current_app.config.get("STAC_ABSOLUTE_HREFS", True)
 
 # Should searches return the full properties for every stac item by default?
 # These searches are much slower we're forced us to use ODC's own metadata table.
-DEFAULT_RETURN_FULL_ITEMS = _model.app.config.get(
+DEFAULT_RETURN_FULL_ITEMS = current_app.config.get(
     "STAC_DEFAULT_FULL_ITEM_INFORMATION", True
 )
 
@@ -248,7 +248,7 @@ def as_stac_item(dataset: DatasetItem) -> pystac.Item:
             dataset_id=dataset.dataset_id,
         ),
         odc_dataset_metadata_url=url_for("dataset.raw_doc", id_=dataset.dataset_id),
-        explorer_base_url=url_for("default_redirect"),
+        explorer_base_url=url_for("pages.default_redirect"),
     )
 
     # Add the region code that Explorer inferred.
@@ -940,7 +940,7 @@ def _geojson_stac_response(doc: Union[STACObject, ItemCollection]) -> flask.Resp
 
 
 def stac_endpoint_information() -> Dict:
-    config = _model.app.config
+    config = current_app.config
     o = dict(
         id=config.get("STAC_ENDPOINT_ID", "odc-explorer"),
         title=config.get("STAC_ENDPOINT_TITLE", "Default ODC Explorer instance"),

--- a/cubedash/run.py
+++ b/cubedash/run.py
@@ -76,13 +76,14 @@ def cli(
     event_log_file: str,
     verbose: bool,
 ):
-    from cubedash import app
+    from cubedash import create_app
     from cubedash.logs import init_logging
 
     init_logging(
         open(event_log_file, "ab") if event_log_file else None, verbosity=verbose
     )
 
+    app = create_app()
     if debug_mode:
         app.debug = True
     run_simple(hostname, port, app, use_reloader=debug_mode, processes=workers)

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -1,6 +1,6 @@
+import os
 from collections import Counter
 from datetime import datetime
-from os import environ
 from typing import Optional, Tuple
 
 import pandas as pd
@@ -29,7 +29,19 @@ _LOG = structlog.get_logger()
 
 _NEWER_SQLALCHEMY = not sqlalchemy.__version__.startswith("1.3")
 
-DEFAULT_TIMEZONE = environ.get("CUBEDASH_DEFAULT_TIMEZONE", "Australia/Darwin")
+# Get default timezone via CUBEDASH_SETTINGS specified config file if it exists,
+# otherwise default to Australia/Darwin
+default_timezone = "Australia/Darwin"
+settings_file = os.environ.get("CUBEDASH_SETTINGS", "settings.env.py")
+try:
+    with open(os.path.join(os.getcwd(), settings_file)) as config_file:
+        for line in config_file:
+            val = line.rstrip().split("=")
+            if val[0] == "CUBEDASH_DEFAULT_TIMEZONE":
+                default_timezone = val[1]
+except FileNotFoundError:
+    pass
+DEFAULT_TIMEZONE = default_timezone
 
 
 def _scalar_subquery(selectable):

--- a/cubedash/templates/about.html
+++ b/cubedash/templates/about.html
@@ -149,9 +149,9 @@
                 </span>
             </li>
             <li>
-                <a href="{{ url_for('arrivals_page') }}">Arriving data</a> summary:
+                <a href="{{ url_for('pages.arrivals_page') }}">Arriving data</a> summary:
                 <span class="uri-path">
-                    {{ url_for('arrivals_csv', _external=True) }}
+                    {{ url_for('pages.arrivals_csv', _external=True) }}
                 </span>
             </li>
             <li>

--- a/cubedash/templates/arrivals.html
+++ b/cubedash/templates/arrivals.html
@@ -8,7 +8,7 @@
         <h2 class="followed lonesome">Recent Dataset Arrivals</h2>
         <span class="header-follow">
             over {{ period_length.days }} days
-            <a href="{{ url_for('.arrivals_csv') }}" class="badge header-badge">
+            <a href="{{ url_for('pages.arrivals_csv') }}" class="badge header-badge">
                 csv
                 <i class="fa-solid fa-file-csv" aria-hidden="true"></i>
             </a>

--- a/cubedash/templates/dataset.html
+++ b/cubedash/templates/dataset.html
@@ -60,7 +60,7 @@
         <div class="sub-header">
             {% if dataset_region_code %}
                 Region
-                <a href="{{ url_for('region_page', region_code=dataset_region_code, product_name=dataset.type.name)}}">
+                <a href="{{ url_for('pages.region_page', region_code=dataset_region_code, product_name=dataset.type.name)}}">
                     {{- dataset_region_code -}}
                 </a>
             {% endif %}

--- a/cubedash/templates/dscount-report.html
+++ b/cubedash/templates/dscount-report.html
@@ -15,7 +15,7 @@
             Total indexed products: <span class="indexed-product-count">{{ datacube_products | length }}</span>,
             hidden products: <span class="hidden-product-count">{{ hidden_product_list | length }}</span> <br/>
             Download csv for all products dataset count
-            <a href="{{ url_for('.dsreport_csv') }}" class="badge header-badge">
+            <a href="{{ url_for('audit.dsreport_csv') }}" class="badge header-badge">
                 csv
                 <i class="fa-solid fa-file-csv" aria-hidden="true"></i>
             </a>
@@ -43,7 +43,7 @@
                             <td>{{ period[1] or '' }}</td>
                             <td>{{ period[2] | month_name if period[2] else '' }}</td>
                             <td class="numeric {% if count == 0 %}muted{% endif %}">
-                                <a href="{{ url_for('product_page',
+                                <a href="{{ url_for('pages.product_page',
                                                 product_name=period[0],
                                                 year=period[1],
                                                 month=period[2])

--- a/cubedash/templates/layout/base.html
+++ b/cubedash/templates/layout/base.html
@@ -33,7 +33,7 @@
 <div class="content-wrapper">
     <div class="header">
         <div id="logo">
-            <a href="{{ url_for('default_redirect') }}">
+            <a href="{{ url_for('pages.default_redirect') }}">
                 {% include theme('logo.html') %}
             </a>
             {%- if explorer_instance_title -%}
@@ -59,7 +59,7 @@
                     <ul>
                         {% for product in datacube_products %}
                             {% if product.name not in hidden_product_list %}
-                                <li><a class="datacube-product-name" href="{{ url_for('product_page', product_name=product.name) }}">{{ product.name }}</a></li>
+                                <li><a class="datacube-product-name" href="{{ url_for('pages.product_page', product_name=product.name) }}">{{ product.name }}</a></li>
                             {% endif %}
                         {% endfor %}
                         {% if hidden_product_list %}
@@ -67,7 +67,7 @@
                         {% endif %}
                         {% for product in datacube_products %}
                             {% if product.name in hidden_product_list %}
-                                <li><a class="configured-hide-product hide" href="{{ url_for('product_page', product_name=product.name) }}">{{ product.name }}</a></li>
+                                <li><a class="configured-hide-product hide" href="{{ url_for('pages.product_page', product_name=product.name) }}">{{ product.name }}</a></li>
                             {% endif %}
                         {% endfor %}
                     </ul>
@@ -83,19 +83,19 @@
                 <li class="top-menu ex-menu">
                     <span class="ex-menu-title">Explore</span>
                     <ul class="left">
-                        <li><a href="{{url_for('arrivals_page')}}">Recently Added</a></li>
+                        <li><a href="{{url_for('pages.arrivals_page')}}">Recently Added</a></li>
                         <li><a href="{{ url_for('product.storage_page') }}">Storage</a></li>
                         <li><a href="{{ url_for('audit.datasets_metadata_page' )}}">Metadata Issues</a></li>
                         <li><a href="{{ url_for('audit.products_overview_page' )}}">Products Overview</a></li>
                         <li><a href="{{ url_for('audit.dscount_report_page') }}">Dataset Counts</a></li>
-                        <li><a href="{{ url_for('about_page') }}">About Explorer</a></li>
+                        <li><a href="{{ url_for('pages.about_page') }}">About Explorer</a></li>
                     </ul>
                 </li>
             </ul>
         </div>
     </div>
     <div id="breadcrumb">
-        <a class="item" href="{{url_for('default_redirect')}}">home</a>
+        <a class="item" href="{{url_for('pages.default_redirect')}}">home</a>
         {% if breadcrumb %}
             {% for url, title, valid_link in breadcrumb %}
                 {% if valid_link %}

--- a/cubedash/templates/layout/macros.html
+++ b/cubedash/templates/layout/macros.html
@@ -11,7 +11,7 @@
                 {% set last = namespace(year=False, bars_this_year=100) %}
                 {% set timeline_items = timeline.items() | sort %}
                 {% for start_time, count in timeline_items  %}
-                    <a href="{{ url_for('product_page',
+                    <a href="{{ url_for('pages.product_page',
                             product_name=product.name,
                             **{
                                 'year': start_time.year,
@@ -57,7 +57,7 @@
                 <span class="query-param {{ prefix+key | maybe_to_css_class_name(prefix="key-") }}">
                     {% set search_link = (dataset and (key in (dataset.type | searchable_fields_keys))) %}
                     {%- if search_link -%}
-                        <a href="{{ url_for('search_page', product_name=dataset.type.name, **{ key: value }) }}" class="query-param-search">
+                        <a href="{{ url_for('pages.search_page', product_name=dataset.type.name, **{ key: value }) }}" class="query-param-search">
                     {%- endif -%}
                     <span class="key"
                         {% if descriptions  and descriptions[key] -%}

--- a/cubedash/templates/layout/product-section.html
+++ b/cubedash/templates/layout/product-section.html
@@ -25,7 +25,7 @@
 
 {% set back_to_product_overview %}
     <div>
-        <a href="{{ url_for('product_page', **product_args) }}">
+        <a href="{{ url_for('pages.product_page', **product_args) }}">
             Return to {{ product.name }} {{ product_args_label }} overview
         </a>
     </div>

--- a/cubedash/templates/product.html
+++ b/cubedash/templates/product.html
@@ -68,7 +68,7 @@
                         </div>
                     {% endif %}
 
-                    <a href="{{ url_for('search_page', **product_args) }}" class="muted dataset-count"
+                    <a href="{{ url_for('pages.search_page', **product_args) }}" class="muted dataset-count"
                     >{{ '{:,d}'.format(selected_summary.dataset_count) if selected_summary else 'Unknown number of' }}
                         dataset{% if selected_summary.dataset_count != 1 %}s{% endif %}
                     </a>
@@ -334,8 +334,8 @@
                   defaultCenter = {{ default_center }};
 
             const routes = new ApplicationRoutes(
-                '{{ url_for('region_page', region_code='__REGION_CODE__', **product_args)}}',
-                '{{ url_for('region_page', region_code='__REGION_CODE__', feelinglucky=True, **product_args) }}',
+                '{{ url_for('pages.region_page', region_code='__REGION_CODE__', **product_args)}}',
+                '{{ url_for('pages.region_page', region_code='__REGION_CODE__', feelinglucky=True, **product_args) }}',
                 '{{ url_for('dataset.dataset_page', id_='__DATASET_ID__') }}',
                 '{{ url_for('api.regions_geojson', **product_args) }}',
                 '{{ url_for('api.datasets_geojson', limit=dataset_limit, **product_args)}}',

--- a/cubedash/templates/products.html
+++ b/cubedash/templates/products.html
@@ -53,7 +53,7 @@
                             {% if product.name not in hidden_product_list %}
                                 <tr class="collapse-when-small">
                                     <td>
-                                        <a href="{{ url_for('product_page', product_name=product.name) }}"
+                                        <a href="{{ url_for('pages.product_page', product_name=product.name) }}"
                                             >{{ product.name }}</a>
                                     </td>
                                     <td class="{% if (not summary) or summary.dataset_count == 0 %}muted{% endif %}">

--- a/cubedash/templates/region.html
+++ b/cubedash/templates/region.html
@@ -42,7 +42,7 @@
         {% endif %}
 
         <div>
-            <a href="{{ url_for('region_geojson', region_code=region_code, **product_args) }}"
+            <a href="{{ url_for('pages.region_geojson', region_code=region_code, **product_args) }}"
                 class="badge">
                 GeoJSON
                 <i class="fa-solid fa-file-text" aria-hidden="true"></i>

--- a/cubedash/templates/search.html
+++ b/cubedash/templates/search.html
@@ -5,7 +5,7 @@
 
 {% block content %}
     <div class="panel relative">
-        <form action="{{ url_for('search_page', product_name=product.name) }}"
+        <form action="{{ url_for('pages.search_page', product_name=product.name) }}"
               method="get"
               class="grid-form">
             <fieldset>

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.4"
 services:
   explorer:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.4"
 services:
   explorer:
     build:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -45,7 +45,7 @@ But Explorer can be run using any typical python wsgi server, for example gunico
 .. code-block:: text
 
     pip install gunicorn
-    gunicorn -b '127.0.0.1:8080' -w 4 cubedash:app
+    gunicorn -b '127.0.0.1:8080' -w 4 cubedash:create_app()
 
 Products will begin appearing one-by-one as the summaries are generated in the
 background.  If impatient, you can manually navigate to a product using

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -10,8 +10,7 @@ from datacube import Datacube
 from flask.testing import FlaskClient
 from structlog import DropEvent
 
-import cubedash
-from cubedash import _model, _utils, generate, logs
+from cubedash import _model, _utils, create_app, generate, logs
 from cubedash.summary import SummaryStore
 from cubedash.summary._schema import METADATA as CUBEDASH_METADATA
 from cubedash.warmup import find_examples_of_all_public_urls
@@ -95,16 +94,17 @@ def all_urls(summary_store: SummaryStore):
 
 @pytest.fixture()
 def empty_client(summary_store: SummaryStore) -> FlaskClient:
-    _model.cache.clear()
     _model.STORE = summary_store
-    cubedash.app.config["TESTING"] = True
-    cubedash.app.config["CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST"] = []
-    cubedash.app.config["CUBEDASH_SISTER_SITES"] = None
-    cubedash.app.config["CUBEDASH_DEFAULT_TIMEZONE"] = "Australia/Darwin"
-    cubedash.app.config["SHOW_DATA_LOCATION"] = {
-        "dea-public-data": "data.dea.ga.gov.au"
-    }
-    return cubedash.app.test_client()
+    app = create_app(
+        {
+            "TESTING": True,
+            "CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST": [],
+            "CUBEDASH_SISTER_SITES": None,
+            "CUBEDASH_DEFAULT_TIMEZONE": "Australia/Darwin",
+            "SHOW_DATA_LOCATION": {"dea-public-data": "data.dea.ga.gov.au"},
+        }
+    )
+    return app.test_client()
 
 
 @pytest.fixture()

--- a/integration_tests/test_configurable_page_elements.py
+++ b/integration_tests/test_configurable_page_elements.py
@@ -1,7 +1,6 @@
 import pytest
 from flask.testing import FlaskClient
 
-import cubedash
 from cubedash.summary import SummaryStore
 from integration_tests.asserts import get_html
 
@@ -22,18 +21,22 @@ pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 @pytest.fixture()
 def app_configured_client(client: FlaskClient):
-    cubedash.app.config["CUBEDASH_INSTANCE_TITLE"] = "Development - ODC"
-    cubedash.app.config["CUBEDASH_SISTER_SITES"] = (
-        ("Production - ODC", "http://prod.odc.example"),
-        ("Production - NCI", "http://nci.odc.example"),
+    client.application.config.update(
+        {
+            "CUBEDASH_INSTANCE_TITLE": "Development - ODC",
+            "CUBEDASH_SISTER_SITES": (
+                ("Production - ODC", "http://prod.odc.example"),
+                ("Production - NCI", "http://nci.odc.example"),
+            ),
+            "CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST": [
+                "ls5_pq_scene",
+                "ls7_pq_scene",
+                "ls8_pq_scene",
+                "ls5_pq_legacy_scene",
+                "ls7_pq_legacy_scene",
+            ],
+        }
     )
-    cubedash.app.config["CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST"] = [
-        "ls5_pq_scene",
-        "ls7_pq_scene",
-        "ls8_pq_scene",
-        "ls5_pq_legacy_scene",
-        "ls7_pq_legacy_scene",
-    ]
     return client
 
 

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -897,9 +897,6 @@ def test_extent_debugging_method(odc_test_db, client: FlaskClient):
     assert cols["crs"] in (28349, 28350, 28351, 28352, 28353, 28354, 28355, 28356)
 
 
-@pytest.mark.skip(
-    reason="TODO: fix issue https://github.com/opendatacube/datacube-explorer/issues/92"
-)
 def test_with_timings(client: FlaskClient):
     _monitoring.init_app_monitoring(client.application)
     # ls7_level1_scene dataset

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -901,7 +901,7 @@ def test_extent_debugging_method(odc_test_db, client: FlaskClient):
     reason="TODO: fix issue https://github.com/opendatacube/datacube-explorer/issues/92"
 )
 def test_with_timings(client: FlaskClient):
-    _monitoring.init_app_monitoring()
+    _monitoring.init_app_monitoring(client.application)
     # ls7_level1_scene dataset
     rv: Response = client.get("/dataset/57848615-2421-4d25-bfef-73f57de0574d")
     assert "Server-Timing" in rv.headers

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -23,7 +23,7 @@ from referencing import Registry, Resource
 from shapely.geometry import shape as shapely_shape
 from shapely.validation import explain_validity
 
-from cubedash import _model
+from cubedash import _model, _stac
 from integration_tests.asserts import (
     DebugContext,
     assert_matching_eo3,
@@ -42,7 +42,7 @@ OUR_PAGE_SIZE = 4
 
 _SCHEMA_BASE = Path(__file__).parent / "schemas"
 # Can't import STAC_VERSION from cubedash._stac since that needs app context
-_STAC_SCHEMA_BASE = _SCHEMA_BASE / "stac/1.0.0"
+_STAC_SCHEMA_BASE = _SCHEMA_BASE / f"stac/{_stac.STAC_VERSION}"
 
 _SCHEMAS_BY_NAME = defaultdict(list)
 for schema_path in _SCHEMA_BASE.rglob("*.json"):

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -23,7 +23,6 @@ from referencing import Registry, Resource
 from shapely.geometry import shape as shapely_shape
 from shapely.validation import explain_validity
 
-import cubedash._stac
 from cubedash import _model
 from integration_tests.asserts import (
     DebugContext,
@@ -42,7 +41,8 @@ OUR_DATASET_LIMIT = 20
 OUR_PAGE_SIZE = 4
 
 _SCHEMA_BASE = Path(__file__).parent / "schemas"
-_STAC_SCHEMA_BASE = _SCHEMA_BASE / f"stac/{cubedash._stac.STAC_VERSION}"
+# Can't import STAC_VERSION from cubedash._stac since that needs app context
+_STAC_SCHEMA_BASE = _SCHEMA_BASE / "stac/1.0.0"
 
 _SCHEMAS_BY_NAME = defaultdict(list)
 for schema_path in _SCHEMA_BASE.rglob("*.json"):
@@ -389,9 +389,13 @@ def stac_client(client: FlaskClient):
     """
     Get a client with populated data and standard settings
     """
-    cubedash._stac.PAGE_SIZE_LIMIT = OUR_DATASET_LIMIT
-    cubedash._stac.DEFAULT_PAGE_SIZE = OUR_PAGE_SIZE
-    _model.app.config["CUBEDASH_DEFAULT_LICENSE"] = "CC-BY-4.0"
+    client.application.config.update(
+        {
+            "STAC_PAGE_SIZE_LIMIT": OUR_DATASET_LIMIT,
+            "STAC_DEFAULT_PAGE_SIZE": OUR_PAGE_SIZE,
+            "CUBEDASH_DEFAULT_LICENSE": "CC-BY-4.0",
+        }
+    )
     return client
 
 


### PR DESCRIPTION
Rather than creating the Flask app module-level across `_model.py` and `_pages.py`, use the preferred application factory pattern to instantiate.
This highlighted an issue around how the default timezone is determined. Having `CUBEDASH_DEFAULT_TIMEZONE` be provided via both an environment variable and the app config seems like overkill, and which version is used - as well as the default value - appears to be inconsistent. Timezone configuration would likely be best revisited and properly reworked in another PR, but for now I suggest having it configurable only via the app config.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--614.org.readthedocs.build/en/614/

<!-- readthedocs-preview datacube-explorer end -->