### PR TITLE
More explicit error for removed Query extension

### DIFF
--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -559,6 +559,13 @@ def _handle_search_request(
                     "Only 'id', 'collection', and Item properties can be used to sort results.",
                 )
 
+    # Make sure users know that the query extension isn't implemented
+    if request_args.get("query") is not None:
+        abort(
+            400,
+            "The Query extension is no longer supported. Please use the Filter extension instead.",
+        )
+
     filter_lang = request_args.get("filter-lang", default=None, type=str)
     filter_cql = request_args.get("filter", default=None, type=_filter_arg)
     filter_crs = request_args.get("filter-crs", default=None)

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -1540,3 +1540,22 @@ def test_stac_filter_extension(stac_client: FlaskClient):
         headers={"Content-Type": "application/json", "Accept": "application/json"},
     )
     assert rv.status_code == 400
+
+
+def test_stac_query_extension_errors(stac_client: FlaskClient):
+    # Trying to use query extension should error
+    query = {"cloud_cover": {"lt": 1}}
+    rv: Response = stac_client.post(
+        "/stac/search",
+        data=json.dumps(
+            {
+                "product": "ga_ls8c_ard_3",
+                "time": "2022-01-01T00:00:00/2022-12-31T00:00:00",
+                "limit": OUR_DATASET_LIMIT,
+                "_full": True,
+                "query": query,
+            }
+        ),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+    )
+    assert rv.status_code == 400


### PR DESCRIPTION
While the STAC API `Query` extension was previously implemented, it suffered from the same flaws in logic as the other API extensions, which meant that while it would return correct results, they risked being oddly distributed when pagination was involved. Since it is recommended to implement the `Filter` extension instead of `Query`, and since correctly re-implementing `Query` was not trivial, it was dropped in favour of `Filter`.
As mentioned in #611, `pystac_client` will warn users if they try to use `query`, but will still return results without issue. The api itself will similarly quietly ignore `query` if provided.
To avoid any silent failure issues down the line, return a 400 error if the request includes a `query` argument.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--615.org.readthedocs.build/en/615/

<!-- readthedocs-preview datacube-explorer end -->