### PR TITLE
Update robots.txt default content

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -40,9 +40,7 @@ _DEFAULT_GROUP_NAME = "Other Products"
 
 _DEFAULT_ARRIVALS_DAYS = 14
 
-_ROBOTS_TXT_DEFAULT = (
-    "User-Agent: *\nAllow: /\nDisallow: /products/*/*\nDisallow: /stac/**"
-)
+_ROBOTS_TXT_DEFAULT = "User-Agent: *\nAllow: /\nDisallow: /products/*/*\nDisallow: /stac/**\nDisallow: /dataset/*"
 
 
 @bp.route("/<product_name>")

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -40,7 +40,12 @@ _DEFAULT_GROUP_NAME = "Other Products"
 
 _DEFAULT_ARRIVALS_DAYS = 14
 
-_ROBOTS_TXT_DEFAULT = "User-Agent: *\nAllow: /\nDisallow: /products/*/*\nDisallow: /stac/**\nDisallow: /dataset/*"
+_ROBOTS_TXT_DEFAULT = """User-Agent: *
+Allow: /
+Disallow: /products/*/*
+Disallow: /stac/**
+Disallow: /dataset/*
+"""
 
 
 @bp.route("/<product_name>")


### PR DESCRIPTION
As recommended, also disallow `/dataset/*` pages in default robots.txt to avoid bots hitting individual datasets.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--616.org.readthedocs.build/en/616/

<!-- readthedocs-preview datacube-explorer end -->