### PR TITLE
Get docker image working with latest gdal ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.5 as builder
+FROM ghcr.io/osgeo/gdal:ubuntu-small-latest as builder
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LC_ALL=C.UTF-8 \
@@ -18,9 +18,9 @@ RUN apt-get update && \
 
 WORKDIR /build
 
-RUN python3.10 -m pip --disable-pip-version-check -q wheel --no-binary psycopg2 psycopg2
+RUN python3 -m pip --disable-pip-version-check -q wheel --no-binary psycopg2 psycopg2
 
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.5
+FROM ghcr.io/osgeo/gdal:ubuntu-small-latest
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LC_ALL=C.UTF-8 \
@@ -59,12 +59,12 @@ COPY . $APPDIR
 # then we want to link the source (with the -e flag) and if we're in prod, we
 # want to delete the stuff in the /code folder to keep it simple.
 COPY --from=builder --link /build/*.whl ./
-RUN python3.10 -m pip --disable-pip-version-check -q install *.whl && \
+RUN python3 -m pip --disable-pip-version-check -q install --break-system-packages *.whl && \
     rm *.whl && \
     ([ "$ENVIRONMENT" = "deployment" ] || \
-        pip --disable-pip-version-check install --editable .[$ENVIRONMENT]) && \
+        pip --disable-pip-version-check install --editable --break-system-packages .[$ENVIRONMENT]) && \
     ([ "$ENVIRONMENT" != "deployment" ] || \
-        (pip --no-cache-dir --disable-pip-version-check install .[$ENVIRONMENT] && \
+        (pip --no-cache-dir --disable-pip-version-check install --break-system-packages .[$ENVIRONMENT] && \
          rm -rf /code/* /code/.git*)) && \
     pip freeze && \
     ([ "$ENVIRONMENT" != "deployment" ] || \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update && \
     rm -rf /var/lib/{apt,dpkg,cache,log} && \
     echo "Environment is: $ENVIRONMENT" && \
     ([ "$ENVIRONMENT" = "deployment" ] || \
-      pip install --disable-pip-version-check pip-tools pytest-cov)
+        pip install --disable-pip-version-check --break-system-packages pip-tools pytest-cov)
 
 # Set up a nice workdir and add the live code
 ENV APPDIR=/code

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update && \
     rm -rf /var/lib/{apt,dpkg,cache,log} && \
     echo "Environment is: $ENVIRONMENT" && \
     ([ "$ENVIRONMENT" = "deployment" ] || \
-        pip install --disable-pip-version-check --break-system-packages pip-tools pytest-cov)
+        pip install --disable-pip-version-check pip-tools pytest-cov --break-system-packages)
 
 # Set up a nice workdir and add the live code
 ENV APPDIR=/code
@@ -59,12 +59,12 @@ COPY . $APPDIR
 # then we want to link the source (with the -e flag) and if we're in prod, we
 # want to delete the stuff in the /code folder to keep it simple.
 COPY --from=builder --link /build/*.whl ./
-RUN python3 -m pip --disable-pip-version-check -q install --break-system-packages *.whl && \
+RUN python3 -m pip --disable-pip-version-check -q install *.whl --break-system-packages && \
     rm *.whl && \
     ([ "$ENVIRONMENT" = "deployment" ] || \
-        pip --disable-pip-version-check install --editable --break-system-packages .[$ENVIRONMENT]) && \
+        pip --disable-pip-version-check install --editable .[$ENVIRONMENT] --break-system-packages) && \
     ([ "$ENVIRONMENT" != "deployment" ] || \
-        (pip --no-cache-dir --disable-pip-version-check install --break-system-packages .[$ENVIRONMENT] && \
+        (pip --no-cache-dir --disable-pip-version-check install .[$ENVIRONMENT] --break-system-packages && \
          rm -rf /code/* /code/.git*)) && \
     pip freeze && \
     ([ "$ENVIRONMENT" != "deployment" ] || \

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -86,9 +86,9 @@ datacube==1.8.18
 dateparser==1.2.0
     # via pygeofilter
 defusedxml==0.7.1
-    # via datacube
-deprecat==2.1.1
     # via eodatasets3
+deprecat==2.1.1
+    # via datacube
 distributed==2023.1.1
     # via datacube
 eodatasets3==0.30.1
@@ -196,9 +196,9 @@ psutil==5.9.4
     # via distributed
 psycopg2==2.9.5
     # via datacube
-pygeofilter==0.2.1
+pygeofilter==0.2.4
     # via datacube-explorer (setup.py)
-pygeoif==1.4.0
+pygeoif==1.5.0
     # via pygeofilter
 pyorbital==1.7.3
     # via datacube-explorer (setup.py)
@@ -241,7 +241,7 @@ referencing==0.32.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2023.12.25
+regex==2024.5.15
     # via dateparser
 requests==2.28.2
     # via pyorbital
@@ -296,7 +296,7 @@ toolz==0.12.0
     #   partd
 tornado==6.2
     # via distributed
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via pygeoif
 tzlocal==5.2
     # via dateparser

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
         "sqlalchemy>=1.4",
         "structlog>=20.2.0",
         "pytz",
-        "pygeofilter",
+        "pygeofilter>=0.2.2",
     ],
     tests_require=tests_require,
     extras_require=extras_require,


### PR DESCRIPTION
Address issues causing docker compile to fail with latest `osgeo/gdal:ubuntu=small` image (>=3.9.0):
- Don't restrict to `python3.10` when running install
- Use `--break-system-packages` option to avoid PEP 668 "externally managed environment" error

Also update `pygeofilter` version, meaning custom class to enable handling unknown field names is no longer needed.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--619.org.readthedocs.build/en/619/

<!-- readthedocs-preview datacube-explorer end -->