### PR TITLE
Dockerfile: fixate GDAL version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-small-latest as builder
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.9.1 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LC_ALL=C.UTF-8 \
@@ -20,7 +20,7 @@ WORKDIR /build
 
 RUN python3 -m pip --disable-pip-version-check -q wheel --no-binary psycopg2 psycopg2
 
-FROM ghcr.io/osgeo/gdal:ubuntu-small-latest
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.9.1
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LC_ALL=C.UTF-8 \


### PR DESCRIPTION
Building from gdal-latest will make
the explorer 2.12.3 image unbuildable
when gdal-latest suddenly contains
breaking changes.

Fixate the image version to keep old
releases of explorer buildable even
in the future.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--620.org.readthedocs.build/en/620/

<!-- readthedocs-preview datacube-explorer end -->