### PR TITLE
Require fiona 1.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "click",
         "datacube>=1.8.18",
         "eodatasets3>=0.30.1",
-        "fiona",
+        "fiona>=1.10.0",
         "flask",
         "Flask-Caching",
         "flask-cors",


### PR DESCRIPTION
This fixes GHSA-q5fm-55c2-v6j9
and GHSA-g4m4-9q4c-mfw6.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--624.org.readthedocs.build/en/624/

<!-- readthedocs-preview datacube-explorer end -->