### PR TITLE
docs: fix flask-caching URL

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -11,7 +11,7 @@ The following configuration values are used internally by Datacube-explorer:
 
 .. py:data:: CACHE_TYPE
 
-    Enable Flask-Cache https://pythonhosted.org/Flask-Caching/#configuring-flask-caching settings.
+    Enable Flask-Cache https://flask-caching.readthedocs.io/en/latest/index.html#configuring-flask-caching settings.
 
     Default: ``NullCache``
 


### PR DESCRIPTION
The URL gives me a "This site can't be reached"
message, stating "might be temporarily down or
it may have moved permanently to a new web
address" with a ERR_INVALID_RESPONSE below.

Trying with curl shows a 404. Rather than
trying to figure out what once was at the page
and how to access that content, update
the URL to point to the documentation
at readthedocs.io that just works.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--626.org.readthedocs.build/en/626/

<!-- readthedocs-preview datacube-explorer end -->