### PR TITLE
Update robots.txt

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -40,11 +40,11 @@ _DEFAULT_GROUP_NAME = "Other Products"
 
 _DEFAULT_ARRIVALS_DAYS = 14
 
-_ROBOTS_TXT_DEFAULT = """User-Agent: *
-Allow: /
-Disallow: /products/*/*
-Disallow: /stac/**
-Disallow: /dataset/*
+_ROBOTS_TXT_DEFAULT = """User-agent: *
+Disallow: /products/
+Disallow: /product/
+Disallow: /stac/
+Disallow: /dataset/
 """
 
 


### PR DESCRIPTION
Attempt to exclude web crawlers by ensuring robots.txt is fully standard compliant (no allow field, same capitalisation as standard, no wildcards) and covers both singular/plural product paths.

More explanation https://github.com/GeoscienceAustralia/dea-tech-support/discussions/36

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--642.org.readthedocs.build/en/642/

<!-- readthedocs-preview datacube-explorer end -->