### PR TITLE
docs: depend on sphinx-tabs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "sphinx_click",
     "sphinx_click.ext",
     "sphinx.ext.autosectionlabel",
+    "sphinx_tabs.tabs",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ pydata-sphinx-theme==0.9.0
 Sphinx==5.0.0
 sphinx-autodoc-typehints==1.19.0
 sphinx-click==4.2.0
+sphinx-tabs==3.4.7


### PR DESCRIPTION
Fixes #627.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--647.org.readthedocs.build/en/647/

<!-- readthedocs-preview datacube-explorer end -->