### PR TITLE
Update to Python 3.10 syntax

### DIFF
--- a/cubedash/_audit.py
+++ b/cubedash/_audit.py
@@ -1,8 +1,8 @@
 import logging
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Iterable
 
 import flask
 from datacube.model import Range

--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -4,8 +4,8 @@ Common global filters for templates.
 
 import calendar
 import logging
+from collections.abc import Mapping
 from datetime import datetime
-from typing import Mapping
 from urllib.parse import quote_plus
 
 import flask

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -1,8 +1,8 @@
 import json
 import os
 import time
+from collections import Counter
 from pathlib import Path
-from typing import Counter, Dict, List, Optional, Tuple
 
 import flask
 import sentry_sdk
@@ -182,15 +182,15 @@ _LOG = structlog.get_logger()
 @cache.memoize(timeout=60)
 def get_time_summary(
     product_name: str,
-    year: Optional[int] = None,
-    month: Optional[int] = None,
-    day: Optional[int] = None,
-) -> Optional[TimePeriodOverview]:
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
+) -> TimePeriodOverview | None:
     return STORE.get(product_name, year, month, day)
 
 
 @cache.memoize(timeout=60)
-def get_time_summary_all_products() -> Dict[Tuple[str, int, int], int]:
+def get_time_summary_all_products() -> dict[tuple[str, int, int], int]:
     return STORE.get_all_dataset_counts()
 
 
@@ -198,11 +198,11 @@ def get_product_summary(product_name: str) -> ProductSummary:
     return STORE.get_product_summary(product_name)
 
 
-ProductWithSummary = Tuple[Product, Optional[ProductSummary]]
+ProductWithSummary = tuple[Product, ProductSummary | None]
 
 
 @cache.memoize(timeout=120)
-def get_products() -> List[ProductWithSummary]:
+def get_products() -> list[ProductWithSummary]:
     """
     The list of all products that we have generated reports for.
     """
@@ -218,7 +218,7 @@ def get_products() -> List[ProductWithSummary]:
 
 
 @cache.memoize(timeout=120)
-def get_products_with_summaries() -> List[ProductWithSummary]:
+def get_products_with_summaries() -> list[ProductWithSummary]:
     """The list of products that we have generated summaries for."""
     return [
         (product, summary) for product, summary in get_products() if summary is not None
@@ -228,10 +228,10 @@ def get_products_with_summaries() -> List[ProductWithSummary]:
 @cache.memoize(timeout=60)
 def get_footprint_geojson(
     product_name: str,
-    year: Optional[int] = None,
-    month: Optional[int] = None,
-    day: Optional[int] = None,
-) -> Optional[Dict]:
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
+) -> dict | None:
     period = get_time_summary(product_name, year, month, day)
     if period is None:
         return None
@@ -254,10 +254,10 @@ def get_footprint_geojson(
 @cache.memoize(timeout=60)
 def get_regions_geojson(
     product_name: str,
-    year: Optional[int] = None,
-    month: Optional[int] = None,
-    day: Optional[int] = None,
-) -> Optional[Dict]:
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
+) -> dict | None:
     product = STORE.get_product(product_name)
 
     region_info = STORE.get_product_region_info(product_name)
@@ -289,7 +289,7 @@ def get_regions_geojson(
     return regions
 
 
-def _get_footprint(period: TimePeriodOverview) -> Optional[MultiPolygon]:
+def _get_footprint(period: TimePeriodOverview) -> MultiPolygon | None:
     if not period or not period.dataset_count:
         return None
 
@@ -309,7 +309,7 @@ def _get_footprint(period: TimePeriodOverview) -> Optional[MultiPolygon]:
 
 def _get_regions_geojson(
     region_counts: Counter[str], region_info: RegionInfo
-) -> Optional[Dict]:
+) -> dict | None:
     if not region_info:
         # Regions are unsupported for product
         return None

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -1,7 +1,6 @@
 import decimal
 import re
 from datetime import datetime, timedelta
-from typing import List, Tuple
 
 import datacube
 import dateutil.parser
@@ -428,7 +427,7 @@ def timeline_page(product_name: str):
 
 def _load_product(
     product_name, year, month, day
-) -> Tuple[
+) -> tuple[
     Product,
     ProductSummary,
     TimePeriodOverview,
@@ -502,7 +501,7 @@ HREF = str
 SHOULD_LINK = bool
 
 
-def _get_breadcrumbs(url: str, script_root: str) -> List[Tuple[HREF, str, SHOULD_LINK]]:
+def _get_breadcrumbs(url: str, script_root: str) -> list[tuple[HREF, str, SHOULD_LINK]]:
     """
     >>> _get_breadcrumbs('/products/great_product', '/')
     [('/products', 'products', True), ('/products/great_product', 'great_product', False)]
@@ -538,7 +537,7 @@ def _get_breadcrumbs(url: str, script_root: str) -> List[Tuple[HREF, str, SHOULD
     return breadcrumb
 
 
-def _get_grouped_products() -> List[Tuple[str, List[ProductWithSummary]]]:
+def _get_grouped_products() -> list[tuple[str, list[ProductWithSummary]]]:
     """
     We group products using the configured grouping field (default "product_type").
 
@@ -589,9 +588,9 @@ def _get_grouped_products() -> List[Tuple[str, List[ProductWithSummary]]]:
 
 
 def _partition_default(
-    grouped_product_summarise: List[Tuple[str, List[ProductWithSummary]]],
+    grouped_product_summarise: list[tuple[str, list[ProductWithSummary]]],
     remainder_group_size=5,
-) -> List[Tuple[str, List[ProductWithSummary]]]:
+) -> list[tuple[str, list[ProductWithSummary]]]:
     """
     For default items and place them at the end in batches.
     """
@@ -616,7 +615,7 @@ def _partition_default(
     return grouped_product_summarise
 
 
-def chunks(ls: List, n: int):
+def chunks(ls: list, n: int):
     """
     Split list into chunks of max size n.
 

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -9,9 +9,9 @@ import io
 import itertools
 import re
 from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime, timedelta
 from io import StringIO
-from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
 from urllib.parse import urljoin, urlparse
 
 import eodatasets3.serialise
@@ -63,7 +63,7 @@ MATCH_CUTOFF = 0.38
 _LOG = structlog.get_logger()
 
 
-def infer_crs(crs_str: str) -> Optional[str]:
+def infer_crs(crs_str: str) -> str | None:
     plausible_list = [
         code
         for code in DEFAULT_CRS_INFERENCES
@@ -139,7 +139,7 @@ def datetime_expression(md_type: MetadataType):
     return center_time
 
 
-def get_dataset_file_offsets(dataset: Dataset) -> Dict[str, str]:
+def get_dataset_file_offsets(dataset: Dataset) -> dict[str, str]:
     """
     Get (usually relative) paths for all known files of a dataset.
 
@@ -172,7 +172,7 @@ def as_resolved_remote_url(location: str, offset: str) -> str:
 
 def as_external_url(
     url: str, s3_region: str = None, is_base: bool = False
-) -> Optional[str]:
+) -> str | None:
     """
     Convert a URL to an externally-visible one.
 
@@ -237,7 +237,7 @@ def group_field_names(request: dict) -> dict:
     return dict(out)
 
 
-def get_sorted_product_summaries(product_summaries: dict, key: str) -> List:
+def get_sorted_product_summaries(product_summaries: dict, key: str) -> list:
     return sorted(
         (
             (name or "", list(items))
@@ -285,7 +285,7 @@ def dataset_label(dataset: Dataset) -> str:
     return str(dataset.id)
 
 
-def _get_reasonable_file_label(uri: str) -> Optional[str]:
+def _get_reasonable_file_label(uri: str) -> str | None:
     """
     Get a label for the dataset from a URI.... if we can.
 
@@ -324,7 +324,7 @@ def _get_reasonable_file_label(uri: str) -> Optional[str]:
     return None
 
 
-def product_license(product: Product) -> Optional[str]:
+def product_license(product: Product) -> str | None:
     """
     What is the license to display for this product?
 
@@ -356,11 +356,11 @@ def _next_month(date: datetime):
 
 
 def as_time_range(
-    year: Optional[int] = None,
-    month: Optional[int] = None,
-    day: Optional[int] = None,
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
     tzinfo=None,
-) -> Optional[Range]:
+) -> Range | None:
     """
     >>> as_time_range(2018)
     Range(begin=datetime.datetime(2018, 1, 1, 0, 0), end=datetime.datetime(2019, 1, 1, 0, 0))
@@ -439,7 +439,7 @@ def now_utc() -> datetime:
     return default_utc(datetime.utcnow())
 
 
-def dataset_created(dataset: Dataset) -> Optional[datetime]:
+def dataset_created(dataset: Dataset) -> datetime | None:
     if "created" in dataset.metadata.fields:
         return dataset.metadata.created
 
@@ -648,8 +648,8 @@ def only_alphanumeric(s: str):
 def as_csv(
     *,
     filename_prefix: str,
-    headers: Tuple[str, ...],
-    rows: Iterable[Tuple[object, ...]],
+    headers: tuple[str, ...],
+    rows: Iterable[tuple[object, ...]],
 ):
     """Return a CSV Flask response."""
     out = io.StringIO()
@@ -704,7 +704,7 @@ def prepare_dataset_formatting(
 def prepare_document_formatting(
     metadata_doc: Mapping,
     doc_friendly_label: str = "",
-    include_source_url: Union[bool, str] = False,
+    include_source_url: bool | str = False,
 ):
     """
     Try to format a raw document for readability.
@@ -712,7 +712,7 @@ def prepare_document_formatting(
     This will change property order, add comments on the type & source url.
     """
 
-    def get_property_priority(ordered_properties: List, keyval):
+    def get_property_priority(ordered_properties: list, keyval):
         key, val = keyval
         if key not in ordered_properties:
             return 999
@@ -861,7 +861,7 @@ EODATASETS_LINEAGE_PROPERTY_ORDER = [
 ]
 
 
-def dataset_shape(ds: Dataset) -> Tuple[Optional[Polygon], bool]:
+def dataset_shape(ds: Dataset) -> tuple[Polygon | None, bool]:
     """
     Get a usable extent from the dataset (if possible), and return
     whether the original was valid.

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -57,11 +57,11 @@ import collections
 import multiprocessing
 import re
 import sys
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import partial
 from textwrap import dedent
-from typing import List, Optional, Sequence, Tuple
 
 import click
 import structlog
@@ -100,8 +100,8 @@ class GenerateSettings:
 
 # pylint: disable=broad-except
 def generate_report(
-    item: Tuple[str, GenerateSettings, str],
-) -> Tuple[str, GenerateResult, Optional[TimePeriodOverview]]:
+    item: tuple[str, GenerateSettings, str],
+) -> tuple[str, GenerateResult, TimePeriodOverview | None]:
     product_name, settings, grouping_time_zone = item
     log = _LOG.bind(product=product_name)
 
@@ -158,7 +158,7 @@ def run_generation(
     products: Sequence[Product],
     grouping_time_zone=DEFAULT_TIMEZONE,
     workers=3,
-) -> Tuple[int, int]:
+) -> tuple[int, int]:
     user_message(
         f"Updating {len(products)} products for "
         f"{style(str(settings.env_name), bold=True)}",
@@ -222,7 +222,7 @@ def run_generation(
     return creation_count, failure_count
 
 
-def _load_products(store: SummaryStore, product_names) -> List[Product]:
+def _load_products(store: SummaryStore, product_names) -> list[Product]:
     for product_name in product_names:
         try:
             yield store.get_product(product_name)
@@ -433,7 +433,7 @@ def cli(
     generate_all_products: bool,
     jobs: int,
     timezone: str,
-    product_names: List[str],
+    product_names: list[str],
     event_log_file: str,
     refresh_stats: bool,
     force_concurrently: bool,
@@ -444,7 +444,7 @@ def cli(
     epsg_code: int,
     recreate_dataset_extents: bool,
     reset_incremental_position: bool,
-    minimum_scan_window: Optional[timedelta],
+    minimum_scan_window: timedelta | None,
 ):
     init_logging(
         open(event_log_file, "ab") if event_log_file else None, verbosity=verbose
@@ -505,7 +505,7 @@ _TIME_PERIOD_FORMAT = re.compile(
 )
 
 
-def parse_timedelta(value: str) -> Optional[timedelta]:
+def parse_timedelta(value: str) -> timedelta | None:
     """
     Parse a string such as "30h40m" into a timedelta.
 

--- a/cubedash/index/api.py
+++ b/cubedash/index/api.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
+from collections.abc import Generator, Iterable
 from datetime import datetime, timedelta
-from typing import Generator, Iterable
 from uuid import UUID
 
 from datacube.index import Index

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -1,5 +1,5 @@
+from collections.abc import Generator, Iterable
 from datetime import date, datetime, timedelta
-from typing import Generator, Iterable
 from uuid import UUID
 
 import shapely.ops

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -1,7 +1,5 @@
+from collections.abc import Generator
 from datetime import datetime, timedelta
-from typing import (
-    Generator,
-)
 from uuid import UUID
 
 import shapely.ops

--- a/cubedash/index/postgres/_schema.py
+++ b/cubedash/index/postgres/_schema.py
@@ -1,6 +1,5 @@
 import warnings
 from textwrap import dedent
-from typing import Set
 
 from datacube.drivers.postgres._schema import DATASET as ODC_DATASET
 from geoalchemy2 import Geometry
@@ -358,7 +357,7 @@ def create_schema(conn: Connection, epsg_code: int):
     )
 
 
-def update_schema(conn: Connection) -> Set[PleaseRefresh]:
+def update_schema(conn: Connection) -> set[PleaseRefresh]:
     """
     Update the schema if needed.
 

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -1,7 +1,6 @@
 import os
 from collections import Counter
 from datetime import datetime
-from typing import Optional, Tuple
 
 import pandas as pd
 import sqlalchemy
@@ -46,7 +45,7 @@ class Summariser:
     def calculate_summary(
         self,
         product_name: str,
-        year_month_day: Tuple[Optional[int], Optional[int], Optional[int]],
+        year_month_day: tuple[int | None, int | None, int | None],
         product_refresh_time: datetime,
     ) -> TimePeriodOverview:
         """

--- a/cubedash/warmup.py
+++ b/cubedash/warmup.py
@@ -1,9 +1,7 @@
-import socket
 import sys
 import time
 import urllib.request
 from textwrap import indent
-from typing import List, Tuple
 from urllib.error import HTTPError, URLError
 from urllib.parse import urljoin
 
@@ -142,7 +140,7 @@ def cli(
     Returns error count.
     """
     max_failure_line_count = sys.maxsize if verbose else 5
-    response_times: List[Tuple[float, str]] = []
+    response_times: list[tuple[float, str]] = []
     failures = []
     consecutive_failures = 0
 
@@ -167,7 +165,7 @@ def cli(
             consecutive_failures = 0
             response_times.append((finished_in, url))
             time.sleep(throttle_seconds)
-        except socket.timeout:
+        except TimeoutError:
             secho(f"timeout (> {timeout_seconds}s)", fg="magenta", err=True)
             handle_failure()
         except HTTPError as e:

--- a/integration_tests/asserts.py
+++ b/integration_tests/asserts.py
@@ -1,10 +1,10 @@
 import json
 import re
+from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
 from pprint import pformat, pprint
 from textwrap import indent
-from typing import Dict, Iterable, Optional, Set, Tuple
 
 import jsonschema
 import pytest
@@ -45,7 +45,7 @@ def assert_shapes_mostly_equal(
     assert (s1 - s2).area < threshold, f"{s1} is not mostly equal to {s2}"
 
 
-def assert_matching_eo3(actual_doc: Dict, expected_doc: Dict):
+def assert_matching_eo3(actual_doc: dict, expected_doc: dict):
     """
     Assert an EO3 document matches an expected document,
 
@@ -73,7 +73,7 @@ def assert_matching_eo3(actual_doc: Dict, expected_doc: Dict):
     )
 
 
-def get_geojson(client: FlaskClient, url: str) -> Dict:
+def get_geojson(client: FlaskClient, url: str) -> dict:
     data = get_json(client, url)
     validate_document(
         data,
@@ -85,7 +85,7 @@ def get_geojson(client: FlaskClient, url: str) -> Dict:
 
 def get_text_response(
     client: FlaskClient, url: str, expect_status_code=200
-) -> Tuple[str, Response]:
+) -> tuple[str, Response]:
     response: Response = client.get(url, follow_redirects=True)
     assert response.status_code == expect_status_code, (
         f"Expected status {expect_status_code} not {response.status_code}."
@@ -94,7 +94,7 @@ def get_text_response(
     return response.data.decode("utf-8"), response
 
 
-def get_json(client: FlaskClient, url: str, expect_status_code=200) -> Dict:
+def get_json(client: FlaskClient, url: str, expect_status_code=200) -> dict:
     rv: Response = client.get(url, follow_redirects=True)
     try:
         assert rv.status_code == expect_status_code, (
@@ -156,9 +156,9 @@ def expect_values(
     newest_creation_time: datetime,
     timeline_period: str,
     timeline_count: int,
-    crses: Set[str],
-    size_bytes: Optional[int],
-    region_dataset_counts: Dict = None,
+    crses: set[str],
+    size_bytes: int | None,
+    region_dataset_counts: dict = None,
 ):
     __tracebackhide__ = True
 
@@ -311,7 +311,7 @@ def _add_context(e: AssertionError, context_message: str):
     e.args = tuple(args)
 
 
-def format_doc_diffs(left: Dict, right: Dict) -> Iterable[str]:
+def format_doc_diffs(left: dict, right: dict) -> Iterable[str]:
     """
     Get a human-readable list of differences in the given documents.
 

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from pathlib import Path
 from pprint import pprint
 from textwrap import dedent
-from typing import Dict
 from uuid import UUID
 
 import pytest
@@ -220,7 +219,7 @@ def test_undo_eo3_compatibility_del_handling():
     assert _utils.undo_eo3_compatibility(doc) is None
 
 
-def with_parsed_datetimes(v: Dict, name=""):
+def with_parsed_datetimes(v: dict, name=""):
     """
     All date fields in eo3 metadata have names ending in 'datetime'. Return a doc
     with all of these fields parsed as actual dates.

--- a/integration_tests/test_pages_render.py
+++ b/integration_tests/test_pages_render.py
@@ -1,5 +1,4 @@
 from textwrap import indent
-from typing import List
 
 import pytest
 from datacube import Datacube
@@ -27,7 +26,7 @@ DATASETS = [
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
-def assert_all_urls_render(all_urls: List[str], client: FlaskClient):
+def assert_all_urls_render(all_urls: list[str], client: FlaskClient):
     """Assert all given URLs return an OK HTTP response
 
     These can be used to test that the application works when

--- a/integration_tests/test_stores.py
+++ b/integration_tests/test_stores.py
@@ -2,7 +2,6 @@ import operator
 import time
 from collections import Counter
 from datetime import date, datetime
-from typing import List
 
 import pytest
 from datacube.model import Range
@@ -114,7 +113,7 @@ def test_add_no_periods(summary_store: SummaryStore):
 
 def test_month_iteration():
     def assert_month_iteration(
-        start: datetime, end: datetime, expected_months: List[date]
+        start: datetime, end: datetime, expected_months: list[date]
     ):
         __tracebackhide__ = operator.methodcaller("errisinstance", AssertionError)
 


### PR DESCRIPTION
Use modern syntax for types,
and import things from collection
instead of typing when possible.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--654.org.readthedocs.build/en/654/

<!-- readthedocs-preview datacube-explorer end -->