### PR TITLE
Fix utcnow() warning

### DIFF
--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -4,7 +4,7 @@ Common global filters for templates.
 
 import calendar
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Mapping
 from urllib.parse import quote_plus
 
@@ -296,7 +296,7 @@ def timesince(dt, default="just now"):
     if dt is None:
         return "an unrecorded time ago"
 
-    now = datetime.utcnow().replace(tzinfo=tz.tzutc())
+    now = datetime.now(timezone.utc).replace(tzinfo=tz.tzutc())
     diff = now - utils.default_utc(dt)
 
     periods = (

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -1,6 +1,6 @@
 import decimal
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Tuple
 
 import datacube
@@ -203,7 +203,7 @@ def search_page(
                 creation_time.begin or product_summary.time_earliest,
                 # product time bounds don't necessarily include the creation time
                 # so use today's date instead as our end bound if needed
-                creation_time.end or datetime.utcnow(),
+                creation_time.end or datetime.now(timezone.utc),
             )
         query["creation_time"] = creation_time
 
@@ -484,7 +484,7 @@ def inject_globals():
             "CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST", []
         ),
         datacube_metadata_types=list(_model.STORE.all_metadata_types()),
-        current_time=datetime.utcnow(),
+        current_time=datetime.now(timezone.utc),
         datacube_version=datacube.__version__,
         app_version=cubedash.__version__,
         grouping_timezone=tz.gettz(_model.DEFAULT_GROUPING_TIMEZONE),

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -9,7 +9,7 @@ import io
 import itertools
 import re
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import StringIO
 from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
 from urllib.parse import urljoin, urlparse
@@ -436,7 +436,7 @@ def default_utc(d: datetime) -> datetime:
 
 
 def now_utc() -> datetime:
-    return default_utc(datetime.utcnow())
+    return default_utc(datetime.now(timezone.utc))
 
 
 def dataset_created(dataset: Dataset) -> Optional[datetime]:

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -3,7 +3,7 @@ Tests that load pages and check the contained text.
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from io import StringIO
 from textwrap import indent
 
@@ -988,7 +988,7 @@ def test_all_give_404s(client: FlaskClient):
             )
 
     name = "does_not_exist"
-    time = datetime.utcnow()
+    time = datetime.now(timezone.utc)
     region_code = "not_a_region"
     dataset_id = "37296b9a-e6ec-4bfd-ab80-cc32902429d1"
 


### PR DESCRIPTION
Use datetime.now(timezone.utc) instead.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--655.org.readthedocs.build/en/655/

<!-- readthedocs-preview datacube-explorer end -->