### PR TITLE
CI: cancel old PR jobs

### DIFF
--- a/.github/workflows/deployment_test.yaml
+++ b/.github/workflows/deployment_test.yaml
@@ -16,6 +16,12 @@ on: # yamllint disable-line rule:truthy
 env:
   IMAGE_NAME: opendatacube/explorer
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   deployment-image-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -9,6 +9,12 @@ on:
 permissions:
   pull-requests: write
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   documentation-preview:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,12 @@ on:
 env:
   IMAGE_NAME: opendatacube/explorer
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -7,6 +7,12 @@ on:
 env:
   IMAGE_NAME: opendatacube/explorer
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   cve-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,12 @@ on:
 env:
   IMAGE_NAME: opendatacube/explorer
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Cancel the previous jobs
when a PR is updated.
Merge jobs are never
cancelled.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--657.org.readthedocs.build/en/657/

<!-- readthedocs-preview datacube-explorer end -->