### PR TITLE
Remove psycopg2 usages

### DIFF
--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -15,7 +15,6 @@ from datacube.drivers.postgres._fields import RangeDocField as PgresRangeDocFiel
 from datacube.model import Dataset, Field, MetadataType, Product
 from geoalchemy2 import Geometry, WKBElement
 from geoalchemy2.shape import to_shape
-from psycopg2._range import Range as PgRange
 from shapely.geometry import shape
 from sqlalchemy import (
     BigInteger,
@@ -379,8 +378,6 @@ def _as_json(obj):
             return str(prefix + to_shape(o).wkt)
         if isinstance(o, datetime):
             return o.isoformat()
-        if isinstance(o, PgRange):
-            return ["∞" if o.lower_inf else o.lower, "∞" if o.upper_inf else o.upper]
         return repr(o)
 
     return json.dumps(obj, indent=4, default=fallback)

--- a/integration_tests/data_wofs_summary.py
+++ b/integration_tests/data_wofs_summary.py
@@ -1,13 +1,14 @@
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import shapely.wkt
 from datacube.model import Range
-from psycopg2.tz import FixedOffsetTimezone
 
 from cubedash.summary import TimePeriodOverview
 
+_tz10 = timezone(timedelta(hours=10))
+_tz11 = timezone(timedelta(hours=11))
 #
 # This is a dump of the wofs_summary overview for all-time.
 # It was consistently failing because the valid footprint becomes invalid when
@@ -22,99 +23,37 @@ wofs_time_summary = TimePeriodOverview(
     dataset_count=1244,
     timeline_dataset_counts=Counter(
         {
-            datetime(
-                1970, 1, 1, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 1244,
-            datetime(
-                1970, 1, 2, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 3, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 4, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 5, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 6, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 7, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 8, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 9, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 10, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 11, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 12, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 13, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 14, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 15, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 16, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 17, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 18, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 19, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 20, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 21, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 22, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 23, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 24, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 25, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 26, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 27, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 28, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 29, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 30, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
-            datetime(
-                1970, 1, 31, 0, 0, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-            ): 0,
+            datetime(1970, 1, 1, 0, 0, tzinfo=_tz10): 1244,
+            datetime(1970, 1, 2, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 3, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 4, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 5, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 6, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 7, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 8, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 9, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 10, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 11, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 12, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 13, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 14, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 15, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 16, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 17, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 18, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 19, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 20, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 21, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 22, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 23, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 24, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 25, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 26, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 27, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 28, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 29, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 30, 0, 0, tzinfo=_tz10): 0,
+            datetime(1970, 1, 31, 0, 0, tzinfo=_tz10): 0,
         }
     ),
     region_dataset_counts=Counter(
@@ -1367,12 +1306,8 @@ wofs_time_summary = TimePeriodOverview(
     ),
     timeline_period="day",
     time_range=Range(
-        begin=datetime(
-            1970, 1, 1, 0, 30, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-        ),
-        end=datetime(
-            1970, 2, 1, 0, 30, tzinfo=FixedOffsetTimezone(offset=600, name=None)
-        ),
+        begin=datetime(1970, 1, 1, 0, 30, tzinfo=_tz10),
+        end=datetime(1970, 2, 1, 0, 30, tzinfo=_tz10),
     ),
     footprint_geometry=(
         shapely.wkt.load(
@@ -1384,35 +1319,10 @@ wofs_time_summary = TimePeriodOverview(
     footprint_crs="EPSG:3577",
     footprint_count=1244,
     newest_dataset_creation_time=datetime(
-        2018,
-        7,
-        4,
-        11,
-        24,
-        25,
-        392_500,
-        tzinfo=FixedOffsetTimezone(offset=600, name=None),
+        2018, 7, 4, 11, 24, 25, 392_500, tzinfo=_tz10
     ),
     crses={"EPSG:3577"},
     size_bytes=0,
-    summary_gen_time=datetime(
-        2019,
-        2,
-        22,
-        21,
-        46,
-        16,
-        853_756,
-        tzinfo=FixedOffsetTimezone(offset=660, name=None),
-    ),
-    product_refresh_time=datetime(
-        2019,
-        2,
-        22,
-        21,
-        22,
-        16,
-        853_756,
-        tzinfo=FixedOffsetTimezone(offset=660, name=None),
-    ),
+    summary_gen_time=datetime(2019, 2, 22, 21, 46, 16, 853_756, tzinfo=_tz11),
+    product_refresh_time=datetime(2019, 2, 22, 21, 22, 16, 853_756, tzinfo=_tz11),
 )


### PR DESCRIPTION
Replace a deprecated use of psycopg2 timezones in the test suite with the recommended `datetime.timezone`, and stop pretty-printing `PgRange` in a function that is only used by the test suite.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--660.org.readthedocs.build/en/660/

<!-- readthedocs-preview datacube-explorer end -->