### PR TITLE
docker-compose: speed up postgis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     volumes:
       - type: tmpfs
         target: /var/lib/postgresql/data
-    command: -c fsync=off -c full_page_writes=off
+    command: -c fsync=off -c full_page_writes=off -c synchronous_commit=off
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "postgres", "-q", "-d", "opendatacube", "-U", "opendatacube"]
       timeout: 45s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     volumes:
       - type: tmpfs
         target: /var/lib/postgresql/data
-    command: -c fsync=off
+    command: -c fsync=off -c full_page_writes=off
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "postgres", "-q", "-d", "opendatacube", "-U", "opendatacube"]
       timeout: 45s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,9 @@ services:
     ports:
       - 5432:5432
     restart: always
+    volumes:
+      - type: tmpfs
+        target: /var/lib/postgresql/data
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "postgres", "-q", "-d", "opendatacube", "-U", "opendatacube"]
       timeout: 45s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     volumes:
       - type: tmpfs
         target: /var/lib/postgresql/data
+    command: -c fsync=off
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "postgres", "-q", "-d", "opendatacube", "-U", "opendatacube"]
       timeout: 45s


### PR DESCRIPTION
Speed up postgis by putting the database on tmpfs instead of the slow Docker overlay filesystem.

Since this means our test data will most likely be lost anyways if the database crashes, also turn off fsync and other data consistency things that slow down postgis.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--661.org.readthedocs.build/en/661/

<!-- readthedocs-preview datacube-explorer end -->