### PR TITLE
Add some type signatures

### DIFF
--- a/cubedash/_api.py
+++ b/cubedash/_api.py
@@ -20,7 +20,10 @@ bp = Blueprint("api", __name__, url_prefix="/api")
 @bp.route("/datasets/<product_name>/<int:year>/<int:month>")
 @bp.route("/datasets/<product_name>/<int:year>/<int:month>/<int:day>")
 def datasets_geojson(
-    product_name: str, year: int = None, month: int = None, day: int = None
+    product_name: str,
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
 ):
     limit = request.args.get(
         "limit",
@@ -71,7 +74,10 @@ def datasets_geojson(
 @bp.route("/footprint/<product_name>/<int:year>/<int:month>")
 @bp.route("/footprint/<product_name>/<int:year>/<int:month>/<int:day>")
 def footprint_geojson(
-    product_name: str, year: int = None, month: int = None, day: int = None
+    product_name: str,
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
 ):
     return as_geojson(
         _model.get_footprint_geojson(product_name, year, month, day),
@@ -84,7 +90,10 @@ def footprint_geojson(
 @bp.route("/regions/<product_name>/<int:year>/<int:month>")
 @bp.route("/regions/<product_name>/<int:year>/<int:month>/<int:day>")
 def regions_geojson(
-    product_name: str, year: int = None, month: int = None, day: int = None
+    product_name: str,
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
 ):
     regions = _model.get_regions_geojson(product_name, year, month, day)
     if regions is None:
@@ -99,7 +108,10 @@ def regions_geojson(
 @bp.route("/dataset-timeline/<product_name>/<int:year>/<int:month>")
 @bp.route("/dataset-timeline/<product_name>/<int:year>/<int:month>/<int:day>")
 def dataset_timeline(
-    product_name: str, year: int = None, month: int = None, day: int = None
+    product_name: str,
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
 ):
     summary = _model.get_time_summary(product_name, year, month, day)
     if summary is None:

--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -68,7 +68,7 @@ def _fast_tojson(obj):
 
 
 @bp.app_template_filter("printable_data_size")
-def sizeof_fmt(num, suffix="B"):
+def sizeof_fmt(num, suffix="B") -> str:
     for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]:
         if abs(num) < 1024.0:
             return f"{num:3.1f}{unit}{suffix}"
@@ -130,7 +130,7 @@ def _dataset_thumbnail_url(dataset: Dataset):
 
 
 @bp.app_template_filter("resolve_remote_url")
-def _to_remote_url(offset: str, base_uri: str = None):
+def _to_remote_url(offset: str, base_uri: str | None = None):
     return utils.as_resolved_remote_url(base_uri, offset)
 
 
@@ -185,7 +185,7 @@ def _format_query_value(val):
 
 
 @bp.app_template_filter("maybe_to_css_class_name")
-def _maybe_format_css_class(val: str, prefix: str = ""):
+def _maybe_format_css_class(val: str, prefix: str = "") -> str:
     """
     Create a CSS class name for the given string if it is safe to do so.
 
@@ -202,7 +202,7 @@ def _format_month_name(val):
 
 
 @bp.app_template_filter("day_ordinal")
-def _format_ordinal(val):
+def _format_ordinal(val) -> str:
     return f"{val}{_get_ordinal_suffix(val)}"
 
 
@@ -266,12 +266,12 @@ def _searchable_fields_keys(product: Product):
 
 
 @bp.app_template_filter("is_numeric_field")
-def _is_numeric_field(field: Field):
+def _is_numeric_field(field: Field) -> bool:
     return field.type_name in NUMERIC_STEP_SIZE
 
 
 @bp.app_template_filter("is_date_field")
-def _is_date_field(field: Field):
+def _is_date_field(field: Field) -> bool:
     return field.type_name in ("datetime", "datetime-range")
 
 

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -2,6 +2,7 @@ import json
 import os
 import time
 from collections import Counter
+from collections.abc import Sequence
 from pathlib import Path
 
 import flask
@@ -202,7 +203,7 @@ ProductWithSummary = tuple[Product, ProductSummary | None]
 
 
 @cache.memoize(timeout=120)
-def get_products() -> list[ProductWithSummary]:
+def get_products() -> Sequence[ProductWithSummary]:
     """
     The list of all products that we have generated reports for.
     """

--- a/cubedash/_monitoring.py
+++ b/cubedash/_monitoring.py
@@ -12,13 +12,13 @@ _INITIALISED = False
 
 
 # Add server timings to http headers.
-def init_app_monitoring(app: flask.Flask):
+def init_app_monitoring(app: flask.Flask) -> None:
     # This affects global flask app settings.
     # pylint: disable=global-statement
     global _INITIALISED
 
     @app.before_request
-    def time_start():
+    def time_start() -> None:
         flask.g.start_render = time.time()
         flask.g.datacube_query_time = 0
         flask.g.datacube_query_count = 0
@@ -43,11 +43,13 @@ def init_app_monitoring(app: flask.Flask):
     @event.listens_for(_model.STORE.e_index.engine, "before_cursor_execute")
     def before_cursor_execute(
         conn, cursor, statement, parameters, context, executemany
-    ):
+    ) -> None:
         conn.info.setdefault("query_start_time", []).append(time.time())
 
     @event.listens_for(_model.STORE.e_index.engine, "after_cursor_execute")
-    def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+    def after_cursor_execute(
+        conn, cursor, statement, parameters, context, executemany
+    ) -> None:
         if flask.has_app_context() and hasattr(flask.g, "datacube_query_time"):
             flask.g.datacube_query_time += time.time() - conn.info[
                 "query_start_time"
@@ -64,7 +66,7 @@ def init_app_monitoring(app: flask.Flask):
                 setattr(cls, name, decorator(attr))
         return cls
 
-    def print_datacube_query_times():
+    def print_datacube_query_times() -> None:
         from click import style
 
         def with_timings(function):

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -57,7 +57,10 @@ Disallow: /dataset/
 @bp.route("/products/<product_name>/extents/<int:year>/<int:month>")
 @bp.route("/products/<product_name>/extents/<int:year>/<int:month>/<int:day>")
 def legacy_product_page(
-    product_name: str = None, year: int = None, month: int = None, day: int = None
+    product_name: str | None = None,
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
 ):
     return redirect(
         url_for(
@@ -75,7 +78,10 @@ def legacy_product_page(
 @bp.route("/products/<product_name>/<int:year>/<int:month>")
 @bp.route("/products/<product_name>/<int:year>/<int:month>/<int:day>")
 def product_page(
-    product_name: str = None, year: int = None, month: int = None, day: int = None
+    product_name: str | None = None,
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
 ):
     (
         product,
@@ -126,7 +132,10 @@ def product_page(
 @bp.route("/datasets/<product_name>/<int:year>/<int:month>")
 @bp.route("/datasets/<product_name>/<int:year>/<int:month>/<int:day>")
 def legacy_search_page(
-    product_name: str = None, year: int = None, month: int = None, day: int = None
+    product_name: str | None = None,
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
 ):
     return redirect(
         url_for(
@@ -145,7 +154,10 @@ def legacy_search_page(
 @bp.route("/products/<product_name>/datasets/<int:year>/<int:month>")
 @bp.route("/products/<product_name>/datasets/<int:year>/<int:month>/<int:day>")
 def search_page(
-    product_name: str = None, year: int = None, month: int = None, day: int = None
+    product_name: str | None = None,
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
 ):
     (
         product,
@@ -261,11 +273,11 @@ def search_page(
 @bp.route("/region/<product_name>/<region_code>/<int:year>/<int:month>")
 @bp.route("/region/<product_name>/<region_code>/<int:year>/<int:month>/<int:day>")
 def legacy_region_page(
-    product_name: str = None,
-    region_code: str = None,
-    year: int = None,
-    month: int = None,
-    day: int = None,
+    product_name: str | None = None,
+    region_code: str | None = None,
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
 ):
     return redirect(
         url_for(
@@ -298,11 +310,11 @@ def regions_page(product_name: str):
     "/product/<product_name>/regions/<region_code>/<int:year>/<int:month>/<int:day>"
 )
 def region_page(
-    product_name: str = None,
-    region_code: str = None,
-    year: int = None,
-    month: int = None,
-    day: int = None,
+    product_name: str | None = None,
+    region_code: str | None = None,
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
 ):
     (
         product,
@@ -387,11 +399,11 @@ def region_page(
     "/product/<product_name>/regions/<region_code>/<int:year>/<int:month>/<int:day>.geojson"
 )
 def region_geojson(
-    product_name: str = None,
-    region_code: str = None,
-    year: int = None,
-    month: int = None,
-    day: int = None,
+    product_name: str | None = None,
+    region_code: str | None = None,
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
 ):
     region_info = _model.STORE.get_product_region_info(product_name)
     if not region_info:

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import datetime, timedelta
 from datetime import time as dt_time
 from functools import partial
@@ -57,7 +57,7 @@ def get_default_limit() -> int:
     return current_app.config.get("STAC_DEFAULT_PAGE_SIZE", DEFAULT_PAGE_SIZE)
 
 
-def check_page_limit(limit: int):
+def check_page_limit(limit: int) -> None:
     page_size_limit = current_app.config.get(
         "STAC_PAGE_SIZE_LIMIT", DEFAULT_PAGE_SIZE_LIMIT
     )
@@ -493,7 +493,7 @@ def _filter_arg(arg: str | dict) -> str:
     return _remove_prefixes(arg)
 
 
-def _validate_filter(filter_lang: str, cql: str):
+def _validate_filter(filter_lang: str, cql: str) -> None:
     # check filter-lang and actual cql format are aligned
     is_json = True
     try:
@@ -665,7 +665,9 @@ def _get_property(prop: str, item: ItemLike, no_default=False):
     return dicttoolz.get_in(prop.split("."), item, no_default=no_default)
 
 
-def _handle_fields_extension(items: list[ItemLike], fields: dict) -> list[ItemLike]:
+def _handle_fields_extension(
+    items: Sequence[ItemLike], fields: dict
+) -> Sequence[ItemLike]:
     """
     Implementation of fields extension (https://github.com/stac-api-extensions/fields/blob/main/README.md)
     This implementation differs slightly from the documented semantics in that the default fields will always

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -171,7 +171,7 @@ def as_resolved_remote_url(location: str, offset: str) -> str:
 
 
 def as_external_url(
-    url: str, s3_region: str = None, is_base: bool = False
+    url: str, s3_region: str | None = None, is_base: bool = False
 ) -> str | None:
     """
     Convert a URL to an externally-visible one.
@@ -487,7 +487,7 @@ def as_rich_json(o):
 
 
 def as_json(
-    o, content_type="application/json", downloadable_filename_prefix: str = None
+    o, content_type="application/json", downloadable_filename_prefix: str | None = None
 ) -> flask.Response:
     """
     Serialise an object into a json flask response.
@@ -526,7 +526,7 @@ def _json_fallback(o, *args, **kwargs):
     )
 
 
-def as_geojson(o, downloadable_filename_prefix: str = None):
+def as_geojson(o, downloadable_filename_prefix: str | None = None):
     """
     Serialise the given object into a GeoJSON flask response.
 
@@ -580,7 +580,9 @@ def common_uri_prefix(uris: Sequence[str]):
     return result[: result.rfind("/") + 1]
 
 
-def suggest_download_filename(response: flask.Response, prefix: str, suffix: str):
+def suggest_download_filename(
+    response: flask.Response, prefix: str, suffix: str
+) -> None:
     """
     Give the Browser a hint to download the file with the given filename
     (rather than display it in-line).
@@ -594,7 +596,9 @@ def suggest_download_filename(response: flask.Response, prefix: str, suffix: str
     response.headers["Content-Disposition"] = f"attachment; filename={prefix}{suffix}"
 
 
-def as_yaml(*o, content_type="text/yaml", downloadable_filename_prefix: str = None):
+def as_yaml(
+    *o, content_type="text/yaml", downloadable_filename_prefix: str | None = None
+):
     """
     Return a yaml response.
 
@@ -787,7 +791,7 @@ def api_path_as_filename_prefix():
     return "-".join([*period, kind])
 
 
-def undo_eo3_compatibility(doc):
+def undo_eo3_compatibility(doc) -> None:
     """
     In-place removal and undo-ing of the EO-compatibility fields added by ODC to EO3
      documents on index.

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -71,6 +71,7 @@ from datacube.cfg import ODCConfig, ODCEnvironment
 from datacube.index import Index, index_connect
 from datacube.model import Product
 from datacube.ui.click import environment_option, pass_config
+from typing_extensions import override
 
 from cubedash.logs import init_logging
 from cubedash.summary import (
@@ -107,7 +108,9 @@ def generate_report(
 
     started_years = set()
 
-    def print_status(product_name=None, year=None, month=None, day=None, summary=None):
+    def print_status(
+        product_name=None, year=None, month=None, day=None, summary=None
+    ) -> None:
         """Print status each time we start a year."""
         if year:
             if (product_name, year) not in started_years:
@@ -170,7 +173,7 @@ def run_generation(
 
     def on_complete(
         product_name: str, result: GenerateResult, summary: TimePeriodOverview
-    ):
+    ) -> None:
         counts[result] += 1
         result_color = {
             GenerateResult.ERROR: "red",
@@ -244,6 +247,7 @@ class TimeDeltaParam(click.ParamType):
 
     name = "time-length"
 
+    @override
     def convert(self, value, param, ctx):
         if isinstance(value, timedelta):
             return value
@@ -445,7 +449,7 @@ def cli(
     recreate_dataset_extents: bool,
     reset_incremental_position: bool,
     minimum_scan_window: timedelta | None,
-):
+) -> None:
     init_logging(
         open(event_log_file, "ab") if event_log_file else None, verbosity=verbose
     )

--- a/cubedash/gunicorn_config.py
+++ b/cubedash/gunicorn_config.py
@@ -3,7 +3,7 @@
 import os
 
 
-def child_exit(server, worker):
+def child_exit(server, worker) -> None:
     if os.environ.get("PROMETHEUS_MULTIPROC_DIR", False):
         from prometheus_flask_exporter.multiprocess import (
             GunicornInternalPrometheusMetrics,

--- a/cubedash/index/api.py
+++ b/cubedash/index/api.py
@@ -46,12 +46,12 @@ class ExplorerAbstractIndex(ABC):
 
     @abstractmethod
     def get_datasets_derived(
-        self, dataset_id: UUID, limit: int = None
+        self, dataset_id: UUID, limit: int | None = None
     ) -> tuple[list[Dataset], int]: ...
 
     @abstractmethod
     def get_dataset_sources(
-        self, dataset_id: UUID, limit: int = None
+        self, dataset_id: UUID, limit: int | None = None
     ) -> tuple[list[Dataset], int]: ...
 
     @abstractmethod
@@ -62,7 +62,7 @@ class ExplorerAbstractIndex(ABC):
 
     @abstractmethod
     def delete_datasets(
-        self, product_id: int, after_date: datetime = None, full: bool = False
+        self, product_id: int, after_date: datetime | None = None, full: bool = False
     ) -> int: ...
 
     @abstractmethod
@@ -184,7 +184,9 @@ class ExplorerAbstractIndex(ABC):
     def region_counts(self, where_clause): ...
 
     @abstractmethod
-    def ds_srid_expression(self, spatial_ref, projection, default_crs: str = None): ...
+    def ds_srid_expression(
+        self, spatial_ref, projection, default_crs: str | None = None
+    ): ...
 
     @abstractmethod
     def sample_dataset(self, product_id: int, columns): ...

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -60,7 +60,7 @@ from ._schema import (  # isort: skip
 class ExplorerIndex(ExplorerAbstractIndex):
     name = "pgis_index"
 
-    def __init__(self, index: Index):
+    def __init__(self, index: Index) -> None:
         self.index = index
         self.engine = index._db._engine
         self.db_api = PostgisDbAPI
@@ -623,7 +623,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def delete_datasets(
-        self, product_id: int, after_date: datetime = None, full: bool = False
+        self, product_id: int, after_date: datetime | None = None, full: bool = False
     ):
         with self.index._active_connection() as conn:
             # Forcing? Check every other dataset for removal, so we catch manually-deleted rows from the table.
@@ -790,7 +790,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
             return init_elements(conn, grouping_epsg_code)
 
     @override
-    def refresh_stats(self, concurrently=False):
+    def refresh_stats(self, concurrently=False) -> None:
         """
         Refresh general statistics tables that cover all products.
 
@@ -896,7 +896,9 @@ class ExplorerIndex(ExplorerAbstractIndex):
             )
 
     @override
-    def ds_srid_expression(self, spatial_ref, projection, default_crs: str = None):
+    def ds_srid_expression(
+        self, spatial_ref, projection, default_crs: str | None = None
+    ):
         default_crs_expression = None
         if default_crs:
             auth_name, auth_srid = default_crs.split(":")

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -59,7 +59,7 @@ from ._schema import (
 class ExplorerIndex(ExplorerAbstractIndex):
     name = "postgres"
 
-    def __init__(self, index: Index):
+    def __init__(self, index: Index) -> None:
         self.index = index
         # There's no public api for sharing the existing engine (it's an implementation detail of the current index).
         # We could create our own from config, but there's no api for getting the ODC config for the index either.
@@ -657,7 +657,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def delete_datasets(
-        self, product_id: int, after_date: datetime = None, full: bool = False
+        self, product_id: int, after_date: datetime | None = None, full: bool = False
     ) -> int:
         with self.index._active_connection() as conn:
             # Forcing? Check every other dataset for removal, so we catch manually-deleted rows from the table.
@@ -833,7 +833,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
             return init_elements(conn, grouping_epsg_code)
 
     @override
-    def refresh_stats(self, concurrently=False):
+    def refresh_stats(self, concurrently=False) -> None:
         """
         Refresh general statistics tables that cover all products.
 
@@ -938,7 +938,9 @@ class ExplorerIndex(ExplorerAbstractIndex):
             )
 
     @override
-    def ds_srid_expression(self, spatial_ref, projection, default_crs: str = None):
+    def ds_srid_expression(
+        self, spatial_ref, projection, default_crs: str | None = None
+    ):
         default_crs_expression = None
         if default_crs:
             auth_name, auth_srid = default_crs.split(":")

--- a/cubedash/logs.py
+++ b/cubedash/logs.py
@@ -8,14 +8,15 @@ from functools import partial
 import structlog
 from orjson import orjson
 from structlog.types import EventDict, WrappedLogger
+from typing_extensions import override
 
 
 def init_logging(
-    output_file: io.BytesIO = None,
+    output_file: io.BytesIO | None = None,
     verbosity: int = 0,
-    cache_logger_on_first_use=True,
-    write_as_json: bool = None,
-):
+    cache_logger_on_first_use: bool = True,
+    write_as_json: bool | None = None,
+) -> None:
     """
     Setup structlog for structured logging output.
 
@@ -81,6 +82,7 @@ class BytesConsoleRenderer(structlog.dev.ConsoleRenderer):
     (orjson emits bytes, so we want to be consistent)
     """
 
+    @override
     def _repr(self, val):
         if isinstance(val, datetime.datetime):
             return val.isoformat()
@@ -88,6 +90,7 @@ class BytesConsoleRenderer(structlog.dev.ConsoleRenderer):
             return val.as_posix()
         return super()._repr(val)
 
+    @override
     def __call__(
         self, logger: WrappedLogger, name: str, event_dict: EventDict
     ) -> bytes:

--- a/cubedash/run.py
+++ b/cubedash/run.py
@@ -15,7 +15,7 @@ from click import style
 from werkzeug.serving import run_simple
 
 
-def _print_version(ctx, param, value):
+def _print_version(ctx, param, value) -> None:
     """Print version information and exit"""
     if not value or ctx.resilient_parsing:
         return
@@ -75,7 +75,7 @@ def cli(
     workers: int,
     event_log_file: str,
     verbose: bool,
-):
+) -> None:
     from cubedash import create_app
     from cubedash.logs import init_logging
 

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -56,7 +56,7 @@ class UnsupportedWKTProductCRSError(NotImplementedError):
 
 
 def get_dataset_extent_alchemy_expression(
-    e_index: ExplorerIndex, md: MetadataType, default_crs: str = None
+    e_index: ExplorerIndex, md: MetadataType, default_crs: str | None = None
 ):
     """
     Build an SQLAlchemy expression to get the extent for a dataset.
@@ -134,7 +134,7 @@ def _size_bytes_field(product: Product):
 
 
 def get_dataset_srid_alchemy_expression(
-    e_index: ExplorerIndex, md: MetadataType, default_crs: str = None
+    e_index: ExplorerIndex, md: MetadataType, default_crs: str | None = None
 ):
     doc = jsonb_doc_expression(md)
 
@@ -183,7 +183,7 @@ def refresh_spatial_extents(
     e_index: ExplorerIndex,
     product: Product,
     clean_up_deleted=False,
-    assume_after_date: datetime = None,
+    assume_after_date: datetime | None = None,
 ):
     """
     Update the spatial extents to match any changes upstream in ODC.
@@ -434,7 +434,7 @@ class RegionInfo:
 
     @classmethod
     def for_product(
-        cls, product: Product, known_regions: Dict[str, RegionSummary] = None
+        cls, product: Product, known_regions: Dict[str, RegionSummary] | None = None
     ):
         region_code_field: Field = product.metadata_type.dataset_fields.get(
             "region_code"

--- a/cubedash/summary/_model.py
+++ b/cubedash/summary/_model.py
@@ -40,7 +40,7 @@ class TimePeriodOverview:
     footprint_count: int
 
     # The most newly created dataset
-    newest_dataset_creation_time: datetime
+    newest_dataset_creation_time: datetime | None
 
     # List of CRSes that these datasets are in
     crses: Set[str]
@@ -54,7 +54,7 @@ class TimePeriodOverview:
     summary_gen_time: datetime = None
 
     @override
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"{self.label} "
             f"({self.dataset_count} dataset{'s' if self.dataset_count > 1 else ''})"
@@ -74,7 +74,9 @@ class TimePeriodOverview:
         return self.product_name, self.year, self.month, self.day
 
     @period_tuple.setter
-    def period_tuple(self, v: Tuple[str, Optional[int], Optional[int], Optional[int]]):
+    def period_tuple(
+        self, v: Tuple[str, Optional[int], Optional[int], Optional[int]]
+    ) -> None:
         self.product_name, self.year, self.month, self.day = v
 
     def as_flat_period(self):
@@ -88,7 +90,7 @@ class TimePeriodOverview:
     @classmethod
     def flat_period_representation(
         cls, year: Optional[int], month: Optional[int], day: Optional[int]
-    ) -> Tuple[str, datetime.date]:
+    ) -> Tuple[str, date]:
         period = "all"
         if year:
             period = "year"

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -67,7 +67,7 @@ def pg_create_index(
     table_name: str,
     col_expr: str | None = None,
     unique: bool = False,
-):
+) -> None:
     conn.execute(
         text(
             f"create {'unique' if unique else ''} index if not exists {idx_name} on {table_name}({col_expr})"
@@ -110,7 +110,7 @@ def get_postgis_versions(conn) -> str:
 
 def pg_add_column(
     conn, schema_name: str, table_name: str, column_name: str, column_type: str
-):
+) -> None:
     conn.execute(
         text(
             f"alter table {schema_name}.{table_name} add column if not exists {column_name} {column_type}"
@@ -156,7 +156,7 @@ def epsg_to_srid(conn: Connection, code: int) -> int:
     ).scalar()
 
 
-def refresh_supporting_views(conn, concurrently=False):
+def refresh_supporting_views(conn, concurrently=False) -> None:
     args = "concurrently" if concurrently else ""
     conn.execute(
         text(f"""

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -256,7 +256,7 @@ class SummaryStore:
         #    tldr: "15 minutes == max expected transaction age of indexer"
         self.dataset_overlap_carefulness = timedelta(minutes=15)
 
-    def add_change_listener(self, listener):
+    def add_change_listener(self, listener) -> None:
         self._update_listeners.append(listener)
 
     def is_initialised(self) -> bool:
@@ -279,7 +279,7 @@ class SummaryStore:
         )
         return is_compatible
 
-    def init(self, grouping_epsg_code: int = None):
+    def init(self, grouping_epsg_code: int | None = None) -> None:
         """
         Initialise any schema elements that don't exist.
 
@@ -314,14 +314,14 @@ class SummaryStore:
             log=log,
         )
 
-    def close(self):  # do we still need this?
+    def close(self) -> None:  # do we still need this?
         """Close any pooled/open connections. Necessary before forking."""
         self.index.close()
         self.e_index.engine.dispose()
 
     def refresh_all_product_extents(
         self,
-    ):
+    ) -> None:
         for product in self.all_products():
             self.refresh_product_extent(
                 product.name,
@@ -415,7 +415,7 @@ class SummaryStore:
         product_name: str,
         dataset_sample_size: int = 1000,
         scan_for_deleted: bool = False,
-        only_those_newer_than: datetime = None,
+        only_those_newer_than: datetime | None = None,
         force: bool = False,
     ) -> Tuple[int, ProductSummary]:
         """
@@ -506,7 +506,7 @@ class SummaryStore:
         log.info("refresh.regions.end", changed_regions=changed_rows)
         return changed_rows
 
-    def refresh_stats(self, concurrently=False):
+    def refresh_stats(self, concurrently=False) -> None:
         """
         Refresh general statistics tables that cover all products.
 
@@ -518,7 +518,7 @@ class SummaryStore:
         self,
         product: Product,
         sample_datasets_size=1000,
-    ) -> Dict[str, any]:
+    ) -> Dict[str, Any]:
         """
         Find metadata fields that have an identical value in every dataset of the product.
 
@@ -626,7 +626,7 @@ class SummaryStore:
         )
         return list(linked_product_names or [])
 
-    def drop_all(self):
+    def drop_all(self) -> None:
         """
         Drop all cubedash-specific tables/schema.
         """
@@ -813,7 +813,7 @@ class SummaryStore:
         """Timezone used for day/month/year grouping."""
         return tz.gettz(self._summariser.grouping_time_zone)
 
-    def _persist_product_extent(self, product: ProductSummary):
+    def _persist_product_extent(self, product: ProductSummary) -> None:
         source_product_ids = [
             self.get_product(name).id for name in product.source_products
         ]
@@ -839,7 +839,7 @@ class SummaryStore:
     def _put(
         self,
         summary: TimePeriodOverview,
-    ):
+    ) -> None:
         log = _LOG.bind(
             period=summary.period_tuple,
             summary_count=summary.dataset_count,
@@ -889,9 +889,9 @@ class SummaryStore:
         field_exprs,
         product_names: Optional[List[str]] = None,
         time: Optional[Tuple[datetime, datetime]] = None,
-        bbox: Tuple[float, float, float, float] = None,
-        intersects: BaseGeometry = None,
-        dataset_ids: Sequence[UUID] = None,
+        bbox: Tuple[float, float, float, float] | None = None,
+        intersects: BaseGeometry | None = None,
+        dataset_ids: Sequence[UUID] | None = None,
     ) -> Select:
         if dataset_ids is not None:
             query = query.where(field_exprs["id"].in_(dataset_ids))
@@ -1038,9 +1038,9 @@ class SummaryStore:
         self,
         product_names: Optional[List[str]] = None,
         time: Optional[Tuple[datetime, datetime]] = None,
-        bbox: Tuple[float, float, float, float] = None,
-        intersects: BaseGeometry = None,
-        dataset_ids: Sequence[UUID] = None,
+        bbox: Tuple[float, float, float, float] | None = None,
+        intersects: BaseGeometry | None = None,
+        dataset_ids: Sequence[UUID] | None = None,
         filter_lang: str | None = None,
         filter_cql: str | dict | None = None,
     ) -> int:
@@ -1082,12 +1082,12 @@ class SummaryStore:
         *,
         product_names: Optional[List[str]] = None,
         time: Optional[Tuple[datetime, datetime]] = None,
-        bbox: Tuple[float, float, float, float] = None,
-        intersects: BaseGeometry = None,
+        bbox: Tuple[float, float, float, float] | None = None,
+        intersects: BaseGeometry | None = None,
         limit: int = 500,
         offset: int = 0,
         full_dataset: bool = False,
-        dataset_ids: Sequence[UUID] = None,
+        dataset_ids: Sequence[UUID] | None = None,
         filter_lang: str | None = None,
         filter_cql: str | dict | None = None,
         order: ItemSort | list[dict[str, str]] = ItemSort.DEFAULT_SORT,
@@ -1171,7 +1171,7 @@ class SummaryStore:
         product: ProductSummary,
         year: Optional[int] = None,
         month: Optional[int] = None,
-        product_refresh_time: datetime = None,
+        product_refresh_time: datetime | None = None,
     ) -> TimePeriodOverview:
         """Recalculate the given period and store it in the DB"""
         if year and month:
@@ -1217,7 +1217,7 @@ class SummaryStore:
         force: bool = False,
         recreate_dataset_extents: bool = False,
         reset_incremental_position: bool = False,
-        minimum_change_scan_window: timedelta = None,
+        minimum_change_scan_window: timedelta | None = None,
     ) -> Tuple[GenerateResult, TimePeriodOverview]:
         """
         Update Explorer's information and summaries for a product.
@@ -1406,7 +1406,7 @@ class SummaryStore:
 
     def _mark_product_refresh_completed(
         self, product: ProductSummary, refresh_timestamp: datetime
-    ):
+    ) -> None:
         """
         Mark the product as successfully refreshed at the given product-table timestamp
 

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -70,7 +70,7 @@ def cli(
     day: int,
     event_log_file: str,
     verbose: bool,
-):
+) -> None:
     """
     Print the recorded summary information for the given product
     """

--- a/cubedash/testutils/database.py
+++ b/cubedash/testutils/database.py
@@ -189,7 +189,7 @@ def odc_test_db(cfg_env):
             _remove_postgis_dynamic_indexes()
 
 
-def _remove_postgres_dynamic_indexes():
+def _remove_postgres_dynamic_indexes() -> None:
     """
     Clear any dynamically created postgresql indexes from the schema.
     """
@@ -200,7 +200,7 @@ def _remove_postgres_dynamic_indexes():
         )
 
 
-def _remove_postgis_dynamic_indexes():
+def _remove_postgis_dynamic_indexes() -> None:
     """
     Clear any dynamically created postgis indexes from the schema.
     """

--- a/cubedash/warmup.py
+++ b/cubedash/warmup.py
@@ -130,7 +130,7 @@ def cli(
     throttle_seconds: float,
     explorer_url: str,
     show_timings: int = 5,
-):
+) -> None:
     """
     A tool to load an example of each Explorer page, reporting if any
     return errors.
@@ -148,7 +148,7 @@ def cli(
         url = urljoin(explorer_url, url_offset)
         secho(f"get {url_offset} ", bold=True, nl=False, err=True)
 
-        def handle_failure():
+        def handle_failure() -> None:
             nonlocal consecutive_failures
             consecutive_failures += 1
             failures.append(url)

--- a/integration_tests/asserts.py
+++ b/integration_tests/asserts.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from pprint import pformat, pprint
 from textwrap import indent
+from types import TracebackType
 
 import jsonschema
 import pytest
@@ -32,7 +33,7 @@ _FEATURE_COLLECTION_SCHEMA = json.load(_FEATURE_COLLECTION_SCHEMA_PATH.open("r")
 
 def assert_shapes_mostly_equal(
     shape1: BaseGeometry, shape2: BaseGeometry, threshold: float
-):
+) -> None:
     # __tracebackhide__ = operator.methodcaller("errisinstance", AssertionError)
 
     # Check area first, as it's a nicer error message when they're wildly different.
@@ -45,7 +46,7 @@ def assert_shapes_mostly_equal(
     assert (s1 - s2).area < threshold, f"{s1} is not mostly equal to {s2}"
 
 
-def assert_matching_eo3(actual_doc: dict, expected_doc: dict):
+def assert_matching_eo3(actual_doc: dict, expected_doc: dict) -> None:
     """
     Assert an EO3 document matches an expected document,
 
@@ -117,21 +118,21 @@ def get_html(client: FlaskClient, url: str) -> HTML:
     return html
 
 
-def check_area(area_pattern, html):
+def check_area(area_pattern, html) -> None:
     assert re.match(
         area_pattern + r" \(approx",
         html.find(".coverage-footprint-area", first=True).text,
     )
 
 
-def check_last_processed(html, time):
+def check_last_processed(html, time) -> None:
     __tracebackhide__ = True
     assert (
         html.find(".last-processed time", first=True).attrs["datetime"].startswith(time)
     )
 
 
-def check_dataset_count(html, count: int):
+def check_dataset_count(html, count: int) -> None:
     __tracebackhide__ = True
     actual = html.find(".dataset-count", first=True).text
     expected = f"{count:,d}"
@@ -140,7 +141,7 @@ def check_dataset_count(html, count: int):
     )
 
 
-def check_datesets_page_datestring(html, datestring: str):
+def check_datesets_page_datestring(html, datestring: str) -> None:
     __tracebackhide__ = True
     actual = html.find(".overview-day-link", first=True).text
     assert datestring == actual, (
@@ -266,17 +267,22 @@ class DebugContext:
     def __init__(self, msg: str) -> None:
         self.msg = msg
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         pass
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         if exc_type is None:
             return
         if issubclass(exc_type, (AssertionError, InvalidDocException)):
             _add_context(exc_val, self.msg)
 
 
-def _add_context(e: AssertionError, context_message: str):
+def _add_context(e: AssertionError, context_message: str) -> None:
     """
     Append some extra information to an assertion error message .
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -46,7 +46,7 @@ def summary_store(odc_test_db: Datacube) -> SummaryStore:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def _init_logs(pytestconfig):
+def _init_logs(pytestconfig) -> None:
     logs.init_logging(
         verbosity=pytestconfig.getoption("verbose"), cache_logger_on_first_use=False
     )
@@ -163,7 +163,7 @@ def pytest_assertrepr_compare(op, left, right):
         return format_doc_diffs(left, right)
 
 
-def _make_all_tables_unlogged(index, metadata: sqlalchemy.MetaData):
+def _make_all_tables_unlogged(index, metadata: sqlalchemy.MetaData) -> None:
     """
     Set all tables in this alchemy metadata to unlogged.
 

--- a/integration_tests/test_arb_crs.py
+++ b/integration_tests/test_arb_crs.py
@@ -14,15 +14,15 @@ PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]
 """
 
 
-def test_crs_infer_has_match_floor():
+def test_crs_infer_has_match_floor() -> None:
     """Don't match something that's too different"""
     assert infer_crs("") is None
 
 
-def test_crs_infer_pass():
+def test_crs_infer_pass() -> None:
     assert infer_crs(TEST_CRS_RAW) == "epsg:4283"
 
 
-def test_crs_infers_itself():
+def test_crs_infers_itself() -> None:
     """Sanity check: something should match itself!"""
     assert infer_crs(CRS.from_epsg(4326).to_wkt()) == "epsg:4326"

--- a/integration_tests/test_archival_handling.py
+++ b/integration_tests/test_archival_handling.py
@@ -19,7 +19,7 @@ DATASETS = ["datasets/ga_ls7e_ard_3-sample.yaml"]
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
-def test_pre_archival_dataset_count(client: FlaskClient):
+def test_pre_archival_dataset_count(client: FlaskClient) -> None:
     html = get_html(client, "/products/ga_ls7e_ard_3")
     check_dataset_count(html, 1)
 
@@ -41,7 +41,7 @@ def test_pre_archival_dataset_count(client: FlaskClient):
     assert dataset_count == "1"
 
 
-def test_post_archival_dataset_count(odc_test_db, run_generate, client):
+def test_post_archival_dataset_count(odc_test_db, run_generate, client) -> None:
     odc_test_db.index.datasets.archive(["50014f19-5546-4853-be8d-0185a798c083"])
     run_generate("ga_ls7e_ard_3")
 

--- a/integration_tests/test_center_datetime_logic.py
+++ b/integration_tests/test_center_datetime_logic.py
@@ -23,7 +23,7 @@ DATASETS = ["datasets/rainfall_chirps_daily-sample.yaml"]
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
-def test_datestring_on_dataset_page(client: FlaskClient):
+def test_datestring_on_dataset_page(client: FlaskClient) -> None:
     # These datasets have gigantic footprints that can trip up postgis.
     html = get_html(
         client,
@@ -40,7 +40,7 @@ def test_datestring_on_dataset_page(client: FlaskClient):
     check_datesets_page_datestring(html, "15th May 2019")
 
 
-def test_datestring_on_datasets_search_page(client: FlaskClient):
+def test_datestring_on_datasets_search_page(client: FlaskClient) -> None:
     html = get_html(client, "/products/rainfall_chirps_daily/datasets")
 
     assert "Time UTC: 2019-05-15 00:00:00" in [
@@ -50,7 +50,7 @@ def test_datestring_on_datasets_search_page(client: FlaskClient):
     )
 
 
-def test_datestring_on_regions_page(client: FlaskClient):
+def test_datestring_on_regions_page(client: FlaskClient) -> None:
     html = get_html(client, "/product/rainfall_chirps_daily/regions/x210y106")
 
     assert "2019-05-15 00:00:00" in [
@@ -60,7 +60,7 @@ def test_datestring_on_regions_page(client: FlaskClient):
     )
 
 
-def test_summary_center_datetime(client: FlaskClient):
+def test_summary_center_datetime(client: FlaskClient) -> None:
     html = get_html(client, "/rainfall_chirps_daily/2019/5")
     check_dataset_count(html, 2)
 

--- a/integration_tests/test_configurable_page_elements.py
+++ b/integration_tests/test_configurable_page_elements.py
@@ -48,7 +48,7 @@ def total_indexed_products_count(summary_store: SummaryStore):
     return len(list(summary_store.index.products.get_all()))
 
 
-def test_instance_title(app_configured_client: FlaskClient):
+def test_instance_title(app_configured_client: FlaskClient) -> None:
     html = get_html(app_configured_client, "/about")
 
     instance_title = html.find(".instance-title", first=True).text
@@ -57,7 +57,7 @@ def test_instance_title(app_configured_client: FlaskClient):
 
 def test_hide_products_audit_page_display(
     app_configured_client: FlaskClient, total_indexed_products_count
-):
+) -> None:
     html = get_html(app_configured_client, "/audit/storage")
     hidden_product_count = html.find("span.hidden-product-count", first=True).text
     assert hidden_product_count == "3"
@@ -70,7 +70,7 @@ def test_hide_products_audit_page_display(
 
 def test_hide_products_audit_bulk_dataset_display(
     app_configured_client: FlaskClient, total_indexed_products_count
-):
+) -> None:
     html = get_html(app_configured_client, "/audit/dataset-counts")
     hidden_product_count = html.find("span.hidden-product-count", first=True).text
     assert hidden_product_count == "3"
@@ -83,7 +83,7 @@ def test_hide_products_audit_bulk_dataset_display(
 
 def test_hide_products_product_page_display(
     app_configured_client: FlaskClient, total_indexed_products_count
-):
+) -> None:
     html = get_html(app_configured_client, "/products")
     hidden_product_count = html.find("span.hidden-product-count", first=True).text
     assert hidden_product_count == "3"
@@ -99,7 +99,7 @@ def test_hide_products_product_page_display(
 
 def test_hide_products_menu_display(
     app_configured_client: FlaskClient, total_indexed_products_count
-):
+) -> None:
     html = get_html(app_configured_client, "/about")
 
     hide_products = html.find("#products-menu li a.configured-hide-product")
@@ -113,7 +113,7 @@ def test_hide_products_menu_display(
     assert total_indexed_products_count - len(products) == 3
 
 
-def test_sister_sites(app_configured_client: FlaskClient):
+def test_sister_sites(app_configured_client: FlaskClient) -> None:
     html = get_html(app_configured_client, "/about")
 
     sister_instances = html.find("#sister-site-menu ul li")
@@ -125,7 +125,7 @@ def test_sister_sites(app_configured_client: FlaskClient):
         )
 
 
-def test_sister_sites_request_path(app_configured_client: FlaskClient):
+def test_sister_sites_request_path(app_configured_client: FlaskClient) -> None:
     html = get_html(app_configured_client, "/products/ga_ls5t_ard_3")
 
     sister_instances = html.find("#sister-site-menu ul li")

--- a/integration_tests/test_dataset_listing.py
+++ b/integration_tests/test_dataset_listing.py
@@ -23,7 +23,7 @@ DATASETS = [
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
-def test_parse_query_args(odc_test_db: Datacube):
+def test_parse_query_args(odc_test_db: Datacube) -> None:
     """
     A user gives time start/end: they should be parsed as a single time field,
     and restricted to the current product.
@@ -52,7 +52,7 @@ def test_parse_query_args(odc_test_db: Datacube):
 @pytest.mark.skip(
     reason="Should be updated to do a flask request. Default params are there."
 )
-def test_default_args(dea_index: Index):
+def test_default_args(dea_index: Index) -> None:
     """
     When the user provides no search args we should constraint their query
 

--- a/integration_tests/test_dataset_maturity.py
+++ b/integration_tests/test_dataset_maturity.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 def test_product_fixed_metadata_by_sample_percentage(
     summary_store: SummaryStore, client
-):
+) -> None:
     # There are 4 interim and 16 final maturity level datasets
     # at 100% (all 20 datasets), the same dictionary will be returned
     # 100% of the time

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -66,7 +66,7 @@ def eo3_index(odc_test_db: Datacube, auto_odc_db):
     return odc_test_db.index
 
 
-def test_eo3_extents(eo3_index: Index):
+def test_eo3_extents(eo3_index: Index) -> None:
     """
     Do we extract the elements of an EO3 extent properly?
 
@@ -132,7 +132,7 @@ def test_eo3_extents(eo3_index: Index):
     assert dataset_extent_row["size_bytes"] is None
 
 
-def test_eo3_dateless_extents(eo3_index: Index):
+def test_eo3_dateless_extents(eo3_index: Index) -> None:
     """
     Can we support datasets with no datetime field?
 
@@ -158,13 +158,13 @@ def test_eo3_dateless_extents(eo3_index: Index):
     assert dataset_extent_row["region_code"] is None
 
 
-def test_location_sampling(eo3_index: Index):
+def test_location_sampling(eo3_index: Index) -> None:
     summary_store = SummaryStore.create(eo3_index)
 
     assert summary_store.product_location_samples("ga_ls8c_level1_3") == []
 
 
-def test_eo3_doc_download(eo3_index: Index, client: FlaskClient):
+def test_eo3_doc_download(eo3_index: Index, client: FlaskClient) -> None:
     response: Response = client.get(
         "/dataset/9989545f-906d-5090-a38e-cdbfbfc1afca.odc-metadata.yaml"
     )
@@ -185,7 +185,7 @@ def test_eo3_doc_download(eo3_index: Index, client: FlaskClient):
 
 
 @pytest.mark.xfail(reason="mismatching date format - to be fixed")
-def test_undo_eo3_doc_compatibility(eo3_index: Index):
+def test_undo_eo3_doc_compatibility(eo3_index: Index) -> None:
     """
     ODC adds compatibility fields on index. Check that our undo-method
     correctly creates an identical document to the original.
@@ -214,7 +214,7 @@ def test_undo_eo3_doc_compatibility(eo3_index: Index):
     )
 
 
-def test_undo_eo3_compatibility_del_handling():
+def test_undo_eo3_compatibility_del_handling() -> None:
     doc = {"extent": "a", "lineage": {}}
     assert _utils.undo_eo3_compatibility(doc) is None
 
@@ -243,14 +243,14 @@ def with_parsed_datetimes(v: dict, name=""):
     return v
 
 
-def test_all_eo3_pages_render(eo3_index: Index, client: FlaskClient):
+def test_all_eo3_pages_render(eo3_index: Index, client: FlaskClient) -> None:
     """
     Do all expected URLS render with HTTP OK response with our normal eo3 test data?
     """
     assert_all_urls_render(find_examples_of_all_public_urls(eo3_index), client)
 
 
-def test_can_search_eo3_items(eo3_index, client: FlaskClient):
+def test_can_search_eo3_items(eo3_index, client: FlaskClient) -> None:
     """
     Searching returns lightweight item records, so the conversion code is different.
     """
@@ -273,7 +273,7 @@ def test_can_search_eo3_items(eo3_index, client: FlaskClient):
     ] == pytest.approx(0.37)
 
 
-def test_eo3_stac_item(eo3_index, client: FlaskClient):
+def test_eo3_stac_item(eo3_index, client: FlaskClient) -> None:
     # Load one stac dataset from the test data.
     response = get_item(
         client,

--- a/integration_tests/test_filter_geom.py
+++ b/integration_tests/test_filter_geom.py
@@ -15,7 +15,7 @@ TEST_DATA_DIR = Path(__file__).parent / "data"
 
 
 class ValidGeometries:
-    def __init__(self, footprint_geometry):
+    def __init__(self, footprint_geometry) -> None:
         self.footprint_geometry = footprint_geometry
 
 
@@ -34,14 +34,14 @@ def testing_polygon():
     return shapely_polygon
 
 
-def test_filter_geom():
+def test_filter_geom() -> None:
     assert _filter_geom([]) == []
     geom = shape(json.loads('{"type": "Point", "coordinates": [0.0, 0.0]}'))
     assert _filter_geom([geom])
 
 
 @pytest.mark.skip("Skipping because the newer Shapely is handling geometry better.")
-def test_nested_exception(testing_polygon):
+def test_nested_exception(testing_polygon) -> None:
     """
     simulating the behaviour in _model.py
     """

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -167,7 +167,7 @@ def _create_overview():
     return overview
 
 
-def test_footprint_antimeridian(benchmark):
+def test_footprint_antimeridian(benchmark) -> None:
     """
     When a polygon crosses the antimeridian, check that it's translated correctly.
     """
@@ -177,7 +177,7 @@ def test_footprint_antimeridian(benchmark):
     assert_shapes_mostly_equal(footprint_latlon, EXPECTED_CLEAN_POLY, 0.1)
 
 
-def test_footprint_normal(benchmark):
+def test_footprint_normal(benchmark) -> None:
     # A normal poly that doesn't cross antimeridian.
     normal_poly = shape(
         {
@@ -220,11 +220,11 @@ def test_footprint_normal(benchmark):
     assert_shapes_mostly_equal(res, expected_poly, 0.001)
 
 
-def test_computed_properties():
+def test_computed_properties() -> None:
     o = _create_overview()
     o.product_name = "test_product"
 
-    def check_flat_period(o, expected_period: str, expected_date: date):
+    def check_flat_period(o, expected_period: str, expected_date: date) -> None:
         assert o.as_flat_period() == (expected_period, expected_date)
 
         # Converting the other way should also match.

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -98,7 +98,7 @@ def _script(html: HTML):
 
 
 @pytest.mark.xfail()
-def test_prometheus(sentry_client: FlaskClient):
+def test_prometheus(sentry_client: FlaskClient) -> None:
     """
     Ensure Prometheus metrics endpoint exists
     """
@@ -106,13 +106,13 @@ def test_prometheus(sentry_client: FlaskClient):
     assert b"flask_exporter_info" in resp.data
 
 
-def test_default_redirect(client: FlaskClient):
+def test_default_redirect(client: FlaskClient) -> None:
     rv: Response = client.get("/", follow_redirects=False)
     # The products page is the default.
     assert rv.location.endswith("/products")
 
 
-def test_get_overview(client: FlaskClient):
+def test_get_overview(client: FlaskClient) -> None:
     html = get_html(client, "/ga_ls9c_ard_3")
     check_dataset_count(html, 11)
     check_last_processed(html, "2024-05-20T20:49:02")
@@ -132,7 +132,7 @@ def test_get_overview(client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_invalid_footprint_wofs_summary_load(client: FlaskClient):
+def test_invalid_footprint_wofs_summary_load(client: FlaskClient) -> None:
     # This all-time overview has a valid footprint that becomes invalid
     # when reprojected to wgs84 by shapely.
     from .data_wofs_summary import wofs_time_summary
@@ -143,7 +143,7 @@ def test_invalid_footprint_wofs_summary_load(client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_all_products_are_shown(client: FlaskClient):
+def test_all_products_are_shown(client: FlaskClient) -> None:
     """
     After all the complicated grouping logic, there should still be one header link for each product.
     """
@@ -159,7 +159,7 @@ def test_all_products_are_shown(client: FlaskClient):
     )
 
 
-def test_get_overview_product_links(client: FlaskClient):
+def test_get_overview_product_links(client: FlaskClient) -> None:
     """
     Are the source and derived product lists being displayed?
     """
@@ -175,7 +175,7 @@ def test_get_overview_product_links(client: FlaskClient):
     assert [p.attrs["href"] for p in product_links] == ["/products/ga_ls_fc_3/2022"]
 
 
-def test_get_day_overviews(client: FlaskClient):
+def test_get_day_overviews(client: FlaskClient) -> None:
     # Individual days are computed on-the-fly rather than from summaries, so can
     # have their own issues.
 
@@ -190,7 +190,7 @@ def test_get_day_overviews(client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_summary_product(client: FlaskClient):
+def test_summary_product(client: FlaskClient) -> None:
     # These datasets have gigantic footprints that can trip up postgis.
     html = get_html(client, "/pq_count_summary")
     check_dataset_count(html, 20)
@@ -198,7 +198,7 @@ def test_summary_product(client: FlaskClient):
 
 def test_uninitialised_overview(
     unpopulated_client: FlaskClient, summary_store: SummaryStore
-):
+) -> None:
     # Populate one product, so they don't get the usage error message ("run cubedash generate")
     # Then load an unpopulated product.
     summary_store.refresh("usgs_ls7e_level1_1")
@@ -216,7 +216,9 @@ Enhanced Thematic Mapper Plus Level 1 Collection 1"
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_uninitialised_product(empty_client: FlaskClient, summary_store: SummaryStore):
+def test_uninitialised_product(
+    empty_client: FlaskClient, summary_store: SummaryStore
+) -> None:
     """
     An unsummarised product should still be viewable on the product page.
 
@@ -237,7 +239,7 @@ def test_uninitialised_product(empty_client: FlaskClient, summary_store: Summary
     assert "not yet summarised" not in one_element(html, "#content").text
 
 
-def test_empty_product_overview(client: FlaskClient):
+def test_empty_product_overview(client: FlaskClient) -> None:
     """
     A page is still displayable without error when it has no datasets.
     """
@@ -249,7 +251,7 @@ def test_empty_product_overview(client: FlaskClient):
     # assert_is_text(html, ".query-param.key-product_type .value", "level1")
 
 
-def test_empty_product_page(client: FlaskClient):
+def test_empty_product_page(client: FlaskClient) -> None:
     """
     A product page is displayable when summarised, but with 0 datasets.
     """
@@ -284,7 +286,7 @@ def one_element(html: HTML, selector: str) -> Element:
     return els[0]
 
 
-def assert_is_text(html: HTML, selector, text: str):
+def assert_is_text(html: HTML, selector, text: str) -> None:
     __tracebackhide__ = True
     el = one_element(html, selector)
     assert el.text == text
@@ -293,7 +295,7 @@ def assert_is_text(html: HTML, selector, text: str):
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
 def test_uninitialised_search_page(
     empty_client: FlaskClient, summary_store: SummaryStore
-):
+) -> None:
     # Populate one product, so they don't get the usage error message ("run cubedash generate")
     summary_store.refresh("ls7_nbar_albers")
 
@@ -303,7 +305,7 @@ def test_uninitialised_search_page(
     assert len(search_results) == 4
 
 
-def test_view_dataset(client: FlaskClient):
+def test_view_dataset(client: FlaskClient) -> None:
     # usgs_ls7e_level1 dataset
     html = get_html(client, "/dataset/7dff1cb5-b297-5701-8390-43c0f2d58fbb")
 
@@ -333,12 +335,12 @@ def _h1_text(html):
     return one_element(html, "h1").text
 
 
-def test_view_product(client: FlaskClient):
+def test_view_product(client: FlaskClient) -> None:
     rv: HTML = get_html(client, "/product/ga_ls8c_ard_3")
     assert "Geoscience Australia Landsat 8" in rv.text
 
 
-def test_view_metadata_type(client: FlaskClient, odc_test_db):
+def test_view_metadata_type(client: FlaskClient, odc_test_db) -> None:
     # Does it load without error?
     html: HTML = get_html(client, "/metadata-type/eo3")
     assert html.find("h2", first=True).text == "eo3"
@@ -360,7 +362,7 @@ def test_view_metadata_type(client: FlaskClient, odc_test_db):
     assert "ga_ls_wo_fq_nov_mar_3" in products_using_it
 
 
-def test_storage_page(client: FlaskClient, odc_test_db):
+def test_storage_page(client: FlaskClient, odc_test_db) -> None:
     html: HTML = get_html(client, "/audit/storage")
 
     assert html.find(".product-name", containing="ga_ls9c_ard_3")
@@ -371,7 +373,7 @@ def test_storage_page(client: FlaskClient, odc_test_db):
 
 
 @pytest.mark.skip(reason="TODO: fix out-of-date range return value")
-def test_out_of_date_range(client: FlaskClient):
+def test_out_of_date_range(client: FlaskClient) -> None:
     """
     We have generated summaries for this product, but the date is out of the product's date range.
     """
@@ -383,7 +385,7 @@ def test_out_of_date_range(client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_loading_high_low_tide_comp(client: FlaskClient):
+def test_loading_high_low_tide_comp(client: FlaskClient) -> None:
     html = get_html(client, "/high_tide_comp_20p/2008")
 
     assert (
@@ -402,7 +404,7 @@ def test_loading_high_low_tide_comp(client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_api_returns_high_tide_comp_datasets(client: FlaskClient):
+def test_api_returns_high_tide_comp_datasets(client: FlaskClient) -> None:
     """
     These are slightly fun to handle as they are a small number with a huge time range.
     """
@@ -444,7 +446,7 @@ def test_api_returns_high_tide_comp_datasets(client: FlaskClient):
     assert len(geojson["features"]) == 0, "Expected no result one-day-after center time"
 
 
-def test_api_returns_scenes_as_geojson(client: FlaskClient):
+def test_api_returns_scenes_as_geojson(client: FlaskClient) -> None:
     """
     L1 scenes have no footprint, falls back to bounds. Have weird CRSes too.
     """
@@ -452,7 +454,7 @@ def test_api_returns_scenes_as_geojson(client: FlaskClient):
     assert len(geojson["features"]) == 5, "Unexpected l1 polygon count"
 
 
-def test_api_returns_tiles_as_geojson(client: FlaskClient):
+def test_api_returns_tiles_as_geojson(client: FlaskClient) -> None:
     """
     Covers most of the 'normal' products: they have a footprint, bounds and a simple crs epsg code.
     """
@@ -461,7 +463,7 @@ def test_api_returns_tiles_as_geojson(client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_api_returns_high_tide_comp_regions(client: FlaskClient):
+def test_api_returns_high_tide_comp_regions(client: FlaskClient) -> None:
     """
     High tide doesn't have anything we can use as regions.
 
@@ -474,7 +476,7 @@ def test_api_returns_high_tide_comp_regions(client: FlaskClient):
     )
 
 
-def test_api_returns_scene_regions(client: FlaskClient):
+def test_api_returns_scene_regions(client: FlaskClient) -> None:
     """
     L1 scenes have no footprint, falls back to bounds. Have weird CRSes too.
     """
@@ -482,7 +484,7 @@ def test_api_returns_scene_regions(client: FlaskClient):
     assert len(geojson["features"]) == 5, "Unexpected l1 region count"
 
 
-def test_region_page(client: FlaskClient):
+def test_region_page(client: FlaskClient) -> None:
     """
     Load a list of scenes for a given region.
     """
@@ -500,7 +502,7 @@ def test_region_page(client: FlaskClient):
     )
 
 
-def test_legacy_region_redirect(client: FlaskClient):
+def test_legacy_region_redirect(client: FlaskClient) -> None:
     # Legacy redirect works, and maintains "feeling lucky"
     assert_redirects_to(
         client,
@@ -509,7 +511,7 @@ def test_legacy_region_redirect(client: FlaskClient):
     )
 
 
-def assert_redirects_to(client: FlaskClient, url: str, redirects_to_url: str):
+def assert_redirects_to(client: FlaskClient, url: str, redirects_to_url: str) -> None:
     __tracebackhide__ = True
     response: Response = client.get(url, follow_redirects=False)
     assert response.status_code == 302
@@ -521,7 +523,7 @@ def assert_redirects_to(client: FlaskClient, url: str, redirects_to_url: str):
     )
 
 
-def test_search_page(client: FlaskClient):
+def test_search_page(client: FlaskClient) -> None:
     html = get_html(client, "/datasets/ga_ls8c_ard_3")
     search_results = html.find(".search-result a")
     assert len(search_results) == 21
@@ -535,7 +537,7 @@ def test_search_page(client: FlaskClient):
     assert len(search_results) == 0
 
 
-def test_search_time_completion(client: FlaskClient):
+def test_search_time_completion(client: FlaskClient) -> None:
     # They only specified a begin time, so the end time should be filled in with the product extent.
     html = get_html(client, "/datasets/ga_ls8c_ard_3?time-begin=1999-05-28")
     assert one_element(html, "#search-time-before").attrs["value"] == "1999-05-28"
@@ -552,7 +554,7 @@ def test_search_time_completion(client: FlaskClient):
     assert len(search_results) == 2
 
 
-def test_api_returns_tiles_regions(client: FlaskClient):
+def test_api_returns_tiles_regions(client: FlaskClient) -> None:
     """
     Covers most of the 'normal' products: they have a footprint, bounds and a simple crs epsg code.
     """
@@ -560,7 +562,7 @@ def test_api_returns_tiles_regions(client: FlaskClient):
     assert len(geojson["features"]) == 11, "Unexpected product region count"
 
 
-def test_api_returns_limited_tile_regions(client: FlaskClient):
+def test_api_returns_limited_tile_regions(client: FlaskClient) -> None:
     """
     Covers most of the 'normal' products: they have a footprint, bounds and a simple crs epsg code.
     """
@@ -573,7 +575,7 @@ def test_api_returns_limited_tile_regions(client: FlaskClient):
     assert len(geojson["features"]) == 0, "Unexpected region count"
 
 
-def test_api_returns_timelines(client: FlaskClient):
+def test_api_returns_timelines(client: FlaskClient) -> None:
     """
     Covers most of the 'normal' products: they have a footprint, bounds and a simple crs epsg code.
     """
@@ -723,7 +725,7 @@ pytest.mark.xfail(True, reason="telemetry data removed")
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_undisplayable_product(client: FlaskClient):
+def test_undisplayable_product(client: FlaskClient) -> None:
     """
     Telemetry products have no footprint available at all.
     """
@@ -735,7 +737,7 @@ def test_undisplayable_product(client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_no_data_pages(client: FlaskClient):
+def test_no_data_pages(client: FlaskClient) -> None:
     """
     Fetch products that exist but have no summaries generated.
 
@@ -754,7 +756,7 @@ def test_no_data_pages(client: FlaskClient):
     check_dataset_count(html, 0)
 
 
-def test_general_dataset_redirect(client: FlaskClient):
+def test_general_dataset_redirect(client: FlaskClient) -> None:
     """
     When someone queries a dataset UUID, they should be redirected
     to the real URL for the collection.
@@ -770,7 +772,7 @@ def test_general_dataset_redirect(client: FlaskClient):
     )
 
 
-def test_missing_dataset(client: FlaskClient):
+def test_missing_dataset(client: FlaskClient) -> None:
     rv: Response = client.get(
         "/products/ga_ls8c_ard_3/datasets/f22a33f4-42f2-4aa5-9b20-cee4ca4a875c",
         follow_redirects=False,
@@ -785,7 +787,7 @@ def test_missing_dataset(client: FlaskClient):
     assert rv.status_code == 200
 
 
-def test_invalid_product_returns_not_found(client: FlaskClient):
+def test_invalid_product_returns_not_found(client: FlaskClient) -> None:
     """
     An invalid product should be "not found". No server errors.
     """
@@ -796,7 +798,7 @@ def test_invalid_product_returns_not_found(client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_show_summary_cli(clirunner, client: FlaskClient):
+def test_show_summary_cli(clirunner, client: FlaskClient) -> None:
     """
     You should be able to view a product with cubedash-view command-line program.
     """
@@ -841,7 +843,7 @@ def test_show_summary_cli(clirunner, client: FlaskClient):
     assert expected_period in res.output
 
 
-def test_show_summary_cli_out_of_bounds(clirunner, client: FlaskClient):
+def test_show_summary_cli_out_of_bounds(clirunner, client: FlaskClient) -> None:
     """
     Can you view a date that doesn't exist?
     """
@@ -852,7 +854,7 @@ def test_show_summary_cli_out_of_bounds(clirunner, client: FlaskClient):
     assert "No summary for chosen period." in res.output
 
 
-def test_show_summary_cli_missing_product(clirunner, client: FlaskClient):
+def test_show_summary_cli_missing_product(clirunner, client: FlaskClient) -> None:
     """
     A missing product should return a nice error message from cubedash-view.
 
@@ -864,7 +866,9 @@ def test_show_summary_cli_missing_product(clirunner, client: FlaskClient):
     assert res.exit_code != 0
 
 
-def test_show_summary_cli_unsummarised_product(clirunner, empty_client: FlaskClient):
+def test_show_summary_cli_unsummarised_product(
+    clirunner, empty_client: FlaskClient
+) -> None:
     """
     An unsummarised product should return a nice error message from cubedash-view.
 
@@ -876,7 +880,7 @@ def test_show_summary_cli_unsummarised_product(clirunner, empty_client: FlaskCli
     assert res.exit_code != 0
 
 
-def test_extent_debugging_method(odc_test_db, client: FlaskClient):
+def test_extent_debugging_method(odc_test_db, client: FlaskClient) -> None:
     index = odc_test_db.index
     product = index.products.get_by_name("ga_ls8c_ard_3")
     e_index = explorer_index(index)
@@ -897,7 +901,7 @@ def test_extent_debugging_method(odc_test_db, client: FlaskClient):
 
 # this test fails in gh with the postgis driver for unknown reasons
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_with_timings(client: FlaskClient):
+def test_with_timings(client: FlaskClient) -> None:
     _monitoring.init_app_monitoring(client.application)
     # ga_ls8c_ard_3 dataset
     rv: Response = client.get("/dataset/e2dd2539-ae18-4edc-a0e6-ddd31848669c")
@@ -918,13 +922,13 @@ def test_with_timings(client: FlaskClient):
     assert int(val) > 0, "At least one query was run, presumably?"
 
 
-def test_plain_product_list(client: FlaskClient):
+def test_plain_product_list(client: FlaskClient) -> None:
     text, rv = get_text_response(client, "/products.txt")
     assert "ga_ls8c_ard_3\n" in text
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_raw_documents(client: FlaskClient):
+def test_raw_documents(client: FlaskClient) -> None:
     """
     Check that raw-documents load without error,
     and have embedded hints on where they came from (source-url)
@@ -959,7 +963,7 @@ def test_raw_documents(client: FlaskClient):
     )
 
 
-def test_get_robots(client: FlaskClient):
+def test_get_robots(client: FlaskClient) -> None:
     """
     Check that robots.txt is correctly served from root
     """
@@ -974,7 +978,7 @@ def test_get_robots(client: FlaskClient):
     )
 
 
-def test_all_give_404s(client: FlaskClient):
+def test_all_give_404s(client: FlaskClient) -> None:
     """
     We should get 404 messages, not exceptions, for missing things.
     """
@@ -1014,12 +1018,12 @@ def test_all_give_404s(client: FlaskClient):
     expect_404(f"/dataset/{dataset_id}.odc-metadata.yaml")
 
 
-def test_invalid_query_gives_400(client: FlaskClient):
+def test_invalid_query_gives_400(client: FlaskClient) -> None:
     """
     We should get 400 errors, not errors, for an invalid field values in a query
     """
 
-    def expect_400(url: str):
+    def expect_400(url: str) -> None:
         __tracebackhide__ = True
         get_text_response(client, url, expect_status_code=400)
 

--- a/integration_tests/test_pages_render.py
+++ b/integration_tests/test_pages_render.py
@@ -64,7 +64,7 @@ def assert_all_urls_render(all_urls: list[str], client: FlaskClient):
             )
 
 
-def test_all_pages_render(all_urls, client: FlaskClient):
+def test_all_pages_render(all_urls, client: FlaskClient) -> None:
     """
     Do all expected URLS render with HTTP OK response with our normal test data?
     """
@@ -76,7 +76,7 @@ def test_allows_null_product_fixed_fields(
     client: FlaskClient,
     odc_test_db: Datacube,
     summary_store: SummaryStore,
-):
+) -> None:
     """
     Pages should not fall over when fixed_metadata is null.
 

--- a/integration_tests/test_raw_yaml.py
+++ b/integration_tests/test_raw_yaml.py
@@ -102,7 +102,7 @@ def dataset_yaml_from_raw(client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_update_type(type_yaml_from_raw):
+def test_update_type(type_yaml_from_raw) -> None:
     result = CliRunner().invoke(
         datacube.scripts.cli_app.cli,
         [
@@ -117,7 +117,7 @@ def test_update_type(type_yaml_from_raw):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_update_product(product_yaml_from_raw):
+def test_update_product(product_yaml_from_raw) -> None:
     result = CliRunner().invoke(
         datacube.scripts.cli_app.cli,
         [
@@ -135,7 +135,7 @@ def test_update_product(product_yaml_from_raw):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_update_dataset(dataset_yaml_from_raw):
+def test_update_dataset(dataset_yaml_from_raw) -> None:
     result = CliRunner().invoke(
         datacube.scripts.cli_app.cli,
         [

--- a/integration_tests/test_regex_group.py
+++ b/integration_tests/test_regex_group.py
@@ -10,7 +10,7 @@ from cubedash._utils import get_sorted_product_summaries
 
 
 class FakeProduct:
-    def __init__(self, name):
+    def __init__(self, name) -> None:
         self.name = name
 
 
@@ -46,7 +46,7 @@ def test_product_list():
     return product_summaries
 
 
-def test_group_by_regex(test_product_groupby_regex_list, test_product_list):
+def test_group_by_regex(test_product_groupby_regex_list, test_product_list) -> None:
     regex_group = {}
     for regex, group in test_product_groupby_regex_list:
         regex_group[re.compile(regex)] = group.strip()
@@ -73,7 +73,9 @@ def test_group_by_regex(test_product_groupby_regex_list, test_product_list):
     # assert grouped_product_summarise[5][0] == 'C2 - Deprecated'
 
 
-def test_reverse_group_by_regex(test_product_groupby_regex_list, test_product_list):
+def test_reverse_group_by_regex(
+    test_product_groupby_regex_list, test_product_list
+) -> None:
     """
     reverse the groupby regex config tuple
     """

--- a/integration_tests/test_region_tiles.py
+++ b/integration_tests/test_region_tiles.py
@@ -36,13 +36,13 @@ DATASETS = [
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
-def test_wo_summary_product(client: FlaskClient):
+def test_wo_summary_product(client: FlaskClient) -> None:
     html = get_html(client, "/ga_ls_wo_fq_nov_mar_3")
 
     check_dataset_count(html, 6)
 
 
-def test_wo_region_dataset_count(client: FlaskClient):
+def test_wo_region_dataset_count(client: FlaskClient) -> None:
     html = get_html(client, "/product/ga_ls_wo_fq_nov_mar_3/regions/x11y46")
 
     search_results = html.find(".search-result a")
@@ -52,13 +52,13 @@ def test_wo_region_dataset_count(client: FlaskClient):
 # Test where region_code is defined in metadata but all are the same
 
 
-def test_landcover_summary_product(client: FlaskClient):
+def test_landcover_summary_product(client: FlaskClient) -> None:
     html = get_html(client, "/ga_ls_landcover_class_cyear_2")
 
     check_dataset_count(html, 3)
 
 
-def test_landcover_region_dataset_count(client: FlaskClient):
+def test_landcover_region_dataset_count(client: FlaskClient) -> None:
     html = get_html(client, "/product/ga_ls_landcover_class_cyear_2/regions/au")
 
     search_results = html.find(".search-result a")
@@ -66,14 +66,14 @@ def test_landcover_region_dataset_count(client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_tmad_summary_product(client: FlaskClient):
+def test_tmad_summary_product(client: FlaskClient) -> None:
     html = get_html(client, "/ls5_nbart_tmad_annual")
 
     check_dataset_count(html, 2)
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_tmad_dataset_regions(client: FlaskClient):
+def test_tmad_dataset_regions(client: FlaskClient) -> None:
     html = get_html(client, "product/ls5_nbart_tmad_annual/regions/-14_-25")
 
     search_results = html.find(".search-result a")
@@ -85,7 +85,7 @@ def test_tmad_dataset_regions(client: FlaskClient):
     assert len(search_results) == 1
 
 
-def test_archived_dataset_is_excluded(client, run_generate, odc_test_db):
+def test_archived_dataset_is_excluded(client, run_generate, odc_test_db) -> None:
     # It's not possible to test this thoroughly, because the Region response is cached for 90
     # seconds, with no way to override other than creating a new `client`. :(
     try:
@@ -104,7 +104,7 @@ def test_archived_dataset_is_excluded(client, run_generate, odc_test_db):
         odc_test_db.index.datasets.restore(["974e1e89-3757-4d94-be8d-7acaeb7adf24"])
 
 
-def test_region_switchable_product(client: FlaskClient):
+def test_region_switchable_product(client: FlaskClient) -> None:
     # Two products share the same region code
     html = get_html(client, "/product/ga_ls_wo_fq_nov_mar_3/regions/x25y41")
     product_list = html.find("#product-headers ul.items li:not(.empty)")

--- a/integration_tests/test_resolved_uri.py
+++ b/integration_tests/test_resolved_uri.py
@@ -36,7 +36,7 @@ def app_s3_region_empty_string():
     return app
 
 
-def test_as_external_url(app_s3_region_unset):
+def test_as_external_url(app_s3_region_unset) -> None:
     with app_s3_region_unset.app_context():
         assert (
             as_external_url(
@@ -63,7 +63,7 @@ def test_as_external_url(app_s3_region_unset):
         )
 
 
-def test_resolved_remote_url_s3_region_unset(app_s3_region_unset):
+def test_resolved_remote_url_s3_region_unset(app_s3_region_unset) -> None:
     with app_s3_region_unset.app_context():
         assert current_app.config.get("CUBEDASH_DATA_S3_REGION") is None
 
@@ -78,7 +78,7 @@ def test_resolved_remote_url_s3_region_unset(app_s3_region_unset):
         )
 
 
-def test_resolved_remote_url_none_s3_region(app_s3_region_none):
+def test_resolved_remote_url_none_s3_region(app_s3_region_none) -> None:
     with app_s3_region_none.app_context():
         assert current_app.config.get("CUBEDASH_DATA_S3_REGION") is None
 
@@ -93,7 +93,7 @@ def test_resolved_remote_url_none_s3_region(app_s3_region_none):
         )
 
 
-def test_resolved_remote_url_string_none_s3_region(app_s3_region_string_none):
+def test_resolved_remote_url_string_none_s3_region(app_s3_region_string_none) -> None:
     with app_s3_region_string_none.app_context():
         assert current_app.config.get("CUBEDASH_DATA_S3_REGION") == "None"
 
@@ -108,7 +108,7 @@ def test_resolved_remote_url_string_none_s3_region(app_s3_region_string_none):
         )
 
 
-def test_resolved_remote_url_empty_string_s3_region(app_s3_region_empty_string):
+def test_resolved_remote_url_empty_string_s3_region(app_s3_region_empty_string) -> None:
     with app_s3_region_empty_string.app_context():
         assert current_app.config.get("CUBEDASH_DATA_S3_REGION") == ""
 
@@ -123,7 +123,7 @@ def test_resolved_remote_url_empty_string_s3_region(app_s3_region_empty_string):
         )
 
 
-def test_resolved_remote_url_data_browser(app_s3_region_string_none):
+def test_resolved_remote_url_data_browser(app_s3_region_string_none) -> None:
     with app_s3_region_string_none.app_context():
         assert current_app.config.get("SHOW_DATA_LOCATION") == {
             "dea-public-data": "data.dea.ga.gov.au"

--- a/integration_tests/test_s2_l2a_footprint.py
+++ b/integration_tests/test_s2_l2a_footprint.py
@@ -24,21 +24,21 @@ DATASETS = ["datasets/s2_l2a-sample.yaml"]
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
-def test_summary_product(client: FlaskClient):
+def test_summary_product(client: FlaskClient) -> None:
     # These datasets have gigantic footprints that can trip up postgis.
     html = get_html(client, "/s2_l2a")
 
     check_dataset_count(html, 4)
 
 
-def test_product_dataset(client: FlaskClient):
+def test_product_dataset(client: FlaskClient) -> None:
     # Check if all datasets are available to be viewed
     html = get_html(client, "/datasets/s2_l2a")
 
     assert len(html.find(".search-result")) == 5
 
 
-def test_s2_l2a_summary(run_generate, summary_store: SummaryStore):
+def test_s2_l2a_summary(run_generate, summary_store: SummaryStore) -> None:
     run_generate("s2_l2a")
     expect_values(
         summary_store.get("s2_l2a"),
@@ -56,7 +56,7 @@ def test_s2_l2a_summary(run_generate, summary_store: SummaryStore):
     )
 
 
-def test_product_audit(unpopulated_client: FlaskClient, run_generate):
+def test_product_audit(unpopulated_client: FlaskClient, run_generate) -> None:
     run_generate()
     client = unpopulated_client
 
@@ -75,7 +75,7 @@ def test_product_audit(unpopulated_client: FlaskClient, run_generate):
     )
 
 
-def test_get_overview_date_selector(client: FlaskClient):
+def test_get_overview_date_selector(client: FlaskClient) -> None:
     # [1] = year, [2] = month, [3] = day
     # check when no year, month, day has been selected
     html = get_html(client, "/s2_l2a")
@@ -105,7 +105,9 @@ def test_get_overview_date_selector(client: FlaskClient):
     assert len(menu[3].find(".option-menu ul li")) == 3
 
 
-def test_refresh_product(empty_client: FlaskClient, summary_store: SummaryStore):
+def test_refresh_product(
+    empty_client: FlaskClient, summary_store: SummaryStore
+) -> None:
     # Populate one product, so they don't get the usage error message ("run cubedash generate")
     summary_store.refresh("s2_l2a")
 

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -279,20 +279,20 @@ def _iter_items_across_pages(
 # Assertions and validations
 
 
-def assert_stac_extensions(doc: dict):
+def assert_stac_extensions(doc: dict) -> None:
     stac_extensions = doc.get("stac_extensions", ())
     for extension_name in stac_extensions:
         get_extension(extension_name).validate(doc)
 
 
-def assert_item_collection(collection: dict):
+def assert_item_collection(collection: dict) -> None:
     assert "features" in collection, "No features in collection"
     _ITEM_COLLECTION_SCHEMA.validate(collection)
     assert_stac_extensions(collection)
     validate_items(collection["features"])
 
 
-def assert_collection(collection: dict):
+def assert_collection(collection: dict) -> None:
     _COLLECTION_SCHEMA.validate(collection)
     assert "features" not in collection
     assert_stac_extensions(collection)
@@ -305,7 +305,7 @@ def assert_collection(collection: dict):
     assert "items" in rels, "Collection has no link to its items"
 
 
-def validate_item(item: dict):
+def validate_item(item: dict) -> None:
     _ITEM_SCHEMA.validate(item)
 
     # Should be a valid polygon
@@ -327,7 +327,7 @@ def validate_item(item: dict):
 
 def validate_items(
     items: Iterable[dict], expect_ordered=True, expect_count: int | dict = None
-):
+) -> None:
     """
     Check that a series of stac Items:
     - has no duplicates,
@@ -402,7 +402,7 @@ def stac_client(client: FlaskClient):
 
 @pytest.mark.skip(reason="FIXME: JSON schema validation issues")
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_loading_all_pages(stac_client: FlaskClient):
+def test_stac_loading_all_pages(stac_client: FlaskClient) -> None:
     # An unconstrained search returning every dataset.
     # It should return every dataset in order with no duplicates.
     all_items = _iter_items_across_pages(stac_client, "/stac/search")
@@ -459,7 +459,7 @@ def test_stac_loading_all_pages(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_huge_page_request(stac_client: FlaskClient):
+def test_huge_page_request(stac_client: FlaskClient) -> None:
     """Return an error if they try to request beyond max-page-size limit"""
     error_message_json = get_json(
         stac_client,
@@ -474,7 +474,7 @@ def test_huge_page_request(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_returns_404s(stac_client: FlaskClient):
+def test_returns_404s(stac_client: FlaskClient) -> None:
     """
     We should get 404 messages, not exceptions, for missing things.
 
@@ -539,7 +539,9 @@ def test_returns_404s(stac_client: FlaskClient):
         ),
     ],
 )
-def test_legacy_redirects(stac_client: FlaskClient, url: str, redirect_to_url: str):
+def test_legacy_redirects(
+    stac_client: FlaskClient, url: str, redirect_to_url: str
+) -> None:
     resp: Response = stac_client.get(url, follow_redirects=False)
     assert resp.location == redirect_to_url, (
         f"Expected {url} to be redirected to:\n"
@@ -552,7 +554,7 @@ def test_legacy_redirects(stac_client: FlaskClient, url: str, redirect_to_url: s
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_links(stac_client: FlaskClient):
+def test_stac_links(stac_client: FlaskClient) -> None:
     """Check that root contains all expected links"""
     response = get_json(stac_client, "/stac")
     _CATALOG_SCHEMA.validate(response)
@@ -623,7 +625,7 @@ def test_stac_links(stac_client: FlaskClient):
 
 @pytest.mark.skip(reason="FIXME: JSON schema validation issues")
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_arrivals_page_validation(stac_client: FlaskClient):
+def test_arrivals_page_validation(stac_client: FlaskClient) -> None:
     # Do the virtual 'arrivals' catalog and items validate?
     response = get_json(stac_client, "/stac/catalogs/arrivals")
     _CATALOG_SCHEMA.validate(response)
@@ -723,7 +725,7 @@ def test_stac_collection(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_item(stac_client: FlaskClient, odc_test_db):
+def test_stac_item(stac_client: FlaskClient, odc_test_db) -> None:
     # Load one stac dataset from the test data.
 
     dataset_uri = (
@@ -744,7 +746,7 @@ def test_stac_item(stac_client: FlaskClient, odc_test_db):
         ),
     )
 
-    def dataset_url(s: str):
+    def dataset_url(s: str) -> str:
         return (
             f"file:///g/data/rs0/scenes/ls7/2017/05/output/nbar/"
             f"LS7_ETM_NBAR_P54_GANBAR01-002_096_082_20170502/{s}"
@@ -927,7 +929,7 @@ def test_stac_item(stac_client: FlaskClient, odc_test_db):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_search_limits(stac_client: FlaskClient):
+def test_stac_search_limits(stac_client: FlaskClient) -> None:
     # Tell user with error if they request too much.
     large_limit = OUR_DATASET_LIMIT + 1
     rv: Response = stac_client.get(f"/stac/search?&limit={large_limit}")
@@ -947,7 +949,7 @@ def test_stac_search_limits(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_search_zero(stac_client: FlaskClient):
+def test_stac_search_zero(stac_client: FlaskClient) -> None:
     # Zero limit is a valid query
     zero_limit = 0
     rv: Response = stac_client.get(f"/stac/search?&limit={zero_limit}")
@@ -955,7 +957,7 @@ def test_stac_search_zero(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_includes_total(stac_client: FlaskClient):
+def test_stac_includes_total(stac_client: FlaskClient) -> None:
     geojson = get_items(
         stac_client,
         (
@@ -969,7 +971,7 @@ def test_stac_includes_total(stac_client: FlaskClient):
 
 @pytest.mark.skip(reason="FIXME: JSON schema validation issues")
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_next_link(stac_client: FlaskClient):
+def test_next_link(stac_client: FlaskClient) -> None:
     # next link should return next page of results
     geojson = get_items(
         stac_client,
@@ -987,7 +989,7 @@ def test_next_link(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_search_by_ids(stac_client: FlaskClient):
+def test_stac_search_by_ids(stac_client: FlaskClient) -> None:
     def geojson_feature_ids(d: dict) -> list[str]:
         return sorted(d.get("id") for d in geojson.get("features", {}))
 
@@ -1058,7 +1060,7 @@ def test_stac_search_by_ids(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_search_by_intersects(stac_client: FlaskClient):
+def test_stac_search_by_intersects(stac_client: FlaskClient) -> None:
     """
     We have the polygon for region 16,-33.
 
@@ -1106,7 +1108,7 @@ def test_stac_search_by_intersects(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_search_by_intersects_paging(stac_client: FlaskClient):
+def test_stac_search_by_intersects_paging(stac_client: FlaskClient) -> None:
     """
     When we search by 'intersects', the next page link should use a correct POST request.
 
@@ -1155,7 +1157,7 @@ def test_stac_search_by_intersects_paging(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_search_collections(stac_client: FlaskClient):
+def test_stac_search_collections(stac_client: FlaskClient) -> None:
     """Can you query a list of multiple collections?"""
 
     # Get all in one collection
@@ -1194,7 +1196,7 @@ def test_stac_search_collections(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_search_bounds(stac_client: FlaskClient):
+def test_stac_search_bounds(stac_client: FlaskClient) -> None:
     # Outside the box there should be no results
     geojson = get_items(
         stac_client,
@@ -1233,7 +1235,7 @@ def test_stac_search_bounds(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_search_by_post(stac_client: FlaskClient):
+def test_stac_search_by_post(stac_client: FlaskClient) -> None:
     # Test POST, product, and assets
     rv: Response = stac_client.post(
         "/stac/search",
@@ -1300,7 +1302,7 @@ def test_stac_search_by_post(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_fields_extension(stac_client: FlaskClient):
+def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     fields = {"include": ["properties.dea:dataset_maturity"]}
     rv: Response = stac_client.post(
         "/stac/search",
@@ -1399,7 +1401,7 @@ def test_stac_fields_extension(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_sortby_extension(stac_client: FlaskClient):
+def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
     sortby = [{"field": "properties.datetime", "direction": "asc"}]
     rv: Response = stac_client.post(
         "/stac/search",
@@ -1479,7 +1481,7 @@ def test_stac_sortby_extension(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_filter_extension(stac_client: FlaskClient):
+def test_stac_filter_extension(stac_client: FlaskClient) -> None:
     filter_json = {
         "op": "and",
         "args": [
@@ -1571,7 +1573,7 @@ def test_stac_filter_extension(stac_client: FlaskClient):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_query_extension_errors(stac_client: FlaskClient):
+def test_stac_query_extension_errors(stac_client: FlaskClient) -> None:
     # Trying to use query extension should error
     query = {"cloud_cover": {"lt": 1}}
     rv: Response = stac_client.post(

--- a/integration_tests/test_stores.py
+++ b/integration_tests/test_stores.py
@@ -67,7 +67,7 @@ def _overview(
     return orig
 
 
-def test_add_period_list():
+def test_add_period_list() -> None:
     total = TimePeriodOverview.add_periods([])
     assert total.dataset_count == 0
 
@@ -88,13 +88,13 @@ def test_add_period_list():
     assert sorted(joined.region_dataset_counts.keys()) == ["1_2", "3_4", "4_5"]
 
 
-def test_srid_calcs():
+def test_srid_calcs() -> None:
     o = _overview()
     assert o.footprint_crs == "EPSG:3577"
     assert o.footprint_srid == 3577
 
 
-def test_add_no_periods(summary_store: SummaryStore):
+def test_add_no_periods(summary_store: SummaryStore) -> None:
     """
     All the get/update methods should work on products with no datasets.
     """
@@ -111,10 +111,10 @@ def test_add_no_periods(summary_store: SummaryStore):
     assert summary_store.get("ga_ls8c_level1_3", 2015, 7, None) is None
 
 
-def test_month_iteration():
+def test_month_iteration() -> None:
     def assert_month_iteration(
         start: datetime, end: datetime, expected_months: list[date]
-    ):
+    ) -> None:
         __tracebackhide__ = operator.methodcaller("errisinstance", AssertionError)
 
         product = ProductSummary(
@@ -156,7 +156,7 @@ def test_month_iteration():
     )
 
 
-def test_get_null(summary_store: SummaryStore):
+def test_get_null(summary_store: SummaryStore) -> None:
     """
     An area with nothing generated should come back as null.
 
@@ -172,7 +172,7 @@ def test_get_null(summary_store: SummaryStore):
 #     assert summary_store.grouping_crs == "EPSG:3577"
 
 
-def test_put_get_summaries(summary_store: SummaryStore):
+def test_put_get_summaries(summary_store: SummaryStore) -> None:
     """
     Test the serialisation/deserialisation from postgres
     """
@@ -236,7 +236,7 @@ def test_put_get_summaries(summary_store: SummaryStore):
     )
 
 
-def test_generate_empty(run_generate):
+def test_generate_empty(run_generate) -> None:
     """
     Run cubedash.generate on a cube with no datasets.
 
@@ -246,7 +246,7 @@ def test_generate_empty(run_generate):
     run_generate()
 
 
-def test_generate_raises_error(run_generate, empty_client):
+def test_generate_raises_error(run_generate, empty_client) -> None:
     """
     generate should return an error when an unknown product is asked for explicitly.
     """

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -50,7 +50,7 @@ pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_generate_month(run_generate, summary_store: SummaryStore):
+def test_generate_month(run_generate, summary_store: SummaryStore) -> None:
     run_generate("ls8_nbar_scene")
     # One Month
     _expect_values(
@@ -79,7 +79,7 @@ def test_generate_month(run_generate, summary_store: SummaryStore):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_generate_scene_year(run_generate, summary_store: SummaryStore):
+def test_generate_scene_year(run_generate, summary_store: SummaryStore) -> None:
     run_generate(multi_processed=True)
     # One year
     _expect_values(
@@ -108,7 +108,7 @@ def test_generate_scene_year(run_generate, summary_store: SummaryStore):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_generate_scene_all_time(run_generate, summary_store: SummaryStore):
+def test_generate_scene_all_time(run_generate, summary_store: SummaryStore) -> None:
     run_generate("ls8_nbar_scene")
 
     # All time
@@ -143,7 +143,9 @@ def test_generate_scene_all_time(run_generate, summary_store: SummaryStore):
     )
 
 
-def test_generate_incremental_archivals(run_generate, summary_store: SummaryStore):
+def test_generate_incremental_archivals(
+    run_generate, summary_store: SummaryStore
+) -> None:
     run_generate("ga_ls9c_ard_3")
     index = summary_store.index
 
@@ -182,7 +184,7 @@ def _one_dataset(index: Index, product_name: str):
     return dataset_id
 
 
-def test_dataset_changing_product(run_generate, summary_store: SummaryStore):
+def test_dataset_changing_product(run_generate, summary_store: SummaryStore) -> None:
     """
     If a dataset it updated to be in a different product, Explorer should
     correctly update its summaries.
@@ -231,7 +233,9 @@ def test_dataset_changing_product(run_generate, summary_store: SummaryStore):
     )
 
 
-def _change_dataset_product(index: Index, dataset_id: UUID, other_product: Product):
+def _change_dataset_product(
+    index: Index, dataset_id: UUID, other_product: Product
+) -> None:
     if index.name == "pg_index":
         table_name = "agdc.dataset"
         ref_column = "dataset_type_ref"
@@ -251,7 +255,7 @@ def _change_dataset_product(index: Index, dataset_id: UUID, other_product: Produ
     assert rows_changed == 1
 
 
-def test_location_sampling(run_generate, summary_store: SummaryStore):
+def test_location_sampling(run_generate, summary_store: SummaryStore) -> None:
     location_samples = summary_store.product_location_samples("ga_ls8c_ard_3")
     assert len(location_samples) == 1
 
@@ -265,7 +269,9 @@ def test_location_sampling(run_generate, summary_store: SummaryStore):
     )
 
 
-def test_has_source_derived_product_links(run_generate, summary_store: SummaryStore):
+def test_has_source_derived_product_links(
+    run_generate, summary_store: SummaryStore
+) -> None:
     run_generate()
 
     ls_fc_pc = summary_store.get_product_summary("ga_ls_fc_pc_cyear_3")
@@ -284,7 +290,7 @@ def test_has_source_derived_product_links(run_generate, summary_store: SummarySt
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_product_fixed_fields(run_generate, summary_store: SummaryStore):
+def test_product_fixed_fields(run_generate, summary_store: SummaryStore) -> None:
     run_generate()
 
     albers = summary_store.get_product_summary("ls8_nbar_albers")
@@ -319,7 +325,7 @@ def test_product_fixed_fields(run_generate, summary_store: SummaryStore):
     }
 
 
-def test_sampled_product_fixed_fields(summary_store: SummaryStore):
+def test_sampled_product_fixed_fields(summary_store: SummaryStore) -> None:
     # Compute fixed fields using a sampled percentage.
 
     # (We're doing this manually to force it to use table sampling -- our test data is
@@ -343,7 +349,7 @@ def test_sampled_product_fixed_fields(summary_store: SummaryStore):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_generate_empty_time(run_generate, summary_store: SummaryStore):
+def test_generate_empty_time(run_generate, summary_store: SummaryStore) -> None:
     run_generate("ls8_nbar_albers")
     # No datasets in 2018
     assert summary_store.get("ls8_nbar_albers", year=2018) is None, (
@@ -355,7 +361,7 @@ def test_generate_empty_time(run_generate, summary_store: SummaryStore):
     assert summary is None
 
 
-def test_calc_empty(summary_store: SummaryStore):
+def test_calc_empty(summary_store: SummaryStore) -> None:
     summary_store.refresh_all_product_extents()
 
     # Should not exist.
@@ -364,7 +370,7 @@ def test_calc_empty(summary_store: SummaryStore):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_generate_telemetry(run_generate, summary_store: SummaryStore):
+def test_generate_telemetry(run_generate, summary_store: SummaryStore) -> None:
     """
     Telemetry data polygons can be synthesized from the path/row values
     """
@@ -417,7 +423,7 @@ def test_generate_telemetry(run_generate, summary_store: SummaryStore):
     )
 
 
-def test_generate_day(run_generate, summary_store: SummaryStore):
+def test_generate_day(run_generate, summary_store: SummaryStore) -> None:
     run_generate("ga_ls8c_ard_3")
 
     _expect_values(
@@ -439,7 +445,7 @@ def test_generate_day(run_generate, summary_store: SummaryStore):
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
 def test_force_dataset_regeneration(
     run_generate, summary_store: SummaryStore, odc_test_db: Datacube
-):
+) -> None:
     """
     We should be able to force-replace dataset extents with the "--recreate-dataset-extents" option
     """
@@ -482,7 +488,7 @@ def test_force_dataset_regeneration(
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_calc_albers_summary_with_storage(summary_store: SummaryStore):
+def test_calc_albers_summary_with_storage(summary_store: SummaryStore) -> None:
     # Should not exist yet.
     summary = summary_store.get("ls8_nbar_albers", year=None, month=None, day=None)
     assert summary is None
@@ -528,7 +534,9 @@ def test_calc_albers_summary_with_storage(summary_store: SummaryStore):
     )
 
 
-def test_cubedash_gen_refresh(run_generate, odc_test_db: Datacube, empty_client):
+def test_cubedash_gen_refresh(
+    run_generate, odc_test_db: Datacube, empty_client
+) -> None:
     """
     cubedash-gen shouldn't increment the product sequence when run normally
     """
@@ -554,7 +562,7 @@ def test_cubedash_gen_refresh(run_generate, odc_test_db: Datacube, empty_client)
     )
 
 
-def test_computed_regions_match_those_summarised(summary_store: SummaryStore):
+def test_computed_regions_match_those_summarised(summary_store: SummaryStore) -> None:
     """
     The region code for all datasets should be computed identically when
     done in both SQL and Python.

--- a/integration_tests/test_utc_tst.py
+++ b/integration_tests/test_utc_tst.py
@@ -45,14 +45,14 @@ pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_summary_product(client: FlaskClient):
+def test_summary_product(client: FlaskClient) -> None:
     # These datasets have gigantic footprints that can trip up postgis.
     html = get_html(client, "/ls5_fc_albers")
 
     check_dataset_count(html, 5)
 
 
-def test_yearly_dataset_count(client: FlaskClient):
+def test_yearly_dataset_count(client: FlaskClient) -> None:
     html = get_html(client, "/ga_ls9c_ard_3/2021/12")
     check_dataset_count(html, 5)
 
@@ -63,7 +63,7 @@ def test_yearly_dataset_count(client: FlaskClient):
     check_dataset_count(html, 6)
 
 
-def test_dataset_search_page_localised_time(client: FlaskClient):
+def test_dataset_search_page_localised_time(client: FlaskClient) -> None:
     html = get_html(client, "/products/ga_ls9c_ard_3/datasets/2022")
 
     assert "2022-01-01 08:11:00" in [
@@ -87,7 +87,9 @@ def test_dataset_search_page_localised_time(client: FlaskClient):
     )
 
 
-def test_clirunner_generate_grouping_timezone(odc_test_db, run_generate, empty_client):
+def test_clirunner_generate_grouping_timezone(
+    odc_test_db, run_generate, empty_client
+) -> None:
     res: Result = run_generate("ga_ls9c_ard_3", grouping_time_zone="America/Chicago")
     assert "2021" in res.output
 
@@ -146,7 +148,7 @@ def test_clirunner_generate_grouping_timezone(odc_test_db, run_generate, empty_c
 
 
 # Unit tests
-def test_dataset_day_link(summary_store):
+def test_dataset_day_link(summary_store) -> None:
     ds = summary_store.index.datasets.get("6293ac37-7f1d-430e-8d7e-ffdc1bfd556c")
     t = datetime_from_metadata(ds)
     t = default_utc(t).astimezone(pytz.timezone("Australia/Darwin"))
@@ -160,7 +162,7 @@ def test_dataset_day_link(summary_store):
     assert t.day == 31
 
 
-def test_dataset_search_page_ls7e_time(client: FlaskClient):
+def test_dataset_search_page_ls7e_time(client: FlaskClient) -> None:
     html = get_html(client, "/products/usgs_ls7e_level1_1/datasets/2020/6/1")
     search_results = html.find(".search-result a")
     assert len(search_results) == 2

--- a/integration_tests/test_wagl_data.py
+++ b/integration_tests/test_wagl_data.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_s2_ard_summary(run_generate, summary_store: SummaryStore):
+def test_s2_ard_summary(run_generate, summary_store: SummaryStore) -> None:
     run_generate("s2a_ard_granule")
     expect_values(
         summary_store.get("s2a_ard_granule"),
@@ -42,7 +42,7 @@ def test_s2_ard_summary(run_generate, summary_store: SummaryStore):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_s2a_l1_summary(run_generate, summary_store: SummaryStore):
+def test_s2a_l1_summary(run_generate, summary_store: SummaryStore) -> None:
     run_generate("s2a_level1c_granule")
     expect_values(
         summary_store.get("s2a_level1c_granule"),
@@ -61,7 +61,7 @@ def test_s2a_l1_summary(run_generate, summary_store: SummaryStore):
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_product_audit(unpopulated_client: FlaskClient, run_generate):
+def test_product_audit(unpopulated_client: FlaskClient, run_generate) -> None:
     run_generate()
     client = unpopulated_client
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ enable_error_code = ["explicit-override"]
 ignore_missing_imports = true
 warn_redundant_casts = true
 warn_unused_ignores = true
-disallow_untyped_defs = true
+# FIXME: Long term goal to enable the next line.
+# disallow_untyped_defs = true
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
Disable the setting that makes MyPy error on all functions that are missing type signatures, and add some type signatures in various places.

This brings the number of errors down from 600+ to 194, so it's now down to a number that makes it possible to start fixing the remaining errors.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--670.org.readthedocs.build/en/670/

<!-- readthedocs-preview datacube-explorer end -->