### PR TITLE
docs/conf: remove hashbang

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # datacube_ows documentation build configuration file, created by
 # sphinx-quickstart on Tue Jul  9 22:26:36 2013.
 #


### PR DESCRIPTION
This file is never executed, so
remove the hashbang.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--672.org.readthedocs.build/en/672/

<!-- readthedocs-preview datacube-explorer end -->