### PR TITLE
pytest: output test runtimes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ warn_unused_ignores = true
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
+console_output_style = "times"
 testpaths = ["cubedash", "integration_tests"]
 norecursedirs = [".*", "build", "dist", ".git", "tmp*", ".jj"]
 filterwarnings = [


### PR DESCRIPTION
Enable the pytest 8.4 feature to display
test times.

Beyond finding the slow tests more easily,
this can also be used as an indication
of CI machines suffering from some kind
temporary hickup when failing.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--706.org.readthedocs.build/en/706/

<!-- readthedocs-preview datacube-explorer end -->