### PR TITLE
CI: pass token to CodeCov action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,4 +49,6 @@ jobs:
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           files: ./coverage.xml
+          disable_search: true
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This repository lags behind with
the CodeCov baseline for some reason,
and the other ODC repositories are
usually close. Paul has a memory
of having had the same problem
in some other repository and suggested
it might be the missing token.

Align the parameters with datacube-core
where CodeCov works as we want, so pass
in the token to the workflow and disable
the search for additional coverage files.
The disabled search shaves a couple of
seconds off the runtime of the action
itself and has nothing to do with the
lagging baseline.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--729.org.readthedocs.build/en/729/

<!-- readthedocs-preview datacube-explorer end -->