### PR TITLE
CI: remove sleep statements

### DIFF
--- a/.github/workflows/deployment_test.yaml
+++ b/.github/workflows/deployment_test.yaml
@@ -38,10 +38,6 @@ jobs:
           make build-prod
           make up-prod
 
-      - name: Sleep for 30 seconds
-        run: sleep 30s
-        shell: bash
-
       - name: Prepare explorer schema
         run: |
           make init-odc

--- a/.github/workflows/deployment_test.yaml
+++ b/.github/workflows/deployment_test.yaml
@@ -53,6 +53,7 @@ jobs:
           --connect-timeout 5 \
           --max-time 10 \
           --retry 5 \
+          --retry-all-errors \
           --retry-delay 0 \
           --retry-max-time 40 \
           "localhost:80/products" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Run tests
         run: |
           make up-d
-          sleep 10
           make create-test-db-docker
           make test-docker
           make docker-clean

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ up: ## Start server using Docker
 	docker compose up --quiet-pull
 
 up-d: ## Start server using Docker in background
-	docker compose up -d --quiet-pull
+	docker compose up -d --wait --quiet-pull
 
 build: ## Build the dev Docker image
 	docker compose build
@@ -81,6 +81,7 @@ build: ## Build the dev Docker image
 docker-clean: ## Get rid of the local docker env and DB
 	docker compose down
 
+# These rules pass --file to avoid loading docker-compose.override.yml.
 build-prod: ## Build the prod Docker image
 	docker compose \
 		--file docker-compose.yml \


### PR DESCRIPTION
I added a health check to
docker-compose.yaml at
the end of 2023, start
using that to decide if
the container is up instead
of sleeping for an arbitrary
number of seconds.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--731.org.readthedocs.build/en/731/

<!-- readthedocs-preview datacube-explorer end -->