### PR TITLE
CI: shorten job timeout

### DIFF
--- a/.github/workflows/deployment_test.yaml
+++ b/.github/workflows/deployment_test.yaml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   deployment-image-test:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   documentation-preview:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # v1.5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,7 @@ concurrency:
 
 jobs:
   docker:
+    timeout-minutes: 35
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop' || github.event_name == 'release'
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   cve-scanner:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   integration-tests:
+    timeout-minutes: 55
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This prevents us from having to
wait for 6 hours if someone
hangs the CI machines.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--733.org.readthedocs.build/en/733/

<!-- readthedocs-preview datacube-explorer end -->