### PR TITLE
CI: quote version number

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install Twine
         run: |


### PR DESCRIPTION
This will be interpreted as
3.1 without quotes.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--738.org.readthedocs.build/en/738/

<!-- readthedocs-preview datacube-explorer end -->