### PR TITLE
CI: stop cleaning tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,6 @@ jobs:
           make up-d
           make create-test-db-docker
           make test-docker
-          make docker-clean
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3


### PR DESCRIPTION
This makes the CI job take
longer for no good reason.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--740.org.readthedocs.build/en/740/

<!-- readthedocs-preview datacube-explorer end -->