### PR TITLE
Various type fixes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: ["3.10"]
         lintcommand:
           - "ruff check --output-format=github"
-          - "mypy --follow-imports=silent cubedash/_api.py"
+          - "mypy --follow-imports=silent cubedash/_[a-m]*.py"
     name: Linting
     steps:
       - name: checkout git

--- a/cubedash/_api.py
+++ b/cubedash/_api.py
@@ -1,7 +1,7 @@
-import logging
 from datetime import date, datetime
 
 import flask
+import structlog
 from dateutil import tz
 from flask import Blueprint, abort, request
 
@@ -11,7 +11,7 @@ from . import _model
 from ._utils import as_geojson, as_json
 from .summary import ItemSort
 
-_LOG = logging.getLogger(__name__)
+_LOG = structlog.stdlib.get_logger()
 bp = Blueprint("api", __name__, url_prefix="/api")
 
 

--- a/cubedash/_audit.py
+++ b/cubedash/_audit.py
@@ -39,7 +39,7 @@ def product_timings() -> Iterable[ProductTiming]:
         if not p:
             _LOG.info("product_no_summarised", product_name=product_name)
             continue
-        if not p.dataset_count or not p.time_earliest:
+        if not p.dataset_count or not p.time_earliest or not p.time_latest:
             yield ProductTiming(product_name, dataset_count=0)
             continue
         done += 1

--- a/cubedash/_audit.py
+++ b/cubedash/_audit.py
@@ -22,8 +22,8 @@ bp = Blueprint(
 class ProductTiming:
     name: str
     dataset_count: int
-    time_seconds: float = None
-    selection_date: datetime = None
+    time_seconds: float | None = None
+    selection_date: datetime | None = None
 
 
 def product_timings() -> Iterable[ProductTiming]:

--- a/cubedash/_audit.py
+++ b/cubedash/_audit.py
@@ -1,17 +1,17 @@
-import logging
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 import flask
+import structlog
 from datacube.model import Range
 from flask import Blueprint, Response, redirect, url_for
 
 from . import _model
 from . import _utils as utils
 
-_LOG = logging.getLogger(__name__)
+_LOG = structlog.stdlib.get_logger()
 bp = Blueprint(
     "audit",
     __name__,

--- a/cubedash/_dataset.py
+++ b/cubedash/_dataset.py
@@ -1,13 +1,13 @@
-import logging
 from uuid import UUID
 
 import flask
+import structlog
 from flask import Blueprint, abort, current_app, url_for
 
 from . import _model
 from . import _utils as utils
 
-_LOG = logging.getLogger(__name__)
+_LOG = structlog.stdlib.get_logger()
 bp = Blueprint(
     "dataset",
     __name__,

--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -3,7 +3,6 @@ Common global filters for templates.
 """
 
 import calendar
-import logging
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from urllib.parse import quote_plus
@@ -11,6 +10,7 @@ from urllib.parse import quote_plus
 import flask
 import orjson
 import pytz
+import structlog
 from datacube.index.fields import Field
 from datacube.model import Dataset, Product, Range
 from dateutil import tz
@@ -33,7 +33,7 @@ NUMERIC_STEP_SIZE = {
 
 CROSS_SYMBOL = Markup('<i class="fa fa-times" aria-label="x"></i>')
 
-_LOG = logging.getLogger(__name__)
+_LOG = structlog.stdlib.get_logger()
 bp = Blueprint("filters", __name__)
 
 

--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -3,7 +3,7 @@ Common global filters for templates.
 """
 
 import calendar
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from urllib.parse import quote_plus
 
@@ -244,7 +244,7 @@ def _product_license(product: Product):
 
 
 @bp.app_template_filter("searchable_fields")
-def _searchable_fields(product: Product):
+def _searchable_fields(product: Product) -> Iterable[tuple]:
     """Searchable field names for a product"""
 
     # No point searching fields that are fixed for this product
@@ -254,7 +254,7 @@ def _searchable_fields(product: Product):
     return sorted(
         (key, field)
         for key, field in product.metadata_type.dataset_fields.items()
-        if key != "product" and key not in skippable_product_keys and field.indexed
+        if key != "product" and key not in skippable_product_keys and field.indexed  # type: ignore[attr-defined]
     )
 
 

--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -249,12 +249,12 @@ def _searchable_fields(product: Product):
 
     # No point searching fields that are fixed for this product
     # (eg: platform is always Landsat 7 on ls7_level1_scene)
-    skippable_product_keys = [k for k, v in product.fields.items() if v is not None]
+    skippable_product_keys = {k for k, v in product.fields.items() if v is not None}
 
     return sorted(
         (key, field)
         for key, field in product.metadata_type.dataset_fields.items()
-        if key not in skippable_product_keys and key != "product" and field.indexed
+        if key != "product" and key not in skippable_product_keys and field.indexed
     )
 
 

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -177,7 +177,7 @@ def create_app(test_config=None):
     return app
 
 
-_LOG = structlog.get_logger()
+_LOG = structlog.stdlib.get_logger()
 
 
 @cache.memoize(timeout=60)

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -194,7 +194,7 @@ def get_time_summary_all_products() -> dict[tuple[str, int, int], int]:
     return STORE.get_all_dataset_counts()
 
 
-def get_product_summary(product_name: str) -> ProductSummary:
+def get_product_summary(product_name: str) -> ProductSummary | None:
     return STORE.get_product_summary(product_name)
 
 
@@ -300,7 +300,7 @@ def _get_footprint(period: TimePeriodOverview) -> MultiPolygon | None:
     _LOG.info(
         "overview.footprint_size_diff",
         from_len=len(period.footprint_geometry.wkt),
-        to_len=len(footprint_wgs84.wkt),
+        to_len=0 if footprint_wgs84 is None else len(footprint_wgs84.wkt),
     )
     _LOG.debug("overview.footprint_proj", time_sec=time.time() - start)
 
@@ -330,9 +330,7 @@ def _get_regions_geojson(
         "features": [
             {
                 "type": "Feature",
-                "geometry": region_info.region(
-                    region_code
-                ).footprint_wgs84.__geo_interface__,
+                "geometry": region.footprint_wgs84.__geo_interface__,  # type: ignore[attr-defined]
                 "properties": {
                     "region_code": region_code,
                     "label": region_info.region_label(region_code),
@@ -340,6 +338,7 @@ def _get_regions_geojson(
                 },
             }
             for region_code in (region_counts or [])
-            if region_info.region(region_code) is not None
+            if (region := region_info.region(region_code)) is not None
+            and region.footprint_wgs84 is not None
         ],
     }

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -18,9 +18,6 @@ from flask_themer import Themer
 from sentry_sdk.integrations.flask import FlaskIntegration
 from shapely.geometry import MultiPolygon
 from werkzeug.exceptions import HTTPException
-
-# Fix up URL Scheme handling using this
-# from https://stackoverflow.com/questions/23347387/x-forwarded-proto-and-flask
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from cubedash import _monitoring
@@ -78,8 +75,10 @@ STORE: SummaryStore = SummaryStore.create(
 def create_app(test_config=None):
     app = flask.Flask(NAME)
 
-    # Also part of the fix from ^
-    app.wsgi_app = ProxyFix(app.wsgi_app)
+    # See:
+    # https://stackoverflow.com/questions/23347387/x-forwarded-proto-and-flask and
+    # https://flask.palletsprojects.com/en/stable/quickstart/#hooking-in-wsgi-middleware
+    app.wsgi_app = ProxyFix(app.wsgi_app)  # type: ignore[method-assign]
 
     # Optional environment settings file or variable
     if test_config is None:

--- a/cubedash/_monitoring.py
+++ b/cubedash/_monitoring.py
@@ -89,6 +89,6 @@ def init_app_monitoring(app: flask.Flask) -> None:
             return decorator
 
         # Print call time for all db layer calls.
-        decorate_all_methods(_model.STORE.e_index.db_api, with_timings)
+        decorate_all_methods(_model.STORE.e_index.db_api, with_timings)  # type: ignore[attr-defined]
 
     print_datacube_query_times()

--- a/cubedash/_monitoring.py
+++ b/cubedash/_monitoring.py
@@ -1,15 +1,15 @@
 import functools
 import inspect
-import logging
 import time
 
 import flask
+import structlog
 from sqlalchemy import event
 
 from . import _model
 
 _INITIALISED = False
-_LOG = logging.getLogger(__name__)
+_LOG = structlog.stdlib.get_logger()
 
 
 # Add server timings to http headers.

--- a/cubedash/_platform.py
+++ b/cubedash/_platform.py
@@ -1,8 +1,7 @@
-import logging
-
+import structlog
 from flask import Blueprint, redirect, url_for
 
-_LOG = logging.getLogger(__name__)
+_LOG = structlog.stdlib.get_logger()
 bp = Blueprint("platform", __name__, url_prefix="/platform")
 
 

--- a/cubedash/_product.py
+++ b/cubedash/_product.py
@@ -1,12 +1,12 @@
-import logging
 from datetime import timedelta
 
+import structlog
 from flask import Blueprint, Response, abort, redirect, url_for
 
 from cubedash import _model, _utils
 from cubedash import _utils as utils
 
-_LOG = logging.getLogger(__name__)
+_LOG = structlog.stdlib.get_logger()
 bp = Blueprint("product", __name__)
 
 

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import uuid
 from collections.abc import Callable, Sequence
 from datetime import datetime, timedelta
@@ -9,6 +8,7 @@ from typing import Any, Union
 
 import flask
 import pystac
+import structlog
 from datacube.model import Dataset, Range
 from datacube.utils import DocReader, parse_time
 from dateutil.tz import tz
@@ -30,7 +30,7 @@ from cubedash.summary._stores import CollectionItem, DatasetItem
 from . import _model, _utils
 from .summary import ItemSort
 
-_LOG = logging.getLogger(__name__)
+_LOG = structlog.stdlib.get_logger()
 bp = flask.Blueprint("stac", __name__, url_prefix="/stac")
 
 DEFAULT_PAGE_SIZE_LIMIT = 1000

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -61,7 +61,7 @@ DEFAULT_CRS_INFERENCES = [
 ]
 MATCH_CUTOFF = 0.38
 
-_LOG = structlog.get_logger()
+_LOG = structlog.stdlib.get_logger()
 
 
 def infer_crs(crs_str: str) -> str | None:

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -160,7 +160,7 @@ def get_dataset_file_offsets(dataset: Dataset) -> dict[str, str]:
     return uri_list
 
 
-def as_resolved_remote_url(location: str, offset: str) -> str:
+def as_resolved_remote_url(location: str | None, offset: str) -> str:
     """
     Convert a dataset location and file offset to a full remote URL.
     """

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -57,7 +57,7 @@ import collections
 import multiprocessing
 import re
 import sys
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import partial
@@ -167,12 +167,12 @@ def run_generation(
         f"{style(str(settings.env_name), bold=True)}",
     )
 
-    counts = collections.Counter()
+    counts: collections.Counter = collections.Counter()
 
     user_message("Generating product summaries...")
 
     def on_complete(
-        product_name: str, result: GenerateResult, summary: TimePeriodOverview
+        product_name: str, result: GenerateResult, summary: TimePeriodOverview | None
     ) -> None:
         counts[result] += 1
         result_color = {
@@ -196,7 +196,7 @@ def run_generation(
             on_complete(*generate_report((p.name, settings, grouping_time_zone)))
     else:
         with multiprocessing.Pool(workers) as pool:
-            summary: TimePeriodOverview
+            summary: TimePeriodOverview | None
             for product_name, result, summary in pool.imap_unordered(
                 generate_report,
                 ((p.name, settings, grouping_time_zone) for p in products),
@@ -225,7 +225,7 @@ def run_generation(
     return creation_count, failure_count
 
 
-def _load_products(store: SummaryStore, product_names) -> list[Product]:
+def _load_products(store: SummaryStore, product_names) -> Generator[Product]:
     for product_name in product_names:
         try:
             yield store.get_product(product_name)

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -509,7 +509,7 @@ _TIME_PERIOD_FORMAT = re.compile(
 )
 
 
-def parse_timedelta(value: str) -> timedelta | None:
+def parse_timedelta(value: str) -> timedelta:
     """
     Parse a string such as "30h40m" into a timedelta.
 
@@ -533,6 +533,8 @@ def parse_timedelta(value: str) -> timedelta | None:
     ValueError: Invalid time period. Expected something like "24h" or "2h30m".
     """
     parts = _TIME_PERIOD_FORMAT.match(value)
+    if parts is None:
+        raise ValueError(f"Invalid time period: {value}")
     params = {}
     for name, param in parts.groupdict().items():
         if param:

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -499,7 +499,7 @@ def cli(
     if updated > 0 and refresh_stats:
         user_message("Refreshing statistics...", nl=False)
         store.refresh_stats(concurrently=force_concurrently)
-        user_message("done", color="green")
+        user_message("done", fg="green")
         _LOG.info("stats.refresh")
     sys.exit(failures)
 

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -84,7 +84,7 @@ from cubedash.summary._stores import DEFAULT_EPSG
 from cubedash.summary._summarise import DEFAULT_TIMEZONE
 
 # Machine (json) logging.
-_LOG = structlog.get_logger()
+_LOG = structlog.stdlib.get_logger()
 
 # Interactive messages for a human go to stderr.
 user_message = partial(click_secho, err=True)

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -96,7 +96,7 @@ class GenerateSettings:
     force_refresh: bool
     recreate_dataset_extents: bool
     reset_incremental_position: bool
-    minimum_change_scan_window: timedelta = None
+    minimum_change_scan_window: timedelta | None = None
 
 
 # pylint: disable=broad-except

--- a/cubedash/logs.py
+++ b/cubedash/logs.py
@@ -1,9 +1,9 @@
 import datetime
-import io
 import pathlib
 import sys
 import uuid
 from functools import partial
+from typing import BinaryIO
 
 import structlog
 from orjson import orjson
@@ -12,7 +12,7 @@ from typing_extensions import override
 
 
 def init_logging(
-    output_file: io.BytesIO | None = None,
+    output_file: BinaryIO | None = None,
     verbosity: int = 0,
     cache_logger_on_first_use: bool = True,
     write_as_json: bool | None = None,

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -37,7 +37,7 @@ from cubedash._utils import (
 )
 from cubedash.index import ExplorerIndex
 
-_LOG = structlog.get_logger()
+_LOG = structlog.stdlib.get_logger()
 
 _WRS_PATH_ROW = [
     Path(__file__).parent.parent / "data" / "WRS2_descending" / "WRS2_descending.shp",

--- a/cubedash/summary/_model.py
+++ b/cubedash/summary/_model.py
@@ -13,7 +13,7 @@ from shapely.geometry import MultiPolygon
 from shapely.geometry.base import BaseGeometry
 from typing_extensions import override
 
-_LOG = structlog.get_logger()
+_LOG = structlog.stdlib.get_logger()
 
 
 @dataclass

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -9,7 +9,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.engine import Connection
 
-_LOG = structlog.get_logger()
+_LOG = structlog.stdlib.get_logger()
 
 CUBEDASH_SCHEMA = "cubedash"
 METADATA = MetaData(schema=CUBEDASH_SCHEMA)

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -75,7 +75,7 @@ DEFAULT_TTL = 90
 
 _DEFAULT_REFRESH_OLDER_THAN = timedelta(hours=23)
 
-_LOG = structlog.get_logger()
+_LOG = structlog.stdlib.get_logger()
 
 # The default grouping epsg code to use on init of a new Explorer schema.
 #

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -12,7 +12,7 @@ from geoalchemy2 import shape as geo_shape
 from cubedash import _utils
 from cubedash.summary import TimePeriodOverview
 
-_LOG = structlog.get_logger()
+_LOG = structlog.stdlib.get_logger()
 
 
 _NEWER_SQLALCHEMY = not sqlalchemy.__version__.startswith("1.3")

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -21,7 +21,7 @@ from cubedash._filters import sizeof_fmt
 from cubedash.logs import init_logging
 from cubedash.summary import SummaryStore
 
-_LOG = structlog.get_logger()
+_LOG = structlog.stdlib.get_logger()
 
 
 def _get_store(cfg_env: ODCEnvironment, variant: str, log=_LOG) -> SummaryStore:


### PR DESCRIPTION
Fix a crash when calling the stdlib's `_LOG.info()` instead of structlog, and switch the rest of the code to use the typed structlog import everywhere as well.

Fix various unrelated type signatures and type errors found along the way, and enable type checking in the CI for `_[a-m]*.py`.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--745.org.readthedocs.build/en/745/

<!-- readthedocs-preview datacube-explorer end -->