### PR TITLE
CI: cache docker layers

### DIFF
--- a/.github/workflows/deployment_test.yaml
+++ b/.github/workflows/deployment_test.yaml
@@ -14,7 +14,7 @@ on: # yamllint disable-line rule:truthy
       - '**'
 
 env:
-  IMAGE_NAME: opendatacube/explorer
+  DOCKER_IMAGE: ghcr.io/opendatacube/explorer:tests
 
 permissions: {}
 
@@ -34,13 +34,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
       - name: Build deployment Docker
-        run: |
-          make build-prod
-          make up-prod
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          file: Dockerfile
+          context: .
+          tags: ${{ env.DOCKER_IMAGE }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Prepare explorer schema
         run: |
+          make up-prod
           make init-odc
           make schema
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,12 +37,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get unstable git tag
-        run: >
-          echo "UNSTABLE_TAG=$(git describe --tags)" >> $GITHUB_ENV
-
-      - name: Log the unstable tag
-        run: echo $UNSTABLE_TAG
+      - name: Get and log unstable git tag
+        run: |
+          set -ex
+          UNSTABLE_TAG=$(git describe --tags)
+          echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
 
       - name: Build and Push unstable + latest Docker image tag
         if: github.event_name != 'release'
@@ -55,13 +54,12 @@ jobs:
           build_extra_args: "--build-arg=ENVIRONMENT=deployment"
 
       # This section is for releases
-      - name: Get tag for this build if it exists
+      - name: Get and log tag for this build if it exists
         if: github.event_name == 'release'
-        run: >
-          echo "RELEASE=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
-
-      - name: Log the tag
-        run: echo $RELEASE
+        run: |
+          set -ex
+          RELEASE=$(git describe --abbrev=0 --tags)
+          echo "RELEASE=$RELEASE" >> $GITHUB_ENV
 
       - name: Build and Push release if we have a tag
         uses: whoan/docker-build-with-cache-action@d8d3ad518e7ac382b880720d0751815e656fe032 # v8.1.0

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
 env:
-  IMAGE_NAME: opendatacube/explorer
+  IMAGE_NAME: ghcr.io/opendatacube/explorer
 
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.
@@ -17,6 +17,7 @@ jobs:
   cve-scanner:
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    if: github.event_name != 'release'
     permissions:
       security-events: write
     steps:
@@ -24,26 +25,27 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          branch: develop
 
-      - name: Get unstable git tag
-        run: >
-          echo "UNSTABLE_TAG=$(git describe --tags)" >> $GITHUB_ENV
+      - name: Get and log unstable git tag
+        run: |
+          set -ex
+          UNSTABLE_TAG=$(git describe --tags)
+          echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
 
-      - name: Log the unstable tag
-        run: echo $UNSTABLE_TAG
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Build unstable + latest Docker image tag
-        if: github.event_name != 'release'
-        uses: whoan/docker-build-with-cache-action@d8d3ad518e7ac382b880720d0751815e656fe032 # v8.1.0
+      - name: Build Docker
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
-          image_name: ${{ env.IMAGE_NAME }}
-          image_tag: ${{ env.UNSTABLE_TAG }},latest
-          build_extra_args: "--build-arg=ENVIRONMENT=deployment"
-          push_image_and_stages: false
+          file: Dockerfile
+          context: .
+          tags: ${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run vulnerability scanner
-        if: github.event_name != 'release'
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # master
         with:
           image-ref: "${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
       - '**'
 
 env:
-  IMAGE_NAME: opendatacube/explorer
+  DOCKER_IMAGE: ghcr.io/opendatacube/explorer:tests
 
 permissions: {}
 
@@ -34,9 +34,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
       - name: Build Docker
-        run: |
-          make build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          file: Dockerfile
+          context: .
+          build-args: |
+            ENVIRONMENT=test
+          tags: ${{ env.DOCKER_IMAGE }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run tests
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         ENVIRONMENT: deployment
+    image: ghcr.io/opendatacube/explorer:tests
     ports:
       - "80:8080"
     environment:


### PR DESCRIPTION
Switch to the same image build setup as used by datacube-core to speed up image building.

Leave the Docker workflow as-is for now, it looks like it should be simplified before being changed.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--749.org.readthedocs.build/en/749/

<!-- readthedocs-preview datacube-explorer end -->