### PR TITLE
tests: fix types and assert more 

### DIFF
--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -72,7 +72,7 @@ STORE: SummaryStore = SummaryStore.create(
 )
 
 
-def create_app(test_config=None):
+def create_app(test_config=None) -> flask.Flask:
     app = flask.Flask(NAME)
 
     # See:

--- a/integration_tests/asserts.py
+++ b/integration_tests/asserts.py
@@ -13,11 +13,11 @@ from datacube.model import Range
 from datacube.utils import InvalidDocException, validate_document
 from dateutil.tz import tzutc
 from deepdiff import DeepDiff
-from flask import Response
 from flask.testing import FlaskClient
 from selectolax.lexbor import LexborHTMLParser, LexborNode
 from shapely.geometry import shape
 from shapely.geometry.base import BaseGeometry
+from werkzeug.test import TestResponse
 
 from cubedash._utils import default_utc
 from cubedash.summary import TimePeriodOverview
@@ -86,7 +86,7 @@ def get_geojson(client: FlaskClient, url: str) -> dict:
 
 def get_text_response(
     client: FlaskClient, url: str, expect_status_code=200
-) -> tuple[str, Response]:
+) -> tuple[str, TestResponse]:
     response = client.get(url, follow_redirects=True)
     assert response.status_code == expect_status_code, (
         f"Expected status {expect_status_code} not {response.status_code}."
@@ -203,7 +203,7 @@ def expect_values(
     timeline_count: int,
     crses: set[str],
     size_bytes: int | None,
-    region_dataset_counts: dict = None,
+    region_dataset_counts: dict | None = None,
 ):
     __tracebackhide__ = True
 
@@ -317,7 +317,7 @@ class DebugContext:
     def __exit__(
         self,
         exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
+        exc_val: AssertionError,
         exc_tb: TracebackType | None,
     ) -> None:
         if exc_type is None:

--- a/integration_tests/asserts.py
+++ b/integration_tests/asserts.py
@@ -22,7 +22,7 @@ from shapely.geometry.base import BaseGeometry
 from cubedash._utils import default_utc
 from cubedash.summary import TimePeriodOverview
 
-# GeoJSON schema from http://geojson.org/schema/FeatureCollection.json
+# GeoJSON schema from https://geojson.org/schema/FeatureCollection.json
 
 
 _FEATURE_COLLECTION_SCHEMA_PATH = (

--- a/integration_tests/asserts.py
+++ b/integration_tests/asserts.py
@@ -167,9 +167,9 @@ def check_area(area_pattern, html: LexborNode | LexborHTMLParser) -> None:
 
 def check_last_processed(html: LexborNode | LexborHTMLParser, time: str) -> None:
     __tracebackhide__ = True
-    assert (
-        html.css_first(".last-processed time").attributes["datetime"].startswith(time)
-    )
+    when = html.css_first(".last-processed time").attributes["datetime"]
+    assert when is not None
+    assert when.startswith(time)
 
 
 def check_dataset_count(html: LexborNode | LexborHTMLParser, count: int) -> None:
@@ -271,6 +271,7 @@ def expect_values(
                 assert region_dataset_counts == s.region_dataset_counts
             was_regions_error = False
     except AssertionError:
+        assert s.newest_dataset_creation_time is not None
         print(
             f"""Got:
         dataset_count {s.dataset_count}

--- a/integration_tests/asserts.py
+++ b/integration_tests/asserts.py
@@ -87,7 +87,7 @@ def get_geojson(client: FlaskClient, url: str) -> dict:
 def get_text_response(
     client: FlaskClient, url: str, expect_status_code=200
 ) -> tuple[str, Response]:
-    response: Response = client.get(url, follow_redirects=True)
+    response = client.get(url, follow_redirects=True)
     assert response.status_code == expect_status_code, (
         f"Expected status {expect_status_code} not {response.status_code}."
         f"\nGot:\n{indent(response.data.decode('utf-8'), ' ' * 6)}"
@@ -96,7 +96,7 @@ def get_text_response(
 
 
 def get_json(client: FlaskClient, url: str, expect_status_code=200) -> dict:
-    rv: Response = client.get(url, follow_redirects=True)
+    rv = client.get(url, follow_redirects=True)
     try:
         assert rv.status_code == expect_status_code, (
             f"Expected status {expect_status_code} not {rv.status_code}."
@@ -152,7 +152,7 @@ def assert_text_contains(
 
 
 def get_html(client: FlaskClient, url: str) -> LexborHTMLParser:
-    response: Response = client.get(url, follow_redirects=True)
+    response = client.get(url, follow_redirects=True)
     assert response.status_code == 200, response.data.decode("utf-8")
     html = LexborHTMLParser(response.data.decode("utf-8"))
     return html

--- a/integration_tests/schemas/update.sh
+++ b/integration_tests/schemas/update.sh
@@ -12,9 +12,9 @@ function get() {
     wget -r "$1"
 }
 
-get 'http://geojson.org/schema/Geometry.json'
-get 'http://geojson.org/schema/FeatureCollection.json'
-get 'http://geojson.org/schema/Feature.json'
+get 'https://geojson.org/schema/Geometry.json'
+get 'https://geojson.org/schema/FeatureCollection.json'
+get 'https://geojson.org/schema/Feature.json'
 
 
 # strip the 'v' from the start if there.

--- a/integration_tests/test_configurable_page_elements.py
+++ b/integration_tests/test_configurable_page_elements.py
@@ -44,7 +44,7 @@ def app_configured_client(client: FlaskClient):
 
 
 @pytest.fixture()
-def total_indexed_products_count(summary_store: SummaryStore):
+def total_indexed_products_count(summary_store: SummaryStore) -> int:
     return len(list(summary_store.index.products.get_all()))
 
 

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -11,7 +11,6 @@ from datacube.index import Index
 from datacube.utils import parse_time
 from dateutil import tz
 from dateutil.tz import tzutc
-from flask import Response
 from flask.testing import FlaskClient
 from geoalchemy2.shape import to_shape
 from ruamel.yaml import YAML
@@ -165,7 +164,7 @@ def test_location_sampling(eo3_index: Index) -> None:
 
 
 def test_eo3_doc_download(eo3_index: Index, client: FlaskClient) -> None:
-    response: Response = client.get(
+    response = client.get(
         "/dataset/9989545f-906d-5090-a38e-cdbfbfc1afca.odc-metadata.yaml"
     )
     text = response.data.decode("utf-8")

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -9,7 +9,6 @@ from io import StringIO
 import pytest
 from click.testing import Result
 from dateutil import tz
-from flask import Response
 from flask.testing import FlaskClient
 from ruamel.yaml import YAML, YAMLError
 
@@ -108,7 +107,7 @@ def test_prometheus(sentry_client: FlaskClient) -> None:
 
 
 def test_default_redirect(client: FlaskClient) -> None:
-    rv: Response = client.get("/", follow_redirects=False)
+    rv = client.get("/", follow_redirects=False)
     # The products page is the default.
     assert rv.location.endswith("/products")
 
@@ -304,7 +303,7 @@ def test_view_dataset(client: FlaskClient) -> None:
     assert not html.css_first(".key-creation_dt")
 
     # No dataset found: should return 404, not a server error.
-    rv: Response = client.get(
+    rv = client.get(
         "/dataset/de071517-af92-4dd7-bf91-12b4e7c9a435", follow_redirects=True
     )
 
@@ -449,7 +448,7 @@ def test_api_returns_high_tide_comp_regions(client: FlaskClient) -> None:
     It should be empty (no regions supported) rather than throw an exception.
     """
 
-    rv: Response = client.get("/api/regions/high_tide_comp_20p")
+    rv = client.get("/api/regions/high_tide_comp_20p")
     assert rv.status_code == 404, (
         "High tide comp does not support regions: it should return not-exist code."
     )
@@ -492,7 +491,7 @@ def test_legacy_region_redirect(client: FlaskClient) -> None:
 
 def assert_redirects_to(client: FlaskClient, url: str, redirects_to_url: str) -> None:
     __tracebackhide__ = True
-    response: Response = client.get(url, follow_redirects=False)
+    response = client.get(url, follow_redirects=False)
     assert response.status_code == 302
     assert response.location.endswith(redirects_to_url), (
         f"Expected redirect to end with:\n"
@@ -756,7 +755,7 @@ def test_general_dataset_redirect(client: FlaskClient) -> None:
     When someone queries a dataset UUID, they should be redirected
     to the real URL for the collection.
     """
-    rv: Response = client.get(
+    rv = client.get(
         "/dataset/c867d666-bf01-48f2-8259-48f756f86858", follow_redirects=False
     )
     # It should be a redirect
@@ -768,14 +767,14 @@ def test_general_dataset_redirect(client: FlaskClient) -> None:
 
 
 def test_missing_dataset(client: FlaskClient) -> None:
-    rv: Response = client.get(
+    rv = client.get(
         "/products/ga_ls8c_ard_3/datasets/f22a33f4-42f2-4aa5-9b20-cee4ca4a875c",
         follow_redirects=False,
     )
     assert rv.status_code == 404
 
     # But a real dataset definitely works:
-    rv: Response = client.get(
+    rv = client.get(
         "/products/ga_ls8c_ard_3/datasets/c867d666-bf01-48f2-8259-48f756f86858",
         follow_redirects=False,
     )
@@ -786,9 +785,7 @@ def test_invalid_product_returns_not_found(client: FlaskClient) -> None:
     """
     An invalid product should be "not found". No server errors.
     """
-    rv: Response = client.get(
-        "/products/fake_test_product/2017", follow_redirects=False
-    )
+    rv = client.get("/products/fake_test_product/2017", follow_redirects=False)
     assert rv.status_code == 404
 
 

--- a/integration_tests/test_pages_render.py
+++ b/integration_tests/test_pages_render.py
@@ -2,7 +2,6 @@ from textwrap import indent
 
 import pytest
 from datacube import Datacube
-from flask import Response
 from flask.testing import FlaskClient
 from sqlalchemy import text
 
@@ -49,7 +48,7 @@ def assert_all_urls_render(all_urls: list[str], client: FlaskClient):
 
     for url in all_urls:
         try:
-            response: Response = client.get(url, follow_redirects=True)
+            response = client.get(url, follow_redirects=True)
         except Exception as e:
             raise AssertionError(f"Error rendering url f{url}.") from e
 

--- a/integration_tests/test_region_tiles.py
+++ b/integration_tests/test_region_tiles.py
@@ -3,7 +3,6 @@ Tests that indexes DEA C3 Summary products region tiles
 """
 
 import pytest
-from flask import Response
 from flask.testing import FlaskClient
 
 from integration_tests.asserts import check_dataset_count, get_html
@@ -96,7 +95,7 @@ def test_archived_dataset_is_excluded(client, run_generate, odc_test_db) -> None
         result = run_generate("ga_ls_wo_fq_nov_mar_3")
         print(result)
 
-        rv: Response = client.get("product/ga_ls_wo_fq_nov_mar_3/regions/x25y41")
+        rv = client.get("product/ga_ls_wo_fq_nov_mar_3/regions/x25y41")
         assert rv.status_code == 404, rv.data
 
     finally:

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -22,6 +22,7 @@ from flask import Response
 from flask.testing import FlaskClient
 from jsonschema import SchemaError
 from referencing import Registry, Resource
+from referencing.exceptions import NoSuchResource
 from shapely.geometry import shape as shapely_shape
 from shapely.validation import explain_validity
 
@@ -118,7 +119,7 @@ def read_document(path: Path) -> dict:
     """
     ds = list(read_documents(path))
     if len(ds) != 1:
-        raise ValueError(f"Expected only one document to be in path {path}")
+        raise NoSuchResource(f"Expected only one document to be in path {path}")
 
     _, doc = ds[0]
     return doc
@@ -131,7 +132,7 @@ def _web_reference(ref: str):
     eg http://geojson.org/schemas/Features.json'
     """
     if not is_url(ref):
-        raise ValueError(f"Expected URL? Got {ref!r}")
+        raise NoSuchResource(f"Expected URL? Got {ref!r}")
     (scheme, netloc, offset, params, query, fragment) = urllib.parse.urlparse(ref)
     # We used `wget -r` to download the remote schemas locally.
     # It puts into hostname/path folders by default. Eg. 'geojson.org/schema/Feature.json'
@@ -141,9 +142,9 @@ def _web_reference(ref: str):
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_bytes(urlopen(ref).read())
         else:
-            raise ValueError(
+            raise NoSuchResource(
                 f"No local copy exists of schema {ref!r}.\n"
-                f"\tPerhaps we need to add it to ./update.sh in the tests folder?\n"
+                "\tPerhaps we need to add it to ./update.sh in the tests folder?\n"
                 f"\t(looked in {path})"
             )
     return read_document(path)
@@ -166,12 +167,14 @@ def _local_reference(schema_location: Path, ref):
             )
         [presumed_schema] = similar_schemas
         return read_document(presumed_schema)
-    raise ValueError(f"Schema reference not found: {ref!r} (within {schema_location})")
+    raise NoSuchResource(
+        f"Schema reference not found: {ref!r} (within {schema_location})"
+    )
 
 
 def load_validator(schema_location: Path) -> jsonschema.Draft7Validator:
     if not schema_location.exists():
-        raise ValueError(f"No jsonschema file found at {schema_location}")
+        raise NoSuchResource(f"No jsonschema file found at {schema_location}")
 
     with schema_location.open("r") as s:
         try:

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -954,7 +954,7 @@ def test_stac_search_limits(stac_client: FlaskClient) -> None:
             "&datetime=2017-04-16T01:12:16/2017-05-10T00:24:21"
         ),
     )
-    assert len(geojson.get("features")) == OUR_PAGE_SIZE
+    assert len(geojson.get("features", [])) == OUR_PAGE_SIZE
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
@@ -985,14 +985,14 @@ def test_next_link(stac_client: FlaskClient) -> None:
         stac_client,
         ("/stac/search?collections=ga_ls8c_ard_3,ls7_nbart_albers"),
     )
-    assert geojson.get("numberMatched") > len(geojson.get("features"))
+    assert geojson.get("numberMatched", 0) > len(geojson.get("features", []))
 
     next_link = _get_next_href(geojson)
     assert next_link is not None
     next_link = next_link.replace("http://localhost", "")
 
     next_page = get_items(stac_client, next_link)
-    assert next_page.get("numberMatched") == geojson.get("numberMatched")
+    assert next_page.get("numberMatched", -10) == geojson.get("numberMatched", -11)
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
@@ -1005,7 +1005,7 @@ def test_stac_search_by_ids(stac_client: FlaskClient) -> None:
         stac_client,
         "/stac/search?&collection=ls7_nbart_albers&ids=",
     )
-    assert len(geojson.get("features")) == 0
+    assert len(geojson.get("features", ["bad_element"])) == 0
 
     # Can request one dataset
     geojson = get_items(
@@ -1045,7 +1045,7 @@ def test_stac_search_by_ids(stac_client: FlaskClient) -> None:
         stac_client,
         "/stac/search?&ids=7afd04ad-6080-4ee8-a280-f64853b399ca",
     )
-    assert len(geojson.get("features")) == 0
+    assert len(geojson.get("features", ["bad_element"])) == 0
 
     # Old JSON-like syntax should be supported for now.
     # (Sat-api and the old code used this?)
@@ -1107,7 +1107,7 @@ def test_stac_search_by_intersects(stac_client: FlaskClient) -> None:
     assert rv.status_code == 200, f"Error response: {rv.data}"
     doc = rv.json
 
-    features = doc.get("features")
+    features = doc.get("features", [])
 
     # We only returned the feature of that region code?
     assert len(features) == 1
@@ -1146,7 +1146,7 @@ def test_stac_search_by_intersects_paging(stac_client: FlaskClient) -> None:
     doc = rv.json
 
     # We got a whole page of features.
-    assert len(doc.get("features")) == OUR_PAGE_SIZE
+    assert len(doc.get("features", [])) == OUR_PAGE_SIZE
 
     # And a POST link to the next page.
     [next_link] = [link for link in doc.get("links", []) if link["rel"] == "next"]
@@ -1172,7 +1172,7 @@ def test_stac_search_collections(stac_client: FlaskClient) -> None:
         stac_client,
         ("/stac/search?&collections=ls7_nbart_scene&limit=20"),
     )
-    assert len(geojson.get("features")) == 4
+    assert len(geojson.get("features", [])) == 4
 
     # Get all the datasets for two collections
     geojson = get_items(
@@ -1180,7 +1180,7 @@ def test_stac_search_collections(stac_client: FlaskClient) -> None:
         ("/stac/search?&collections=ls7_nbart_scene,ls7_nbar_scene&limit=20"),
     )
     # Four datasets each.
-    assert len(geojson.get("features")) == 8
+    assert len(geojson.get("features", ["bad_element"])) == 8
     returned_feature_ids = sorted(f["id"] for f in geojson["features"])
     assert returned_feature_ids == [
         "0c5b625e-5432-4911-9f7d-f6b894e27f3c",
@@ -1199,7 +1199,7 @@ def test_stac_search_collections(stac_client: FlaskClient) -> None:
         stac_client,
         ("/stac/search?&collections=&limit=20"),
     )
-    assert len(geojson.get("features")) > 0
+    assert len(geojson.get("features", [])) > 0
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
@@ -1213,7 +1213,7 @@ def test_stac_search_bounds(stac_client: FlaskClient) -> None:
             "&datetime=2017-04-16T01:12:16/2017-05-10T00:24:21"
         ),
     )
-    assert len(geojson.get("features")) == 0
+    assert len(geojson.get("features", [])) == 0
 
     # Search a whole-day for a scene
     geojson = get_items(
@@ -1226,7 +1226,7 @@ def test_stac_search_bounds(stac_client: FlaskClient) -> None:
             "&datetime=2017-04-20"
         ),
     )
-    assert len(geojson.get("features")) == 1
+    assert len(geojson.get("features", [])) == 1
 
     # Search a whole-day on an empty day.
     geojson = get_items(
@@ -1238,7 +1238,7 @@ def test_stac_search_bounds(stac_client: FlaskClient) -> None:
             "&datetime=2017-04-22"
         ),
     )
-    assert len(geojson.get("features")) == 0
+    assert len(geojson.get("features", ["bad_element"])) == 0
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
@@ -1259,8 +1259,8 @@ def test_stac_search_by_post(stac_client: FlaskClient) -> None:
     )
     assert rv.status_code == 200
     doc = rv.json
-    assert len(doc.get("features")) == OUR_PAGE_SIZE
-    # We requested the full dataset, so band assets etc should be included.
+    assert len(doc.get("features", [])) == OUR_PAGE_SIZE
+    # We requested the full dataset, so band assets etc. should be included.
     assert "water" in doc["features"][0]["assets"]
     assert doc["features"][0]["assets"]["water"].get("href")
 

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -22,6 +22,7 @@ from flask.testing import FlaskClient
 from jsonschema import SchemaError
 from referencing import Registry, Resource
 from referencing.exceptions import NoSuchResource
+from referencing.typing import URI
 from shapely.geometry import shape as shapely_shape
 from shapely.validation import explain_validity
 
@@ -192,13 +193,16 @@ def load_schema_doc(schema: dict, location: str | Path) -> jsonschema.Draft7Vali
     except SchemaError as e:
         raise RuntimeError(f"Invalid schema {location}") from e
 
-    def retrieve(uri: str):
+    def retrieve(uri: URI) -> Resource:
         parsed = urlsplit(uri)
         if parsed.scheme == "https" or parsed.scheme == "http":
             return Resource.from_contents(_web_reference(uri))
-        return Resource.from_contents(_local_reference(location, uri))
+        return Resource.from_contents(_local_reference(Path(location), uri))
 
-    return jsonschema.Draft7Validator(schema, registry=Registry(retrieve=retrieve))
+    return jsonschema.Draft7Validator(
+        schema,
+        registry=Registry(retrieve=retrieve),  # type: ignore[call-arg]
+    )
 
 
 # Run `./update.sh` in the schema dir to check for newer versions of these.
@@ -266,7 +270,7 @@ def _get_next_href(geojson: dict) -> str | None:
 
 
 def _iter_items_across_pages(
-    client: FlaskClient, url: str
+    client: FlaskClient, url: str | None
 ) -> Generator[dict, None, None]:
     """
     Keep loading "next" pages and yield every Stac Item in order
@@ -341,7 +345,7 @@ def validate_items(
     seen_ids = set()
     last_item = None
     i = 0
-    product_counts = Counter()
+    product_counts: Counter = Counter()
     for item in items:
         id_ = item["id"]
         with DebugContext(f"Invalid item {i}, id {str(id_)!r}"):
@@ -385,7 +389,7 @@ def validate_items(
 
 
 @pytest.fixture()
-def stac_client(client: FlaskClient):
+def stac_client(client: FlaskClient) -> FlaskClient:
     """
     Get a client with populated data and standard settings
     """
@@ -482,7 +486,7 @@ def test_returns_404s(stac_client: FlaskClient) -> None:
     (and stac errors are expected in json)
     """
 
-    def expect_404(url: str, message_contains: str = None):
+    def expect_404(url: str, message_contains: str | None = None) -> None:
         __tracebackhide__ = True
         data = get_json(stac_client, url, expect_status_code=404)
         if message_contains and message_contains not in data.get("description", ""):
@@ -1472,6 +1476,7 @@ def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
 
     # sorting across pages
     next_link = _get_next_href(doc)
+    assert next_link is not None
     next_link = next_link.replace("http://localhost", "")
     rv = stac_client.get(next_link)
     last_item = doc["features"][-1]

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -18,7 +18,6 @@ import pytest
 from datacube.migration import ODC2DeprecationWarning
 from datacube.utils import is_url, read_documents
 from dateutil import tz
-from flask import Response
 from flask.testing import FlaskClient
 from jsonschema import SchemaError
 from referencing import Registry, Resource
@@ -545,7 +544,7 @@ def test_returns_404s(stac_client: FlaskClient) -> None:
 def test_legacy_redirects(
     stac_client: FlaskClient, url: str, redirect_to_url: str
 ) -> None:
-    resp: Response = stac_client.get(url, follow_redirects=False)
+    resp = stac_client.get(url, follow_redirects=False)
     assert resp.location == redirect_to_url, (
         f"Expected {url} to be redirected to:\n"
         f"             {redirect_to_url}\n"
@@ -937,7 +936,7 @@ def test_stac_item(stac_client: FlaskClient, odc_test_db) -> None:
 def test_stac_search_limits(stac_client: FlaskClient) -> None:
     # Tell user with error if they request too much.
     large_limit = OUR_DATASET_LIMIT + 1
-    rv: Response = stac_client.get(f"/stac/search?&limit={large_limit}")
+    rv = stac_client.get(f"/stac/search?&limit={large_limit}")
     assert rv.status_code == 400
     assert b"Max page size" in rv.data
 
@@ -957,7 +956,7 @@ def test_stac_search_limits(stac_client: FlaskClient) -> None:
 def test_stac_search_zero(stac_client: FlaskClient) -> None:
     # Zero limit is a valid query
     zero_limit = 0
-    rv: Response = stac_client.get(f"/stac/search?&limit={zero_limit}")
+    rv = stac_client.get(f"/stac/search?&limit={zero_limit}")
     assert rv.status_code == 200
 
 
@@ -1071,7 +1070,7 @@ def test_stac_search_by_intersects(stac_client: FlaskClient) -> None:
 
     ... and we should only get the one dataset in that region.
     """
-    rv: Response = stac_client.post(
+    rv = stac_client.post(
         "/stac/search",
         data=json.dumps(
             {
@@ -1117,7 +1116,7 @@ def test_stac_search_by_intersects_paging(stac_client: FlaskClient) -> None:
 
     (Stac only supports 'intersects' for POST requests.)
     """
-    rv: Response = stac_client.post(
+    rv = stac_client.post(
         "/stac/search",
         data=json.dumps(
             {
@@ -1240,7 +1239,7 @@ def test_stac_search_bounds(stac_client: FlaskClient) -> None:
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
 def test_stac_search_by_post(stac_client: FlaskClient) -> None:
     # Test POST, product, and assets
-    rv: Response = stac_client.post(
+    rv = stac_client.post(
         "/stac/search",
         data=json.dumps(
             {
@@ -1261,7 +1260,7 @@ def test_stac_search_by_post(stac_client: FlaskClient) -> None:
     assert doc["features"][0]["assets"]["water"].get("href")
 
     # Test high_tide_comp_20p with POST and assets
-    rv: Response = stac_client.post(
+    rv = stac_client.post(
         "/stac/search",
         data=json.dumps(
             {
@@ -1307,7 +1306,7 @@ def test_stac_search_by_post(stac_client: FlaskClient) -> None:
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
 def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     fields = {"include": ["properties.dea:dataset_maturity"]}
-    rv: Response = stac_client.post(
+    rv = stac_client.post(
         "/stac/search",
         data=json.dumps(
             {
@@ -1341,7 +1340,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
 
     # exclude without include should remove from full set of properties
     fields = {"exclude": ["properties.title"]}
-    rv: Response = stac_client.post(
+    rv = stac_client.post(
         "/stac/search",
         data=json.dumps(
             {
@@ -1363,7 +1362,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     assert "dea:dataset_maturity" in set(properties.keys())
 
     # with get
-    rv: Response = stac_client.get(
+    rv = stac_client.get(
         "/stac/search?collection=ga_ls8c_ard_3&limit=5&fields=+properties.title"
     )
     assert rv.status_code == 200
@@ -1373,7 +1372,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     assert {"datetime", "title"} == set(properties.keys())
 
     # invalid field
-    rv: Response = stac_client.get(
+    rv = stac_client.get(
         "/stac/search?collection=ga_ls8c_ard_3&limit=5&fields=properties.foo"
     )
     assert rv.status_code == 200
@@ -1383,7 +1382,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     assert {"datetime"} == set(properties.keys())
 
     # exclude properties, but nested field properties.datetime is included by default
-    rv: Response = stac_client.get(
+    rv = stac_client.get(
         "/stac/search?collection=ga_ls8c_ard_3&limit=5&fields=-properties"
     )
     assert rv.status_code == 200
@@ -1393,9 +1392,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     assert {"datetime"} == set(properties.keys())
 
     # empty include and exclude should return just default fields
-    rv: Response = stac_client.get(
-        "/stac/search?collection=ga_ls8c_ard_3&limit=5&fields="
-    )
+    rv = stac_client.get("/stac/search?collection=ga_ls8c_ard_3&limit=5&fields=")
     assert rv.status_code == 200
     doc = rv.json
     assert doc.get("features")
@@ -1406,7 +1403,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
 def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
     sortby = [{"field": "properties.datetime", "direction": "asc"}]
-    rv: Response = stac_client.post(
+    rv = stac_client.post(
         "/stac/search",
         data=json.dumps(
             {
@@ -1429,7 +1426,7 @@ def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
         )
 
     sortby = [{"field": "properties.datetime", "direction": "desc"}]
-    rv: Response = stac_client.post(
+    rv = stac_client.post(
         "/stac/search",
         data=json.dumps(
             {
@@ -1450,12 +1447,10 @@ def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
             > doc["features"][i]["properties"]["datetime"]
         )
 
-    rv: Response = stac_client.get(
-        "/stac/search?collection=ga_ls8c_ard_3&limit=5&sortby=assets"
-    )
+    rv = stac_client.get("/stac/search?collection=ga_ls8c_ard_3&limit=5&sortby=assets")
     assert rv.status_code == 400
 
-    rv: Response = stac_client.get(
+    rv = stac_client.get(
         "/stac/search?collection=ga_ls8c_ard_3&limit=5&sortby=id,-properties.datetime"
     )
     doc = rv.json
@@ -1463,13 +1458,13 @@ def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
         assert doc["features"][i - 1]["id"] < doc["features"][i]["id"]
 
     # use of property prefixes shouldn't impact result
-    rv: Response = stac_client.get(
+    rv = stac_client.get(
         "/stac/search?collection=ga_ls8c_ard_3&limit=5&sortby=item.id,-datetime"
     )
     assert rv.json == doc
 
     # ignore undefined field
-    rv: Response = stac_client.get(
+    rv = stac_client.get(
         "/stac/search?collection=ga_ls8c_ard_3&limit=5&sortby=id,-datetime,foo"
     )
     assert rv.json["features"] == doc["features"]
@@ -1477,7 +1472,7 @@ def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
     # sorting across pages
     next_link = _get_next_href(doc)
     next_link = next_link.replace("http://localhost", "")
-    rv: Response = stac_client.get(next_link)
+    rv = stac_client.get(next_link)
     last_item = doc["features"][-1]
     next_item = rv.json["features"][0]
     assert last_item["id"] < next_item["id"]
@@ -1498,7 +1493,7 @@ def test_stac_filter_extension(stac_client: FlaskClient) -> None:
             },
         ],
     }
-    rv: Response = stac_client.post(
+    rv = stac_client.post(
         "/stac/search",
         data=json.dumps(
             {
@@ -1520,28 +1515,26 @@ def test_stac_filter_extension(stac_client: FlaskClient) -> None:
 
     # test cql2-text
     filter_text = "collection='ga_ls8c_ard_3' AND dataset_maturity <> 'final' AND cloud_cover >= 2"
-    rv: Response = stac_client.get(f"/stac/search?filter={filter_text}")
+    rv = stac_client.get(f"/stac/search?filter={filter_text}")
     assert rv.json.get("numberMatched") == 2
 
     filter_text = "view:sun_azimuth < 40 AND dataset_maturity = 'final'"
-    rv: Response = stac_client.get(
-        f"/stac/search?collections=ga_ls8c_ard_3&filter={filter_text}"
-    )
+    rv = stac_client.get(f"/stac/search?collections=ga_ls8c_ard_3&filter={filter_text}")
     assert rv.json.get("numberMatched") == 4
 
     # test invalid property name treated as null
-    rv: Response = stac_client.get(
+    rv = stac_client.get(
         "/stac/search?filter=item.collection='ga_ls8c_ard_3' AND properties.foo > 2"
     )
     assert rv.json.get("numberMatched") == 0
 
-    rv: Response = stac_client.get(
+    rv = stac_client.get(
         "/stac/search?filter=collection='ga_ls8c_ard_3' AND foo IS NULL"
     )
     assert rv.json.get("numberMatched") == 21
 
     # test lang mismatch
-    rv: Response = stac_client.post(
+    rv = stac_client.post(
         "/stac/search",
         data=json.dumps(
             {
@@ -1558,7 +1551,7 @@ def test_stac_filter_extension(stac_client: FlaskClient) -> None:
     assert rv.status_code == 400
 
     # filter-crs invalid value
-    rv: Response = stac_client.post(
+    rv = stac_client.post(
         "/stac/search",
         data=json.dumps(
             {
@@ -1579,7 +1572,7 @@ def test_stac_filter_extension(stac_client: FlaskClient) -> None:
 def test_stac_query_extension_errors(stac_client: FlaskClient) -> None:
     # Trying to use query extension should error
     query = {"cloud_cover": {"lt": 1}}
-    rv: Response = stac_client.post(
+    rv = stac_client.post(
         "/stac/search",
         data=json.dumps(
             {

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -1106,7 +1106,7 @@ def test_stac_search_by_intersects(stac_client: FlaskClient) -> None:
     )
     assert rv.status_code == 200, f"Error response: {rv.data}"
     doc = rv.json
-
+    assert doc is not None, "Empty response from server"
     features = doc.get("features", [])
 
     # We only returned the feature of that region code?
@@ -1144,7 +1144,7 @@ def test_stac_search_by_intersects_paging(stac_client: FlaskClient) -> None:
     )
     assert rv.status_code == 200, f"Error response: {rv.data}"
     doc = rv.json
-
+    assert doc is not None, "Empty response from server"
     # We got a whole page of features.
     assert len(doc.get("features", [])) == OUR_PAGE_SIZE
 
@@ -1259,6 +1259,7 @@ def test_stac_search_by_post(stac_client: FlaskClient) -> None:
     )
     assert rv.status_code == 200
     doc = rv.json
+    assert doc is not None, "Empty response from server"
     assert len(doc.get("features", [])) == OUR_PAGE_SIZE
     # We requested the full dataset, so band assets etc. should be included.
     assert "water" in doc["features"][0]["assets"]
@@ -1280,7 +1281,7 @@ def test_stac_search_by_post(stac_client: FlaskClient) -> None:
     )
     assert rv.status_code == 200
     doc = rv.json
-
+    assert doc is not None, "Empty response from server"
     # Features should include all bands.
 
     for feature in doc["features"]:
@@ -1326,6 +1327,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     )
     assert rv.status_code == 200
     doc = rv.json
+    assert doc is not None, "Empty response from server"
     assert doc.get("features")
     keys = set(doc["features"][0].keys())
     assert {
@@ -1360,6 +1362,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     )
     assert rv.status_code == 200
     doc = rv.json
+    assert doc is not None, "Empty response from server"
     keys = set(doc["features"][0].keys())
     assert "collection" in keys
     properties = doc["features"][0]["properties"]
@@ -1372,6 +1375,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     )
     assert rv.status_code == 200
     doc = rv.json
+    assert doc is not None, "Empty response from server"
     assert doc.get("features")
     properties = doc["features"][0]["properties"]
     assert {"datetime", "title"} == set(properties.keys())
@@ -1382,6 +1386,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     )
     assert rv.status_code == 200
     doc = rv.json
+    assert doc is not None, "Empty response from server"
     assert doc.get("features")
     properties = doc["features"][0]["properties"]
     assert {"datetime"} == set(properties.keys())
@@ -1392,6 +1397,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     )
     assert rv.status_code == 200
     doc = rv.json
+    assert doc is not None, "Empty response from server"
     assert doc.get("features")
     properties = doc["features"][0]["properties"]
     assert {"datetime"} == set(properties.keys())
@@ -1400,6 +1406,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     rv = stac_client.get("/stac/search?collection=ga_ls8c_ard_3&limit=5&fields=")
     assert rv.status_code == 200
     doc = rv.json
+    assert doc is not None, "Empty response from server"
     assert doc.get("features")
     properties = doc["features"][0]["properties"]
     assert {"datetime"} == set(properties.keys())
@@ -1423,6 +1430,7 @@ def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
     )
     assert rv.status_code == 200
     doc = rv.json
+    assert doc is not None, "Empty response from server"
     assert doc.get("features")
     for i in range(1, len(doc["features"])):
         assert (
@@ -1446,6 +1454,7 @@ def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
     )
     assert rv.status_code == 200
     doc = rv.json
+    assert doc is not None, "Empty response from server"
     for i in range(1, len(doc["features"])):
         assert (
             doc["features"][i - 1]["properties"]["datetime"]
@@ -1459,6 +1468,7 @@ def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
         "/stac/search?collection=ga_ls8c_ard_3&limit=5&sortby=id,-properties.datetime"
     )
     doc = rv.json
+    assert doc is not None, "Empty response from server"
     for i in range(1, len(doc["features"])):
         assert doc["features"][i - 1]["id"] < doc["features"][i]["id"]
 
@@ -1472,6 +1482,7 @@ def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
     rv = stac_client.get(
         "/stac/search?collection=ga_ls8c_ard_3&limit=5&sortby=id,-datetime,foo"
     )
+    assert rv.json is not None
     assert rv.json["features"] == doc["features"]
 
     # sorting across pages
@@ -1479,6 +1490,7 @@ def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
     assert next_link is not None
     next_link = next_link.replace("http://localhost", "")
     rv = stac_client.get(next_link)
+    assert rv.json is not None
     last_item = doc["features"][-1]
     next_item = rv.json["features"][0]
     assert last_item["id"] < next_item["id"]
@@ -1513,6 +1525,7 @@ def test_stac_filter_extension(stac_client: FlaskClient) -> None:
         headers={"Content-Type": "application/json", "Accept": "application/json"},
     )
     assert rv.status_code == 200
+    assert rv.json is not None
     features = rv.json.get("features")
     assert len(features) == rv.json.get("numberMatched") == 2
     ids = [f["id"] for f in features]
@@ -1522,21 +1535,25 @@ def test_stac_filter_extension(stac_client: FlaskClient) -> None:
     # test cql2-text
     filter_text = "collection='ga_ls8c_ard_3' AND dataset_maturity <> 'final' AND cloud_cover >= 2"
     rv = stac_client.get(f"/stac/search?filter={filter_text}")
+    assert rv.json is not None
     assert rv.json.get("numberMatched") == 2
 
     filter_text = "view:sun_azimuth < 40 AND dataset_maturity = 'final'"
     rv = stac_client.get(f"/stac/search?collections=ga_ls8c_ard_3&filter={filter_text}")
+    assert rv.json is not None
     assert rv.json.get("numberMatched") == 4
 
     # test invalid property name treated as null
     rv = stac_client.get(
         "/stac/search?filter=item.collection='ga_ls8c_ard_3' AND properties.foo > 2"
     )
+    assert rv.json is not None
     assert rv.json.get("numberMatched") == 0
 
     rv = stac_client.get(
         "/stac/search?filter=collection='ga_ls8c_ard_3' AND foo IS NULL"
     )
+    assert rv.json is not None
     assert rv.json.get("numberMatched") == 21
 
     # test lang mismatch

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -129,13 +129,13 @@ def _web_reference(ref: str):
     """
     A reference to a schema via a URL
 
-    eg http://geojson.org/schemas/Features.json'
+    e.g https://geojson.org/schema/Feature.json
     """
     if not is_url(ref):
         raise NoSuchResource(f"Expected URL? Got {ref!r}")
     (scheme, netloc, offset, params, query, fragment) = urllib.parse.urlparse(ref)
     # We used `wget -r` to download the remote schemas locally.
-    # It puts into hostname/path folders by default. Eg. 'geojson.org/schema/Feature.json'
+    # It puts into hostname/path folders by default. E.g 'geojson.org/schema/Feature.json'
     path = _SCHEMA_BASE / f"{netloc}{offset}"
     if not path.exists():
         if ALLOW_INTERNET:

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -714,6 +714,7 @@ def test_stac_collection(stac_client: FlaskClient):
     }
     # HACK: Make things float again
     assert_collection(scene_collection)
+    item_links = None
     for link in scene_collection["links"]:
         if link["rel"] == "items":
             item_links = link["href"]

--- a/integration_tests/test_wagl_data.py
+++ b/integration_tests/test_wagl_data.py
@@ -7,7 +7,6 @@ from datetime import datetime
 import pytest
 from datacube.model import Range
 from dateutil.tz import tzutc
-from flask import Response
 from flask.testing import FlaskClient
 
 from cubedash.summary import SummaryStore
@@ -81,7 +80,7 @@ def test_product_audit(unpopulated_client: FlaskClient, run_generate) -> None:
 
     assert len(res.css(".unavailable-metadata .search-result")) == 2
 
-    res: Response = client.get("/audit/day-query-times.txt")
+    res = client.get("/audit/day-query-times.txt")
     plain_timing_results = res.data.decode("utf-8")
     print(plain_timing_results)
     assert '"s2a_ard_granule"\t8\t' in plain_timing_results

--- a/integration_tests/test_zzz_timings.py
+++ b/integration_tests/test_zzz_timings.py
@@ -5,7 +5,6 @@ The timing decorator modifies global state, run these tests last.
 """
 
 import pytest
-from flask import Response
 from flask.testing import FlaskClient
 
 from cubedash import _monitoring
@@ -16,7 +15,7 @@ from cubedash import _monitoring
 def test_with_timings(client: FlaskClient) -> None:
     _monitoring.init_app_monitoring(client.application)
     # ga_ls8c_ard_3 dataset
-    rv: Response = client.get("/dataset/e2dd2539-ae18-4edc-a0e6-ddd31848669c")
+    rv = client.get("/dataset/e2dd2539-ae18-4edc-a0e6-ddd31848669c")
     assert "Server-Timing" in rv.headers
 
     count_header = [


### PR DESCRIPTION
Remove the faulty type annotations, put in type-correct default values, put in annotations for the type checker, and add more asserts in tests to give an error instead of crashing when things go wrong.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--757.org.readthedocs.build/en/757/

<!-- readthedocs-preview datacube-explorer end -->