### PR TITLE
pre-commit: update ruff hook name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.5
     hooks:
-    - id: ruff
+    - id: ruff-check
       args: [--fix, --show-fixes, --output-format, grouped]
     - id: ruff-format
   # # Lint Jinja2 templates


### PR DESCRIPTION
The new name is ruff-check, so use
that.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--762.org.readthedocs.build/en/762/

<!-- readthedocs-preview datacube-explorer end -->