### PR TITLE
CI: use OIDC for CodeCov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,8 @@ jobs:
   integration-tests:
     timeout-minutes: 55
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -63,4 +64,4 @@ jobs:
           files: ./coverage.xml
           disable_search: true
           fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true


### PR DESCRIPTION
This uses a short-lived token
which is better for security.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--765.org.readthedocs.build/en/765/

<!-- readthedocs-preview datacube-explorer end -->