### PR TITLE
Dockerfile: avoid copying in uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,10 +60,18 @@ RUN --mount=type=cache,id=opendatacube-uv-cache,target=/root/.cache \
 COPY --link . /build/
 
 ARG ENVIRONMENT=deployment
+# The deployment image should not have binaries that aid an attacker to get their
+# rootkit in place, and uv downloads over the network. There is no conditional
+# copy in Docker, so truncate the uv binaries to 0 bytes to render them harmless
+# in the resulting deployment image.
 RUN --mount=type=cache,id=opendatacube-uv-cache,target=/root/.cache \
     EXTRAS=$( ([ "$ENVIRONMENT" = "deployment" ] && echo "--extra=deployment --no-dev") || \
                  echo "--extra=test") \
-    && uv sync --frozen $EXTRAS --no-editable
+    && uv sync --frozen $EXTRAS --no-editable \
+    && ([ "$ENVIRONMENT" != "deployment" ] || \
+        (chmod 644 /usr/local/bin/uv* && \
+         echo "" > /usr/local/bin/uv && \
+         echo "" > /usr/local/bin/uvx))
 
 FROM base
 
@@ -84,11 +92,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && chown ubuntu:ubuntu /app
 
 COPY --from=builder --link /usr/local/bin/uv* /usr/local/bin/
-
-# Environment is test or deployment.
-ARG ENVIRONMENT=deployment
-RUN ([ "$ENVIRONMENT" != "deployment" ] || \
-           rm -f /usr/local/bin/uv*)
 
 COPY --from=builder --link --chown=1000:1000 /app /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
             tini \
     && mkdir /app \
     && chown ubuntu:ubuntu /app
-
+# In the "deployment" build, these `uv` binaries will be 0 bytes.
+# In the "test" build they're the actual `uv` tools.
 COPY --from=builder --link /usr/local/bin/uv* /usr/local/bin/
 
 COPY --from=builder --link --chown=1000:1000 /app /app


### PR DESCRIPTION
Truncate the uv binaries to 0 bytes
for deployment image. This reduces
the image size by 46 MB.

This also removes the conditional
parts of the produced image, which
should improve Docker cache hit rates.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--766.org.readthedocs.build/en/766/

<!-- readthedocs-preview datacube-explorer end -->