### PR TITLE
CI: fixate time stamp for image layers (reproducible docker builds)

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: Get Git commit timestamps
+        run: |
+          TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock cubedash)
+          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+
       - name: Build Docker
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
@@ -44,6 +49,8 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
       - name: Run vulnerability scanner
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: Get Git commit timestamps
+        run: |
+          TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock cubedash)
+          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+
       - name: Build Docker
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
@@ -49,6 +54,8 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
       - name: Run tests
         run: |


### PR DESCRIPTION
Set the timestamp of the layers in
the Docker image according to:

https://docs.docker.com/build/ci/github-actions/reproducible-builds/

We improve on that solution by
just getting the time of the last
commit for the package-related
files, so timestamps change
less often.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--771.org.readthedocs.build/en/771/

<!-- readthedocs-preview datacube-explorer end -->