### PR TITLE
Remove pytz

### DIFF
--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -6,10 +6,10 @@ import calendar
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from urllib.parse import quote_plus
+from zoneinfo import ZoneInfo
 
 import flask
 import orjson
-import pytz
 import structlog
 from datacube.index.fields import Field
 from datacube.model import Dataset, Product, Range
@@ -49,7 +49,7 @@ def _get_metadata_center_time(dataset):
 
 @bp.app_template_filter("localised_metadata_center_time")
 def _get_localised_metadata_center_time(date):
-    return date.astimezone(pytz.timezone(_model.DEFAULT_GROUPING_TIMEZONE))
+    return date.astimezone(ZoneInfo(_model.DEFAULT_GROUPING_TIMEZONE))
 
 
 @bp.app_template_filter("printable_dataset")

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -15,9 +15,9 @@ from typing import (
     Sequence,
 )
 from uuid import UUID
+from zoneinfo import ZoneInfo
 
 import dateutil.parser
-import pytz
 import structlog
 from cachetools.func import ttl_cache
 from dateutil import tz
@@ -77,7 +77,7 @@ _LOG = structlog.stdlib.get_logger()
 # We'll use a global equal area.
 DEFAULT_EPSG = 6933
 
-default_timezone = pytz.timezone(DEFAULT_TIMEZONE)
+default_timezone = ZoneInfo(DEFAULT_TIMEZONE)
 
 
 def explorer_index(index: Index) -> ExplorerIndex:
@@ -1551,7 +1551,7 @@ def _safe_read_date(d):
 
 
 def _summary_from_row(
-    res, product_name: str, grouping_timezone: pytz.tzinfo.DstTzInfo = default_timezone
+    res, product_name: str, grouping_timezone: tzinfo = default_timezone
 ):
     timeline_dataset_counts = (
         Counter(
@@ -1622,8 +1622,7 @@ def _summary_from_row(
 
 
 def _summary_to_row(
-    summary: TimePeriodOverview,
-    grouping_timezone: pytz.tzinfo.DstTzInfo = default_timezone,
+    summary: TimePeriodOverview, grouping_timezone: tzinfo = default_timezone
 ) -> dict:
     day_values, day_counts = _counter_key_vals(summary.timeline_dataset_counts)
     region_values, region_counts = _counter_key_vals(summary.region_dataset_counts)
@@ -1661,7 +1660,7 @@ def _summary_to_row(
 
 
 def _row_to_collection(
-    res: Row, grouping_timezone: pytz.tzinfo.DstTzInfo = default_timezone
+    res: Row, grouping_timezone: tzinfo = default_timezone
 ) -> CollectionItem:
     return CollectionItem(
         name=res.name,

--- a/integration_tests/test_utc_tst.py
+++ b/integration_tests/test_utc_tst.py
@@ -4,9 +4,9 @@ Tests that load pages and check the contained text.
 
 from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 from click.testing import Result
 from datacube.model import Range
 from dateutil import tz
@@ -151,12 +151,12 @@ def test_clirunner_generate_grouping_timezone(
 def test_dataset_day_link(summary_store) -> None:
     ds = summary_store.index.datasets.get("6293ac37-7f1d-430e-8d7e-ffdc1bfd556c")
     t = datetime_from_metadata(ds)
-    t = default_utc(t).astimezone(pytz.timezone("Australia/Darwin"))
+    t = default_utc(t).astimezone(ZoneInfo("Australia/Darwin"))
     assert t.year == 2022
     assert t.month == 1
     assert t.day == 1
 
-    t = default_utc(t).astimezone(pytz.timezone("America/Chicago"))
+    t = default_utc(t).astimezone(ZoneInfo("America/Chicago"))
     assert t.year == 2021
     assert t.month == 12
     assert t.day == 31

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "pyproj",
     "pystac",
     "python-dateutil",
-    "pytz",
     "sentry-sdk[flask]",
     "shapely",
     "simplekml",
@@ -96,7 +95,6 @@ test = [
     "selectolax",
     "types-cachetools",
     "types-python-dateutil",
-    "types-pytz",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,6 @@ dependencies = [
     { name = "pyproj" },
     { name = "pystac" },
     { name = "python-dateutil" },
-    { name = "pytz" },
     { name = "sentry-sdk", extra = ["flask"] },
     { name = "shapely" },
     { name = "simplekml" },
@@ -700,7 +699,6 @@ test = [
     { name = "setproctitle" },
     { name = "types-cachetools" },
     { name = "types-python-dateutil" },
-    { name = "types-pytz" },
 ]
 
 [package.dev-dependencies]
@@ -759,7 +757,6 @@ requires-dist = [
     { name = "pytest-benchmark", marker = "extra == 'test'" },
     { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "python-dateutil" },
-    { name = "pytz" },
     { name = "ruff", marker = "extra == 'test'" },
     { name = "selectolax", marker = "extra == 'test'" },
     { name = "sentry-sdk", extras = ["flask"] },
@@ -770,7 +767,6 @@ requires-dist = [
     { name = "structlog", specifier = ">=20.2.0" },
     { name = "types-cachetools", marker = "extra == 'test'" },
     { name = "types-python-dateutil", marker = "extra == 'test'" },
-    { name = "types-pytz", marker = "extra == 'test'" },
 ]
 provides-extras = ["deployment", "test"]
 
@@ -933,7 +929,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1250,7 +1246,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -3593,15 +3589,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/95/6bdde7607da2e1e99ec1c1672a759d42f26644bbacf939916e086db34870/types_python_dateutil-2.9.0.20250708.tar.gz", hash = "sha256:ccdbd75dab2d6c9696c350579f34cffe2c281e4c5f27a585b2a2438dd1d5c8ab", size = 15834, upload-time = "2025-07-08T03:14:03.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/52/43e70a8e57fefb172c22a21000b03ebcc15e47e97f5cb8495b9c2832efb4/types_python_dateutil-2.9.0.20250708-py3-none-any.whl", hash = "sha256:4d6d0cc1cc4d24a2dc3816024e502564094497b713f7befda4d5bc7a8e3fd21f", size = 17724, upload-time = "2025-07-08T03:14:02.593Z" },
-]
-
-[[package]]
-name = "types-pytz"
-version = "2025.2.0.20250516"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/72/b0e711fd90409f5a76c75349055d3eb19992c110f0d2d6aabbd6cfbc14bf/types_pytz-2025.2.0.20250516.tar.gz", hash = "sha256:e1216306f8c0d5da6dafd6492e72eb080c9a166171fa80dd7a1990fd8be7a7b3", size = 10940, upload-time = "2025-05-16T03:07:01.91Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/ba/e205cd11c1c7183b23c97e4bcd1de7bc0633e2e867601c32ecfc6ad42675/types_pytz-2025.2.0.20250516-py3-none-any.whl", hash = "sha256:e0e0c8a57e2791c19f718ed99ab2ba623856b11620cb6b637e5f62ce285a7451", size = 10136, upload-time = "2025-05-16T03:07:01.075Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This functionality is available
in the standard library since
Python 3.9.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--774.org.readthedocs.build/en/774/

<!-- readthedocs-preview datacube-explorer end -->