### PR TITLE
Remove setuptools_scm workarounds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,4 +122,4 @@ lint-docker: ## Run linting inside inside Docker
 
 test-docker: ## Run tests inside Docker
 	docker compose run --rm explorer \
-		bash --login -c "cd /code && pytest --cov=cubedash --cov-report=xml -r sx --durations=5"
+		bash --login -c "cd /code && pytest --import-mode=append --cov=cubedash --cov-report=xml -r sx --durations=5 integration_tests"

--- a/cubedash/__init__.py
+++ b/cubedash/__init__.py
@@ -1,8 +1,4 @@
-try:
-    from ._version import version as __version__
-except ImportError:
-    __version__ = "Unknown/Not Installed"
-
 from ._model import create_app
+from ._version import version as __version__
 
 __all__ = ("create_app", "__version__")

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -28,11 +28,6 @@ from cubedash.summary._summarise import DEFAULT_TIMEZONE
 
 from . import _utils as utils
 
-try:
-    from ._version import version as __version__
-except ImportError:
-    __version__ = "Unknown/Not Installed"
-
 NAME = "cubedash"
 BASE_DIR = Path(__file__).parent.parent
 

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -21,9 +21,9 @@ from flask import (
 from sqlalchemy.exc import DataError
 from werkzeug.datastructures import MultiDict
 
-import cubedash
 from cubedash._model import ProductWithSummary
 from cubedash._utils import default_utc
+from cubedash._version import __version__
 from cubedash.summary import TimePeriodOverview
 from cubedash.summary._stores import ProductSummary
 
@@ -497,7 +497,7 @@ def inject_globals():
         datacube_metadata_types=list(_model.STORE.all_metadata_types()),
         current_time=datetime.now(timezone.utc),
         datacube_version=datacube.__version__,
-        app_version=cubedash.__version__,
+        app_version=__version__,
         grouping_timezone=tz.gettz(_model.DEFAULT_GROUPING_TIMEZONE),
         last_updated_time=last_updated,
         explorer_instance_title=current_app.config.get(

--- a/cubedash/run.py
+++ b/cubedash/run.py
@@ -22,11 +22,11 @@ def _print_version(ctx, param, value) -> None:
 
     import datacube
 
-    import cubedash
+    from cubedash._version import __version__
 
     click.echo(
         f"Open Data Cube:\n"
-        f"    {style('Explorer', bold=True)} version: {cubedash.__version__}\n"
+        f"    {style('Explorer', bold=True)} version: {__version__}\n"
         f"    {style('Core', bold=True)} version: {datacube.__version__}"
     )
     ctx.exit()

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -20,11 +20,15 @@ import dateutil.parser
 import pytz
 import structlog
 from cachetools.func import ttl_cache
+from datacube.drivers.postgres._fields import PgDocField
+from datacube.index import Index
+from datacube.model import Dataset, MetadataType, Product, Range
 from dateutil import tz
 from eodatasets3.stac import MAPPING_EO3_TO_STAC
 from geoalchemy2 import WKBElement
 from geoalchemy2 import shape as geo_shape
 from geoalchemy2.shape import from_shape, to_shape
+from odc.geo.geom import Geometry
 from pygeofilter.backends.sqlalchemy.evaluate import (
     SQLAlchemyFilterEvaluator as FilterEvaluator,
 )
@@ -42,15 +46,6 @@ from sqlalchemy import (
 from sqlalchemy.dialects import postgresql as postgres
 from sqlalchemy.dialects.postgresql import TSTZRANGE
 from sqlalchemy.sql import Select
-
-try:
-    from cubedash._version import version as explorer_version
-except ModuleNotFoundError:
-    explorer_version = "ci-test-pipeline"
-from datacube.drivers.postgres._fields import PgDocField
-from datacube.index import Index
-from datacube.model import Dataset, MetadataType, Product, Range
-from odc.geo.geom import Geometry
 
 from cubedash import _utils
 from cubedash.index import EmptyDbError, ExplorerIndex
@@ -300,14 +295,12 @@ class SummaryStore:
         """
         Have all schema updates been applied?
         """
+        from cubedash._version import __version__
+
         postgis_ver, is_compatible = self.e_index.schema_compatible_info(
             for_writing_operations_too
         )
-        _LOG.debug(
-            "software.version",
-            postgis=postgis_ver,
-            explorer=explorer_version,
-        )
+        _LOG.debug("software.version", postgis=postgis_ver, explorer=__version__)
         return is_compatible
 
     def init(self, grouping_epsg_code: int | None = None) -> None:


### PR DESCRIPTION
These look like things that are masking
issues with packaging.

Coincidentally, this also seems to
reduce the "every file imports everything
else" that you notice when type checking
a single file.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--775.org.readthedocs.build/en/775/

<!-- readthedocs-preview datacube-explorer end -->