### PR TITLE
Error check refresh_spatial_extents

### DIFF
--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -107,7 +107,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
         Returns a list of sources and how many more sources exist beyond the limit.
         """
-        source_ids = self.index.lineage.get_source_tree(
+        source_ids: set | list = self.index.lineage.get_source_tree(
             dataset_id, max_depth=1
         ).child_datasets()
         if limit and len(source_ids) > limit:
@@ -719,7 +719,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     @override
     def delete_datasets(
         self, product_id: int, after_date: datetime | None = None, full: bool = False
-    ):
+    ) -> int:
         with self.index._active_connection() as conn:
             # Forcing? Check every other dataset for removal, so we catch manually-deleted rows from the table.
             if full:

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -192,7 +192,8 @@ def refresh_spatial_extents(
                               If None, all datasets will be regenerated.
     :param clean_up_deleted: Scan for any manually deleted rows too. Slow.
     """
-
+    if product.id is None:
+        return 0
     log = _LOG.bind(product_name=product.name, after_date=assume_after_date)
 
     log.info(

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -182,7 +182,7 @@ def _gis_point(doc, doc_offset):
 def refresh_spatial_extents(
     e_index: ExplorerIndex,
     product: Product,
-    clean_up_deleted=False,
+    clean_up_deleted: bool = False,
     assume_after_date: datetime | None = None,
 ) -> int:
     """


### PR DESCRIPTION
None of the called methods expects
the product ID to be None, so return
0 when that happens.

Also throw in a couple of commits with
type annotations added during investigation
of this issue.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--781.org.readthedocs.build/en/781/

<!-- readthedocs-preview datacube-explorer end -->