### PR TITLE
RegionInfo: fix crash in region()

### DIFF
--- a/cubedash/index/api.py
+++ b/cubedash/index/api.py
@@ -82,7 +82,7 @@ class ExplorerAbstractIndex(ABC):
     def upsert_datasets(
         self,
         product_id: int,
-        column_values: dict[str, list[Label]],
+        column_values: dict[str, Label],
         after_date: datetime | None,
     ) -> int: ...
 

--- a/cubedash/index/api.py
+++ b/cubedash/index/api.py
@@ -193,7 +193,7 @@ class ExplorerAbstractIndex(ABC):
 
     @abstractmethod
     def products_by_region(
-        self, region_code: str, time_range: Range, limit: int, offset: int = 0
+        self, region_code: str, time_range: Range | None, limit: int, offset: int = 0
     ) -> Generator[int, None, None]: ...
 
     @abstractmethod

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -762,7 +762,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     def upsert_datasets(
         self,
         product_id: int,
-        column_values: dict[str, list[Label]],
+        column_values: dict[str, Label],
         after_date: datetime | None,
     ) -> int:
         column_values["id"] = ODC_DATASET.id

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -694,7 +694,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     def products_by_region(
         self,
         region_code: str,
-        time_range: Range,
+        time_range: Range | None,
         limit: int,
         offset: int = 0,
     ) -> Generator[int, None, None]:

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -795,7 +795,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     def upsert_datasets(
         self,
         product_id: int,
-        column_values: dict[str, list[Label]],
+        column_values: dict[str, Label],
         after_date: datetime | None,
     ) -> int:
         column_values["id"] = ODC_DATASET.c.id

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -718,7 +718,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     def products_by_region(
         self,
         region_code: str,
-        time_range: Range,
+        time_range: Range | None,
         limit: int,
         offset: int = 0,
     ) -> Generator[int, None, None]:

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -455,7 +455,7 @@ class RegionInfo:
         return None
 
     def region(self, region_code: str) -> RegionSummary | None:
-        return self._known_regions.get(region_code)
+        return (self._known_regions or {}).get(region_code)
 
     def dataset_region_code(self, dataset: Dataset) -> str | None:
         """

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -13,7 +13,7 @@ from datacube.drivers.postgis._fields import PgDocField as PgisDocField
 from datacube.drivers.postgis._fields import RangeDocField as PgisRangeDocField
 from datacube.drivers.postgres._fields import PgDocField as PgresDocField
 from datacube.drivers.postgres._fields import RangeDocField as PgresRangeDocField
-from datacube.model import Dataset, Field, MetadataType, Product
+from datacube.model import Dataset, MetadataType, Product
 from geoalchemy2 import Geometry, WKBElement
 from geoalchemy2.shape import to_shape
 from shapely.geometry import shape
@@ -437,9 +437,7 @@ class RegionInfo:
     def for_product(
         cls, product: Product, known_regions: dict[str, RegionSummary] | None = None
     ):
-        region_code_field: Field = product.metadata_type.dataset_fields.get(
-            "region_code"
-        )
+        region_code_field = product.metadata_type.dataset_fields.get("region_code")
 
         grid_spec = product.grid_spec
         # Ingested grids trump the "region_code" field because they've probably sliced it up smaller.
@@ -477,9 +475,7 @@ class RegionInfo:
         Classes that override this should also override dataset_region_code to match.
         """
         product = self.product
-        region_code_field: Field = product.metadata_type.dataset_fields.get(
-            "region_code"
-        )
+        region_code_field = product.metadata_type.dataset_fields.get("region_code")
         # `alchemy_expression` is part of the postgres driver (PgDocField),
         # not the base Field class.
         if not hasattr(region_code_field, "alchemy_expression"):
@@ -516,7 +512,7 @@ class GridRegionInfo(RegionInfo):
         This is usually the 'region_code' field, if one exists, but there are
         fallbacks for other native Satellites/Platforms.
 
-        Eg.
+        E.g.
 
         On Landsat scenes this is the path/row (separated by underscore)
         On tiles this is the tile numbers (separated by underscore: possibly with negative)
@@ -595,8 +591,8 @@ class SceneRegionInfo(RegionInfo):
         product = self.product
         # Generate region code for older sat_path/sat_row pairs.
         md_fields = product.metadata_type.dataset_fields
-        path_field: RangeDocField = md_fields["sat_path"]
-        row_field: RangeDocField = md_fields["sat_row"]
+        path_field = md_fields["sat_path"]
+        row_field = md_fields["sat_row"]
 
         return case(
             # Is this just one scene? Include it specifically

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import uuid
+from collections.abc import Generator
 from dataclasses import dataclass
 from datetime import date, datetime
 from pathlib import Path
@@ -672,7 +673,7 @@ def _get_path_row_shapes():
 
 
 # see comment on get_sample_dataset
-def get_mapped_crses(products, e_index: ExplorerIndex) -> Iterable[dict]:
+def get_mapped_crses(products, e_index: ExplorerIndex) -> Generator[dict]:
     for product in products:
         res = e_index.mapped_crses(
             product,


### PR DESCRIPTION
Ensure get() is always called on a dict.

Also fix the upsert_datasets type annotation,
and remove some faulty type annotations
in extents.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--782.org.readthedocs.build/en/782/

<!-- readthedocs-preview datacube-explorer end -->