### PR TITLE
summarise: change calculate_summary signature

### DIFF
--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -671,9 +671,7 @@ class SummaryStore:
         if year and month and day:
             # We don't store days, they're quick.
             return self._summariser.calculate_summary(
-                product_name,
-                year_month_day=(year, month, day),
-                product_refresh_time=datetime.now(),
+                product_name, year, month, day, datetime.now()
             )
 
         product = self.get_product_summary(product_name)
@@ -1217,9 +1215,7 @@ class SummaryStore:
         """Recalculate the given period and store it in the DB"""
         if year and month:
             summary = self._summariser.calculate_summary(
-                product.name,
-                year_month_day=(year, month, None),
-                product_refresh_time=product_refresh_time,
+                product.name, year, month, None, product_refresh_time
             )
         elif year:
             summary = TimePeriodOverview.add_periods(

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1208,9 +1208,9 @@ class SummaryStore:
     def _recalculate_period(
         self,
         product: ProductSummary,
-        year: int | None = None,
-        month: int | None = None,
-        product_refresh_time: datetime | None = None,
+        year: int | None,
+        month: int | None,
+        product_refresh_time: datetime,
     ) -> TimePeriodOverview:
         """Recalculate the given period and store it in the DB"""
         if year and month:
@@ -1367,10 +1367,7 @@ class SummaryStore:
                 change_count=new_count,
             )
             self._recalculate_period(
-                new_product,
-                change_month.year,
-                change_month.month,
-                product_refresh_time=refresh_timestamp,
+                new_product, change_month.year, change_month.month, refresh_timestamp
             )
 
         # Find year records who are older than their month records
@@ -1378,16 +1375,11 @@ class SummaryStore:
         #    as from previous interrupted runs.)
         years_to_update = self.find_years_needing_update(product_name)
         for year in years_to_update:
-            self._recalculate_period(
-                new_product,
-                year,
-                product_refresh_time=refresh_timestamp,
-            )
+            self._recalculate_period(new_product, year, None, refresh_timestamp)
 
         # Now update the whole-product record
         updated_summary = self._recalculate_period(
-            new_product,
-            product_refresh_time=refresh_timestamp,
+            new_product, None, None, refresh_timestamp
         )
         _LOG.info(
             "product.complete!",

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -48,13 +48,15 @@ class Summariser:
     def calculate_summary(
         self,
         product_name: str,
-        year_month_day: tuple[int | None, int | None, int | None],
+        year: int,
+        month: int | None,
+        day: int | None,
         product_refresh_time: datetime,
     ) -> TimePeriodOverview:
         """
         Create a summary of the given product/time range.
         """
-        time = _utils.as_time_range(*year_month_day)
+        time = _utils.as_time_range(year, month, day)
         log = self.log.bind(product_name=product_name, time=time)
         log.debug("summary.query")
 
@@ -127,7 +129,6 @@ class Summariser:
                 "not have a null product refresh time."
             )
 
-        year, month, day = year_month_day
         summary = TimePeriodOverview(
             **row,
             product_name=product_name,

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -57,6 +57,7 @@ class Summariser:
         Create a summary of the given product/time range.
         """
         time = _utils.as_time_range(year, month, day)
+        assert time is not None  # Guaranteed by passing in a year to as_time_range.
         log = self.log.bind(product_name=product_name, time=time)
         log.debug("summary.query")
 

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -124,12 +124,6 @@ class Summariser:
                 }
             )
 
-        if product_refresh_time is None:
-            raise RuntimeError(
-                "Internal error: Newly-made time summaries should "
-                "not have a null product refresh time."
-            )
-
         summary = TimePeriodOverview(
             **row,
             product_name=product_name,


### PR DESCRIPTION
Pass the year, month, and day as
parameters instead of forcing the caller
to pack arguments into a tuple and then
unpacking the tuple immediately inside
the method.

This made it clear that `_recalculate_period`
can also be adjusted, so the product refresh
time is never None, which allows removing
a runtime check of that value.

Also add a type checker assert so
MyPy understands that None will
never be returned from the
helper function.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--788.org.readthedocs.build/en/788/

<!-- readthedocs-preview datacube-explorer end -->