### PR TITLE
pages: order except clauses

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -173,10 +173,10 @@ def search_page(
     args = MultiDict(flask.request.args)
     try:
         query = utils.query_to_search(args, product=product)
-    except ValueError as e:  # invalid query val
-        abort(400, str(e))
     except ParserError:
         abort(400, "Invalid datetime format")
+    except ValueError as e:  # invalid query val
+        abort(400, str(e))
     except decimal.InvalidOperation:
         abort(400, "Could not convert value to decimal")
 


### PR DESCRIPTION
ValueError is a superclass
of ParserError, so catch
the ParserError before
to get the specific
error handling for bad
datetimes.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--789.org.readthedocs.build/en/789/

<!-- readthedocs-preview datacube-explorer end -->