### PR TITLE
index: remove faulty type annotation

### DIFF
--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -1104,8 +1104,6 @@ class ExplorerIndex(ExplorerAbstractIndex):
     @override
     def mapped_crses(self, product, srid_expression):
         with self.index._active_connection() as conn:
-            # SQLAlchemy queries require "column == None", not "column is None" due to operator overloading:
-            # pylint: disable=singleton-comparison
             res = conn.execute(
                 select(
                     literal(product.name).label("product"),

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -468,7 +468,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     @override
     def latest_arrivals(self, period_length: timedelta) -> Result:
         with self.engine.begin() as conn:
-            latest_arrival_date: datetime = conn.execute(
+            latest_arrival_date = conn.execute(
                 text("select max(added) from odc.dataset;")
             ).scalar()
             if latest_arrival_date is None:
@@ -874,7 +874,8 @@ class ExplorerIndex(ExplorerAbstractIndex):
     def schema_compatible_info(self, for_writing_operations_too=False):
         """
         Schema compatibility information
-        postgis version, if schema has latest changes (optional: and has updated column)
+        postgis version, if schema has the latest changes
+        (optional: and has updated column).
         """
         with self.engine.begin() as conn:
             return (

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -1136,8 +1136,6 @@ class ExplorerIndex(ExplorerAbstractIndex):
     @override
     def mapped_crses(self, product, srid_expression):
         with self.index._active_connection() as conn:
-            # SQLAlchemy queries require "column == None", not "column is None" due to operator overloading:
-            # pylint: disable=singleton-comparison
             res = conn.execute(
                 select(
                     literal(product.name).label("product"),

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -482,7 +482,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     @override
     def latest_arrivals(self, period_length: timedelta) -> Result:
         with self.engine.begin() as conn:
-            latest_arrival_date: datetime = conn.execute(
+            latest_arrival_date = conn.execute(
                 text("select max(added) from agdc.dataset;")
             ).scalar()
             if latest_arrival_date is None:
@@ -913,7 +913,8 @@ class ExplorerIndex(ExplorerAbstractIndex):
     ) -> tuple[str, bool]:
         """
         Schema compatibility information
-        postgis version, if schema has latest changes (optional: and has updated column)
+        postgis version, if schema has the latest changes
+        (optional: and has updated column)
         """
         with self.engine.begin() as conn:
             return _schema.get_postgis_versions(conn), _schema.is_compatible_schema(


### PR DESCRIPTION
The next line checks if the value
is None, so the annotation is clearly
faulty.

Also remove an old comment that comments
about overloaded ==, but the code now uses `is_()`.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--793.org.readthedocs.build/en/793/

<!-- readthedocs-preview datacube-explorer end -->