### PR TITLE
Dockerfile: stop installing psql

### DIFF
--- a/.docker/create_db.sh
+++ b/.docker/create_db.sh
@@ -1,3 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-PGPASSWORD=${POSTGRES_PASSWORD} psql -h ${POSTGRES_HOSTNAME} -U ${POSTGRES_USER} -c 'create database opendatacube_test'
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOF
+  CREATE DATABASE opendatacube_test;
+EOF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,6 @@ jobs:
           export LOCAL_UID=$(id -u $USER)
           export LOCAL_GID=$(id -g $USER)
           make up-d
-          make create-test-db-docker
           make test-docker
 
       - name: Upload coverage to Codecov

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -380,7 +380,7 @@ When you have some ODC data indexed, you can run ``make index`` to create the Ex
 
 Once Explorer indexes have been created, you can browse the running application at `http://localhost:5000 <http://localhost:5000>`__
 
-You can run tests by first creating a test database ``make create-test-db-docker`` and then running tests with ``make test-docker``.
+You can run tests with ``make test-docker``.
 
 And you can run a single test in Docker using a command like this: ``docker-compose --file docker-compose.yml run explorer pytest integration_tests/test_dataset_listing.py``
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,8 +85,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
             gosu \
-            # For .docker/create_db.sh.
-            postgresql-client \
+            libpq5 \
             tini \
     && mkdir /app \
     && chown ubuntu:ubuntu /app

--- a/Makefile
+++ b/Makefile
@@ -112,10 +112,6 @@ force-refresh: ## Entirely refresh the Explorer tables in Docker
 	docker compose exec -T explorer \
 		cubedash-gen --force-refresh --refresh-stats --all
 
-create-test-db-docker: ## Create a test database inside Docker
-	docker compose run --rm -T explorer \
-		bash /code/.docker/create_db.sh
-
 lint-docker: ## Run linting inside inside Docker
 	docker compose run --rm explorer \
 		make lint

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ When you have some ODC data indexed, you can run `make index` to create the Expl
 
 Once Explorer indexes have been created, you can browse the running application at [http://localhost:5000](http://localhost:5000).
 
-You can run tests by first creating a test database `make create-test-db-docker` and then running tests with `make test-docker`.
+You can run tests with `make test-docker`.
 
 And you can run a single test in Docker using a command like this: `docker-compose --file docker-compose.yml run explorer pytest integration_tests/test_dataset_listing.py`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - "35433:35433"
     restart: always
     volumes:
+      - ./.docker/create_db.sh:/docker-entrypoint-initdb.d/create-pg-databases.sh
       - type: tmpfs
         target: /var/lib/postgresql/data
     command: -c fsync=off -c full_page_writes=off -c synchronous_commit=off

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - "35433:35433"
     restart: always
     volumes:
+      # See https://hub.docker.com/_/postgres/#initialization-scripts
+      # Create `opendatacube_test` database in addition to `opendatacube`
       - ./.docker/create_db.sh:/docker-entrypoint-initdb.d/create-pg-databases.sh
       - type: tmpfs
         target: /var/lib/postgresql/data


### PR DESCRIPTION
Create the test database when starting
the postgis container instead of doing
it from the client side.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--799.org.readthedocs.build/en/799/

<!-- readthedocs-preview datacube-explorer end -->