### PR TITLE
CI: split into multiple test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,21 @@ concurrency:
 
 jobs:
   integration-tests:
-    timeout-minutes: 55
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    strategy:
+      matrix:
+        # Tests take a long time, so split them over multiple CI jobs.
+        # Ignoring tests inverts the logic which makes it harder to understand,
+        # but ignoring tests ensures that any added test will be run by at least
+        # one CI job, even if the test was added outside the current structure.
+        ignored-tests:
+        - "test_{[a-oq-z],pages}" # Tests test_page_loads
+        - "test_{[a-rt-z],s2,stores,su}" # Tests test_stac
+        - "test_{[a-rt-z],s2,stac,stores}" # Tests test_summarise_data
+        - "test_{page_,stac,summarise}" # Tests remaining tests
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -63,11 +74,17 @@ jobs:
           SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
       - name: Run tests
+        shell: bash
         run: |
+          files=$(ls integration_tests/${{ matrix.ignored-tests }}*.py)
+          [ $? = 0 ] || (echo "Listing tests failed" && exit 1)
+          for f in $files; do
+            ig="$ig --ignore=$f";
+          done
           export LOCAL_UID=$(id -u $USER)
           export LOCAL_GID=$(id -g $USER)
           make up-d
-          make test-docker
+          make PYTEST_PARAMS="$ig" test-docker
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
@@ -76,6 +93,17 @@ jobs:
           disable_search: true
           fail_ci_if_error: false
           use_oidc: true
+
+  test-package:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    needs: integration-tests
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3

--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,11 @@ cubedash/static/overview.js: cubedash/static/overview.ts
 
 .PHONY: test
 test: ## Run tests using pytest
-	pytest --cov=cubedash --cov-report=xml -r sx --durations=5
+	pytest $(PYTEST_PARAMS) --cov=cubedash --cov-report=xml -r sx --durations=5
 
 .PHONY: testcov
 testcov:
-	pytest --cov=cubedash
+	pytest $(PYTEST_PARAMS) --cov=cubedash
 	@echo "building coverage html"
 	@coverage html
 
@@ -118,4 +118,5 @@ lint-docker: ## Run linting inside inside Docker
 
 test-docker: ## Run tests inside Docker
 	docker compose run --rm explorer \
-		bash --login -c "cd /code && pytest --cov=cubedash --cov-report=xml -r sx --durations=5"
+		bash --login -c \
+		  "cd /code && pytest $(PYTEST_PARAMS) --cov=cubedash --cov-report=xml -r sx --durations=5"


### PR DESCRIPTION
We get 20 concurrent CI runners, so this should reduce the time it takes to run the CI on a pull request.

The split makes a PR complete all the workflows in 12-14 minutes instead of 30-33 minutes. This is especially important if the intermittent "closed cursor" error happens, since a single job can be retriggered and the results are completed within 15 minutes.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--800.org.readthedocs.build/en/800/

<!-- readthedocs-preview datacube-explorer end -->