### PR TITLE
pytest: only doctest relevant files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include cubedash/_version.py
+exclude cubedash/conftest.py
 graft cubedash/data
 graft cubedash/static
 graft cubedash/templates

--- a/cubedash/conftest.py
+++ b/cubedash/conftest.py
@@ -8,7 +8,7 @@ from pathlib import Path
 # The only thing tested under this directory is doctests, so only collect
 # files that need testing (=have lines starting with whitespace + ">>>").
 #
-# This isn't a performance consideration, but is to 
+# This isn't a performance consideration, but is to
 # avoid triggering spurious deprecation warnings
 def pytest_ignore_collect(collection_path: Path) -> bool:
     if collection_path.is_dir():

--- a/cubedash/conftest.py
+++ b/cubedash/conftest.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 # The only thing tested under this directory is doctests, so only collect
 # files that need testing (=have lines starting with whitespace + ">>>").
+#
+# This isn't a performance consideration, but is to 
+# avoid triggering spurious deprecation warnings
 def pytest_ignore_collect(collection_path: Path) -> bool:
     if collection_path.is_dir():
         return False

--- a/cubedash/conftest.py
+++ b/cubedash/conftest.py
@@ -1,0 +1,16 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2025 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+
+# The only thing tested under this directory is doctests, so only collect
+# files that need testing (=have lines starting with whitespace + ">>>").
+def pytest_ignore_collect(collection_path: Path) -> bool:
+    if collection_path.is_dir():
+        return False
+    if collection_path.suffix != ".py":
+        return True
+    with collection_path.open() as f:
+        return not any(line.strip().startswith(">>>") for line in f)


### PR DESCRIPTION
Avoid collecting files under cubedash/
unless they need to be tested (=contain
lines that start with whitespace followed
by ">>>").

This aligns with datacube-core and
minimizes the risk of triggering
deprecation warnings.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--801.org.readthedocs.build/en/801/

<!-- readthedocs-preview datacube-explorer end -->