### PR TITLE
utils: remove old workaround

### DIFF
--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -179,8 +179,8 @@ def as_external_url(
     >>> as_external_url('s3://some-data/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml', "ap-southeast-2")
     'https://some-data.s3.ap-southeast-2.amazonaws.com/L2/S2A_OPER_MSI_ARD__A030100_T56LNQ_N02.09/ARD-METADATA.yaml'
     >>> # Other URLs are left as-is
-    >>> unconvertable_url = 'file:///g/data/xu18/ga_ls8c_ard_3-1-0_095073_2019-03-22_final.odc-metadata.yaml'
-    >>> unconvertable_url == as_external_url(unconvertable_url)
+    >>> unconvertible_url = 'file:///g/data/xu18/ga_ls8c_ard_3-1-0_095073_2019-03-22_final.odc-metadata.yaml'
+    >>> unconvertible_url == as_external_url(unconvertible_url)
     True
     >>> as_external_url('some/relative/path.txt')
     'some/relative/path.txt'
@@ -543,7 +543,7 @@ def as_geojson(o, downloadable_filename_prefix: str | None = None):
 def common_uri_prefix(uris: Sequence[str]):
     """
     This is like `os.path.commonpath()`, but always expects URL paths.
-    (ie. forward slashes in all environments, and wont strip double slashes '//')
+    (i.e. forward slashes in all environments, and will not strip double slashes '//')
 
     >>> common_uri_prefix(['file:///a/thing-1.txt'])
     'file:///a/thing-1.txt'

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -386,7 +386,7 @@ def as_time_range(
     return Range(start.replace(tzinfo=tzinfo), end.replace(tzinfo=tzinfo))
 
 
-def _parse_url_query_args(request: MultiDict, product: Product) -> dict:
+def _parse_url_query_args(request: MultiDict, product: Product) -> dict[str, Any]:
     """
     Convert search arguments from url query args into datacube index search parameters
     """
@@ -597,8 +597,8 @@ def suggest_download_filename(
 
 
 def as_yaml(
-    *o, content_type="text/yaml", downloadable_filename_prefix: str | None = None
-):
+    *o, content_type: str = "text/yaml", downloadable_filename_prefix: str | None = None
+) -> flask.Response:
     """
     Return a yaml response.
 
@@ -634,7 +634,7 @@ def as_yaml(
 _ALNUM_PATTERN = re.compile("[^0-9a-zA-Z]+")
 
 
-def only_alphanumeric(s: str):
+def only_alphanumeric(s: str) -> str:
     """
     Strip any chars that aren't simple alphanumeric.
 

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -162,8 +162,8 @@ def as_resolved_remote_url(location: str | None, offset: str) -> str:
     Convert a dataset location and file offset to a full remote URL.
     """
     return as_external_url(
-        urljoin(location, offset),
-        (flask.current_app.config.get("CUBEDASH_DATA_S3_REGION", "ap-southeast-2")),
+        urljoin(location or "", offset),
+        flask.current_app.config.get("CUBEDASH_DATA_S3_REGION", "ap-southeast-2"),
         location is None,
     )
 

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -17,7 +17,6 @@ from urllib.parse import urljoin, urlparse
 
 import eodatasets3.serialise
 import flask
-import numpy as np
 import shapely.geometry
 import shapely.validation
 import structlog
@@ -605,25 +604,7 @@ def as_yaml(
     Multiple args will return a multi-doc yaml file.
     """
     stream = StringIO()
-
-    # TODO: remove the two functions once eo-datasets fix is released
-    def _represent_float(self, value):
-        text = np.format_float_scientific(value)
-        return self.represent_scalar("tag:yaml.org,2002:float", text)
-
-    def dumps_yaml(yml, stream, *docs) -> None:
-        """Dump yaml through a stream, using the default serialisation settings."""
-        return yml.dump_all(docs, stream=stream)
-
-    yml = eodatasets3.serialise._init_yaml()
-
-    # extend from eodatasets3 serialise
-    yml.representer.add_representer(float, _represent_float)
-    dumps_yaml(yml, stream, *o)
-    # ENDTODO
-
-    # TODO: once upstream is fixed, use the below line only
-    # eodatasets3.serialise.dumps_yaml(stream, *o)
+    eodatasets3.serialise.dumps_yaml(stream, *o)
     response = flask.Response(stream.getvalue(), content_type=content_type)
     if downloadable_filename_prefix:
         suggest_download_filename(response, downloadable_filename_prefix, ".yaml")


### PR DESCRIPTION
This entered the tree in #399,
so the fix in eodatasets3 has
been merged for a while.

Also add a couple of commits that
fixes types/doc strings.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--808.org.readthedocs.build/en/808/

<!-- readthedocs-preview datacube-explorer end -->