### PR TITLE
ProductSummary: store time as tuple

### DIFF
--- a/cubedash/_audit.py
+++ b/cubedash/_audit.py
@@ -26,7 +26,7 @@ class ProductTiming:
 def product_timings() -> Iterable[ProductTiming]:
     """
     How long does it take to query a day?
-    Useful for finding missing time indexes..
+    Useful for finding missing time indexes.
     """
     done = 0
     store = _model.STORE

--- a/cubedash/_audit.py
+++ b/cubedash/_audit.py
@@ -36,11 +36,12 @@ def product_timings() -> Iterable[ProductTiming]:
         if not p:
             _LOG.info("product_no_summarised", product_name=product_name)
             continue
-        if not p.dataset_count or not p.time_earliest or not p.time_latest:
+        if not p.dataset_count or p.full_time is None:
             yield ProductTiming(product_name, dataset_count=0)
             continue
         done += 1
-        middle_period = p.time_earliest + (p.time_latest - p.time_earliest) / 2
+        time_earliest, time_latest = p.full_time
+        middle_period = time_earliest + (time_latest - time_earliest) / 2
         day = middle_period.replace(hour=0, minute=0, second=0)
 
         start = time.time()

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -197,10 +197,11 @@ def search_page(
         if not isinstance(search_time, Range):
             search_time = Range(search_time, search_time + timedelta(days=1))
         # If they left one end of the range open, fill it in with the product bounds.
-        if product_summary:
+        if product_summary and product_summary.full_time is not None:
+            time_earliest, time_latest = product_summary.full_time
             search_time = Range(
-                search_time.begin or product_summary.time_earliest,
-                search_time.end or product_summary.time_latest + timedelta(days=1),
+                search_time.begin or time_earliest,
+                search_time.end or time_latest + timedelta(days=1),
             )
         query["time"] = search_time
 
@@ -209,9 +210,9 @@ def search_page(
         creation_time = query["creation_time"]
         if not isinstance(creation_time, Range):
             creation_time = Range(creation_time, creation_time + timedelta(days=1))
-        if product_summary:
+        if product_summary and product_summary.full_time is not None:
             creation_time = Range(
-                creation_time.begin or product_summary.time_earliest,
+                creation_time.begin or product_summary.full_time[0],
                 # product time bounds don't necessarily include the creation time
                 # so use today's date instead as our end bound if needed
                 creation_time.end or datetime.now(timezone.utc),
@@ -244,10 +245,14 @@ def search_page(
         )
 
     # For display on the page (and future searches).
-    if "time" not in query and product_summary and product_summary.time_earliest:
+    if (
+        "time" not in query
+        and product_summary
+        and product_summary.full_time is not None
+    ):
         query["time"] = Range(
-            product_summary.time_earliest,
-            product_summary.time_latest + timedelta(days=1),
+            product_summary.full_time[0],
+            product_summary.full_time[1] + timedelta(days=1),
         )
 
     return utils.render(

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -102,9 +102,8 @@ class GenerateResult(Enum):
 class ProductSummary:
     name: str
     dataset_count: int
-    # Null when dataset_count == 0
-    time_earliest: datetime | None
-    time_latest: datetime | None
+    # Tuple of (time_earliest, time_latest), None when dataset_count == 0.
+    full_time: tuple[datetime, datetime] | None
 
     source_products: list[str]
     derived_products: list[str]
@@ -130,15 +129,12 @@ class ProductSummary:
         """
         Iterate through all months in its time range.
         """
-        if (
-            self.dataset_count == 0
-            or self.time_earliest is None
-            or self.time_latest is None
-        ):
+        if self.dataset_count == 0 or self.full_time is None:
             return
 
-        start = self.time_earliest.astimezone(grouping_timezone)
-        end = self.time_latest.astimezone(grouping_timezone)
+        time_earliest, time_latest = self.full_time
+        start = time_earliest.astimezone(grouping_timezone)
+        end = time_latest.astimezone(grouping_timezone)
         if start > end:
             raise ValueError(f"Start date must precede end date ({start} < {end})")
 
@@ -366,6 +362,8 @@ class SummaryStore:
            3) They have month-records that are newer than our year-record.
         """
         product = self.get_product_summary(product_name)
+        if product is None:
+            return []
 
         # Years that have already been summarised
         summarised_years = {
@@ -374,15 +372,16 @@ class SummaryStore:
         }
 
         # Empty product? No years
-        if product.dataset_count == 0:
+        if product.dataset_count == 0 or product.full_time is None:
             # check if the timeoverview needs cleanse
             return list(summarised_years)
 
+        time_earliest, time_latest = product.full_time
         # All years we are expected to have
         expected_years = set(
             range(
-                product.time_earliest.astimezone(self.grouping_timezone).year,
-                product.time_latest.astimezone(self.grouping_timezone).year + 1,
+                time_earliest.astimezone(self.grouping_timezone).year,
+                time_latest.astimezone(self.grouping_timezone).year + 1,
             )
         )
 
@@ -476,8 +475,7 @@ class SummaryStore:
         new_summary = ProductSummary(
             product.name,
             total_count,
-            earliest,
-            latest,
+            (earliest, latest),
             source_products=source_products,
             derived_products=derived_products,
             fixed_metadata=fixed_metadata,
@@ -711,9 +709,14 @@ class SummaryStore:
         derived_products = [
             self._product_by_id(id_).name for id_ in row.pop("derived_product_refs")
         ]
+        time_earliest: datetime | None = row.pop("time_earliest")
+        time_latest: datetime | None = row.pop("time_latest")
 
         return ProductSummary(
             name=name,
+            full_time=None
+            if time_earliest is None or time_latest is None
+            else (time_earliest, time_latest),
             source_products=source_products,
             derived_products=derived_products,
             **row,
@@ -804,10 +807,12 @@ class SummaryStore:
         derived_product_ids = [
             self.get_product(name).id for name in product.derived_products
         ]
+        time_earliest = None if product.full_time is None else product.full_time[0]
+        time_latest = None if product.full_time is None else product.full_time[1]
         fields = dict(
             dataset_count=product.dataset_count,
-            time_earliest=product.time_earliest,
-            time_latest=product.time_latest,
+            time_earliest=time_earliest,
+            time_latest=time_latest,
             source_product_refs=source_product_ids,
             derived_product_refs=derived_product_ids,
             fixed_metadata=product.fixed_metadata,
@@ -1171,12 +1176,13 @@ class SummaryStore:
             )
 
         # Product. Does it have data?
-        elif product.dataset_count > 0:
+        elif product.dataset_count > 0 and product.full_time is not None:
+            time_earliest, time_latest = product.full_time
             summary = TimePeriodOverview.add_periods(
                 self.get(product.name, year_, None, None)
                 for year_ in range(
-                    product.time_earliest.astimezone(self.grouping_timezone).year,
-                    product.time_latest.astimezone(self.grouping_timezone).year + 1,
+                    time_earliest.astimezone(self.grouping_timezone).year,
+                    time_latest.astimezone(self.grouping_timezone).year + 1,
                 )
             )
         else:

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -99,10 +99,10 @@ def cli(
 
     if product.dataset_count:
         echo(
-            f"from {'Unknown' if product.time_earliest is None else product.time_earliest.isoformat()} "
+            f"from {'Unknown' if product.full_time is None else product.full_time[0].isoformat()} "
         )
         echo(
-            f"  to {'Unknown' if product.time_latest is None else product.time_latest.isoformat()} "
+            f"  to {'Unknown' if product.full_time is None else product.full_time[1].isoformat()} "
         )
 
     echo()

--- a/integration_tests/test_stores.py
+++ b/integration_tests/test_stores.py
@@ -118,7 +118,7 @@ def test_month_iteration() -> None:
         __tracebackhide__ = operator.methodcaller("errisinstance", AssertionError)
 
         product = ProductSummary(
-            "test_product", 5, start, end, [], [], {}, datetime.now()
+            "test_product", 5, (start, end), [], [], {}, datetime.now()
         )
         got_months = list(product.iter_months())
         assert got_months == expected_months, "Incorrect set of iterated months"
@@ -179,8 +179,7 @@ def test_put_get_summaries(summary_store: SummaryStore) -> None:
         ProductSummary(
             product_name,
             4321,
-            datetime(2017, 1, 1),
-            datetime(2017, 4, 1),
+            (datetime(2017, 1, 1), datetime(2017, 4, 1)),
             [],
             [],
             {},


### PR DESCRIPTION
Combine the time_earliest and time_latest
fields in the ProductSummary, so the summary
will either have both an earliest and a latest
time, or no time at all, never just one
of them.

This fixes about a dozen errors from
the type checker.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--810.org.readthedocs.build/en/810/

<!-- readthedocs-preview datacube-explorer end -->