### PR TITLE
CI: make twine check strict

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Build Packages
         run: |
           uv build
-          uv tool run twine check dist/*
+          uv tool run twine check --strict dist/*
 
       # Uses to OIDC identification between GitHub and PyPI
       - name: Upload package to PyPI on GitHub Release


### PR DESCRIPTION
This will cause the job to fail
if there are package warnings.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--813.org.readthedocs.build/en/813/

<!-- readthedocs-preview datacube-explorer end -->