### PR TITLE
stores: abort refresh early

### DIFF
--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -485,32 +485,23 @@ class SummaryStore:
         )
 
         # TODO: This is an expensive operation. We regenerate them all every time there are changes.
-        self._refresh_product_regions(product)
-
-        self._persist_product_extent(new_summary)
-        return change_count, new_summary
-
-    def _refresh_product_regions(self, product: Product) -> int:
         log = _LOG.bind(product_name=product.name)  # , engine=str(self._engine))
         log.info("refresh.regions.start")
-
         log.info("refresh.regions.update.count.and.insert.new")
-
         result = self.e_index.upsert_product_regions(product.id)
         log.info("refresh.regions.inserted", list(result))
-        changed_rows = result.rowcount
         log.info(
-            "refresh.regions.update.count.and.insert.new.end", changed_rows=changed_rows
+            "refresh.regions.update.count.and.insert.new.end",
+            changed_rows=result.rowcount,
         )
-
         # delete region rows with no related datasets in dataset_spatial table
         log.info("refresh.regions.delete.empty.regions")
         result = self.e_index.delete_product_empty_regions(product.id)
-        changed_rows = result.rowcount
         log.info("refresh.regions.delete.empty.regions.end")
+        log.info("refresh.regions.end", changed_regions=result.rowcount)
 
-        log.info("refresh.regions.end", changed_regions=changed_rows)
-        return changed_rows
+        self._persist_product_extent(new_summary)
+        return change_count, new_summary
 
     def refresh_stats(self, concurrently: bool = False) -> None:
         """

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -423,7 +423,7 @@ class SummaryStore:
         scan_for_deleted: bool = False,
         only_those_newer_than: datetime | None = None,
         force: bool = False,
-    ) -> tuple[int, ProductSummary]:
+    ) -> tuple[int, ProductSummary] | None:
         """
         Update Explorer's computed extents for the given product, and record any new
         datasets into the spatial table.
@@ -454,6 +454,8 @@ class SummaryStore:
             self._persist_product_extent(new_summary)
             return 0, new_summary
 
+        if product.id is None:
+            return None
         # if change_count or force_dataset_extent_recompute:
         earliest, latest, total_count = self.e_index.product_time_overview(product.id)
 
@@ -1209,7 +1211,7 @@ class SummaryStore:
         recreate_dataset_extents: bool = False,
         reset_incremental_position: bool = False,
         minimum_change_scan_window: timedelta | None = None,
-    ) -> tuple[GenerateResult, TimePeriodOverview]:
+    ) -> tuple[GenerateResult, TimePeriodOverview | None]:
         """
         Update Explorer's information and summaries for a product.
 
@@ -1272,13 +1274,16 @@ class SummaryStore:
                 self._database_time_now() - minimum_change_scan_window,
             )
 
-        extent_changes, new_product = self.refresh_product_extent(
+        rv = self.refresh_product_extent(
             product_name,
             scan_for_deleted=recreate_dataset_extents or force,
             only_those_newer_than=(
                 None if recreate_dataset_extents else only_datasets_newer_than
             ),
         )
+        if rv is None:
+            return GenerateResult.ERROR, None
+        extent_changes, new_product = rv
         log.info("extent.refresh.done", changed=extent_changes)
 
         refresh_timestamp = new_product.last_refresh_time


### PR DESCRIPTION
Return None and signal ERROR when getting a product without ID.

Also inline a single-use method to unconfuse MyPy about the invariants
that hold. There is already a TODO comment at the call site, so this code will
be reworked later.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--820.org.readthedocs.build/en/820/

<!-- readthedocs-preview datacube-explorer end -->