### PR TITLE
Multiplatform/arch uv support in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ ENV LC_ALL=C.UTF-8 \
     PYTHONFAULTHANDLER=1 \
     PYTHONUNBUFFERED=1
 
+# This cannot be inlined below (e.g., COPY --from=...) because Dependabot does not support that syntax yet
+FROM ghcr.io/astral-sh/uv:0.8.15@sha256:a5727064a0de127bdb7c9d3c1383f3a9ac307d9f2d8a391edc7896c54289ced0 AS uv
+
 FROM base AS builder
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -39,7 +42,7 @@ ENV UV_COMPILE_BYTECODE=0 \
 
 WORKDIR /build
 
-COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
+COPY --link --from=uv /uv /uvx /usr/local/bin/
 
 COPY --link pyproject.toml uv.lock /build/
 
@@ -85,6 +88,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
             tini \
     && mkdir /app \
     && chown ubuntu:ubuntu /app
+
 # In the "deployment" build, these `uv` binaries will be 0 bytes.
 # In the "test" build they're the actual `uv` tools.
 COPY --from=builder --link /usr/local/bin/uv* /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ ENV LC_ALL=C.UTF-8 \
 
 FROM base AS builder
 
-ARG UV=https://github.com/astral-sh/uv/releases/download/0.8.6/uv-x86_64-unknown-linux-gnu.tar.gz
-
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     export DEBIAN_FRONTEND=noninteractive \
@@ -41,9 +39,7 @@ ENV UV_COMPILE_BYTECODE=0 \
 
 WORKDIR /build
 
-ADD --checksum=sha256:5429c9b96cab65198c2e5bfe83e933329aa16303a0369d5beedc71785a4a2f36 --chown=root:root --chmod=644 --link $UV uv.tar.gz
-
-RUN tar xf uv.tar.gz -C /usr/local/bin --strip-components=1 --no-same-owner
+COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
 
 COPY --link pyproject.toml uv.lock /build/
 


### PR DESCRIPTION
The Docker Image here was failing to build for me on an ARM Mac, because it was using a Linux ARM base image with an x64 binary of uv.

Install uv from a distroless docker image instead of downloading the binary directly. This is documented at [uv_docker] and is an easy way to support multiple platforms/architectures.

[uv_docker]: https://docs.astral.sh/uv/guides/integration/docker/#installing-uv

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--826.org.readthedocs.build/en/826/

<!-- readthedocs-preview datacube-explorer end -->