### PR TITLE
Fix crash caused by faulty call to logger

### DIFF
--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -489,7 +489,7 @@ class SummaryStore:
         log.info("refresh.regions.start")
         log.info("refresh.regions.update.count.and.insert.new")
         result = self.e_index.upsert_product_regions(product.id)
-        log.info("refresh.regions.inserted", list(result))
+        log.info("refresh.regions.inserted", result=list(result))
         log.info(
             "refresh.regions.update.count.and.insert.new.end",
             changed_rows=result.rowcount,


### PR DESCRIPTION
I was setting up a local database for testing Explorer, and `cubedash-gen` was throwing stack traces left right and center at me.

It only occurred with multiple jobs, which is the default. 

I suspected it's something we're doing wrong with `structlog`, on the [structlog Performance](https://www.structlog.org/en/stable/performance.html) page it says to not use `cache_logger_on_first_use=True` if you're passing loggers around with `multiprocessing`, which is what `cubedash-gen` uses for running in parallel.

But, that didn't fix it.

What did fix it was changing the line that was the top of the exception to take a kwarg instead of an arg. I don't know why this works, but, it does, and I've spent too long debugging! 

```
2025-09-05 15:22:22 [error    ] product.error                  product=abares_clum_2023
Traceback (most recent call last):
  File "/Users/aye011/dev/odc/datacube-explorer/cubedash/generate.py", line 136, in generate_report
    result, updated_summary = store.refresh(
                              ^^^^^^^^^^^^^^
  File "/Users/aye011/dev/odc/datacube-explorer/cubedash/summary/_stores.py", line 1289, in refresh
    rv = self.refresh_product_extent(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aye011/dev/odc/datacube-explorer/cubedash/summary/_stores.py", line 488, in refresh_product_extent
    self._refresh_product_regions(product)
  File "/Users/aye011/dev/odc/datacube-explorer/cubedash/summary/_stores.py", line 500, in _refresh_product_regions
    log.info("refresh.regions.inserted", list(result))
  File "/Users/aye011/dev/odc/datacube-explorer/.venv/lib/python3.12/site-packages/structlog/_native.py", line 146, in meth
    return self._proxy_to_logger(name, event % args, **kw)
                                       ~~~~~~^~~~~~
TypeError: not all arguments converted during string formatting
2025-09-05 15:22:22 [error    ] product.error                  product=abares_clum_2020
Traceback (most recent call last):
  File "/Users/aye011/dev/odc/datacube-explorer/cubedash/generate.py", line 136, in generate_report
    result, updated_summary = store.refresh(
                              ^^^^^^^^^^^^^^
  File "/Users/aye011/dev/odc/datacube-explorer/cubedash/summary/_stores.py", line 1289, in refresh
    rv = self.refresh_product_extent(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aye011/dev/odc/datacube-explorer/cubedash/summary/_stores.py", line 488, in refresh_product_extent
    self._refresh_product_regions(product)
  File "/Users/aye011/dev/odc/datacube-explorer/cubedash/summary/_stores.py", line 500, in _refresh_product_regions
    log.info("refresh.regions.inserted", list(result))
  File "/Users/aye011/dev/odc/datacube-explorer/.venv/lib/python3.12/site-packages/structlog/_native.py", line 146, in meth
    return self._proxy_to_logger(name, event % args, **kw)
                                       ~~~~~~^~~~~~
TypeError: not all arguments converted during string formatting
```

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--829.org.readthedocs.build/en/829/

<!-- readthedocs-preview datacube-explorer end -->