### PR TITLE
CI: do not cancel matrix jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
     permissions:
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
         # Tests take a long time, so split them over multiple CI jobs.
         # Ignoring tests inverts the logic which makes it harder to understand,


### PR DESCRIPTION
The majority of failures come from
intermittent issues, so stop
cancelling all other jobs just because
one of the test jobs fail so it
is easier to re-run the failing job.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--834.org.readthedocs.build/en/834/

<!-- readthedocs-preview datacube-explorer end -->