### PR TITLE
Add a 'dev' dependency group to make development easier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ doc = [
     "sphinx-click",
     "sphinx-tabs",
 ]
+dev = [
+    "datacube-explorer[deployment,test]",
+    {include-group = "doc"}
+]
 
 [project.optional-dependencies]
 deployment = [

--- a/uv.lock
+++ b/uv.lock
@@ -728,6 +728,19 @@ test = [
 ]
 
 [package.dev-dependencies]
+dev = [
+    { name = "autodocsumm" },
+    { name = "beautifulsoup4" },
+    { name = "datacube-explorer", extra = ["deployment", "test"] },
+    { name = "nbsphinx" },
+    { name = "pydata-sphinx-theme" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx-autodoc-typehints", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-click" },
+    { name = "sphinx-tabs" },
+]
 doc = [
     { name = "autodocsumm" },
     { name = "beautifulsoup4" },
@@ -798,6 +811,17 @@ requires-dist = [
 provides-extras = ["deployment", "test"]
 
 [package.metadata.requires-dev]
+dev = [
+    { name = "autodocsumm" },
+    { name = "beautifulsoup4" },
+    { name = "datacube-explorer", extras = ["deployment", "test"] },
+    { name = "nbsphinx" },
+    { name = "pydata-sphinx-theme" },
+    { name = "sphinx" },
+    { name = "sphinx-autodoc-typehints" },
+    { name = "sphinx-click" },
+    { name = "sphinx-tabs" },
+]
 doc = [
     { name = "autodocsumm" },
     { name = "beautifulsoup4" },
@@ -1279,7 +1303,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [


### PR DESCRIPTION
This allows all the nice `uv` things to work, like `uv run pytest`.

I've left the old `optional-dependencies` `test` section there for now, since it's referenced in the Makefile and README.



<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--835.org.readthedocs.build/en/835/

<!-- readthedocs-preview datacube-explorer end -->