### PR TITLE
index: fail when no SRID is found

### DIFF
--- a/cubedash/index/postgis/_schema.py
+++ b/cubedash/index/postgis/_schema.py
@@ -350,6 +350,8 @@ def init_elements(conn: Connection, grouping_epsg_code: int):
 
     # If they specified an epsg code, make sure the existing schema uses it.
     srid = conn.execute(select(FOOTPRINT_SRID_EXPRESSION)).scalar()
+    if srid is None:
+        raise RuntimeError("No SRID found in database")
     crs_used_by_schema = get_srid_name(conn, srid)
     # hopefully default epsg wouldn't case an issue?
     if crs_used_by_schema != f"EPSG:{grouping_epsg_code}":

--- a/cubedash/index/postgres/_schema.py
+++ b/cubedash/index/postgres/_schema.py
@@ -466,6 +466,8 @@ def init_elements(conn: Connection, grouping_epsg_code: int):
 
     # If they specified an epsg code, make sure the existing schema uses it.
     srid = conn.execute(select(FOOTPRINT_SRID_EXPRESSION)).scalar()
+    if srid is None:
+        raise RuntimeError("No SRID found in database")
     crs_used_by_schema = get_srid_name(conn, srid)
     # hopefully default epsg wouldn't case an issue?
     if crs_used_by_schema != f"EPSG:{grouping_epsg_code}":


### PR DESCRIPTION
Casting None to integer is not going
to make the database happy, so fail
when we detect the problem instead.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--837.org.readthedocs.build/en/837/

<!-- readthedocs-preview datacube-explorer end -->