### PR TITLE
stores: check for product earlier

### DIFF
--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -619,6 +619,9 @@ class SummaryStore:
         month: int | None = None,
         day: int | None = None,
     ) -> TimePeriodOverview | None:
+        product = self.get_product_summary(product_name)
+        if product is None:
+            return None
         period, start_day = TimePeriodOverview.flat_period_representation(
             year, month, day
         )
@@ -627,11 +630,8 @@ class SummaryStore:
             return self._summariser.calculate_summary(
                 product_name, year, month, day, datetime.now()
             )
-
-        product = self.get_product_summary(product_name)
-        if product is None or product.id_ is None:
+        if product.id_ is None:
             return None
-
         res = self.e_index.product_time_summary(
             product.id_, start_day, period
         ).fetchone()

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -978,6 +978,8 @@ def test_all_give_404s(client: FlaskClient) -> None:
     expect_404(f"/dataset/{dataset_id}")
     expect_404(f"/dataset/{dataset_id}.odc-metadata.yaml")
 
+    expect_404("/dataset-timeline/non_existent/2025")
+
 
 def test_invalid_query_gives_400(client: FlaskClient) -> None:
     """


### PR DESCRIPTION
Without this, the 404 can't be
returned from the dataset-timelines
test.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--840.org.readthedocs.build/en/840/

<!-- readthedocs-preview datacube-explorer end -->