### PR TITLE
generate: autodetect number of jobs

### DIFF
--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -61,6 +61,7 @@ from collections.abc import Generator, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import partial
+from os import sched_getaffinity
 from textwrap import dedent
 
 import click
@@ -301,10 +302,11 @@ class TimeDeltaParam(click.ParamType):
     "-j",
     "--jobs",
     type=int,
-    default=3,
+    default=min(len(sched_getaffinity(0)), 16),
     help=dedent(
         """\
-        Number of concurrent worker subprocesses to use (default: 3)
+        Number of concurrent worker subprocesses to use
+        (default: number of cores or 16, whichever is smaller)
 
         This should match how many io-and-cpu-heavy queries your DB would
         like to handle concurrently.


### PR DESCRIPTION
Detect the number of cores in the machine,
but cap the default value to 16.

Cap only applies to the default value, so
if a user specifies --jobs 48, they will
get 48 workers.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--844.org.readthedocs.build/en/844/

<!-- readthedocs-preview datacube-explorer end -->