### PR TITLE
stores: use CreateSchema

### DIFF
--- a/cubedash/index/postgis/_schema.py
+++ b/cubedash/index/postgis/_schema.py
@@ -28,7 +28,6 @@ from cubedash.summary._schema import (
     METADATA,
     REF_TABLE_METADATA,
     epsg_to_srid,
-    has_schema,
     pg_create_index,
 )
 
@@ -239,19 +238,10 @@ def get_srid_name(conn: Connection, srid: int):
     ).scalar()
 
 
-def create_schema(conn: Connection, epsg_code: int):
+def create_after_schema(conn: Connection, epsg_code: int) -> None:
     """
-    Create any missing parts of the cubedash schema
+    Create any missing parts once there is a cubedash schema
     """
-    # Create schema if needed.
-    #
-    # Note that we don't use the built-in "if not exists" because running it *always* requires
-    # `create` permission.
-    #
-    # Doing it separately allows users to run this tool without `create` permission.
-    #
-    if not has_schema(conn):
-        conn.execute(DDL(f"create schema {CUBEDASH_SCHEMA}"))
     # Add Postgis if needed
     #
     # Note that, as above, we deliberately don't use the built-in "if not exists"
@@ -346,7 +336,7 @@ def init_elements(conn: Connection, grouping_epsg_code: int):
     (Requires `create` permissions in the db)
     """
     # Add any missing schema items or patches.
-    create_schema(conn, epsg_code=grouping_epsg_code)
+    create_after_schema(conn, epsg_code=grouping_epsg_code)
 
     # If they specified an epsg code, make sure the existing schema uses it.
     srid = conn.execute(select(FOOTPRINT_SRID_EXPRESSION)).scalar()

--- a/cubedash/index/postgres/_schema.py
+++ b/cubedash/index/postgres/_schema.py
@@ -36,7 +36,6 @@ from cubedash.summary._schema import (
     PleaseRefresh,
     SchemaNotRefreshableError,
     epsg_to_srid,
-    has_schema,
     pg_add_column,
     pg_column_exists,
     pg_create_index,
@@ -263,20 +262,10 @@ def get_srid_name(conn: Connection, srid: int):
     ).scalar()
 
 
-def create_schema(conn: Connection, epsg_code: int):
+def create_after_schema(conn: Connection, epsg_code: int) -> None:
     """
-    Create any missing parts of the cubedash schema
+    Create any missing parts once there is a cubedash schema
     """
-    # Create schema if needed.
-    #
-    # Note that we don't use the built-in "if not exists" because running it *always* requires
-    # `create` permission.
-    #
-    # Doing it separately allows users to run this tool without `create` permission.
-    #
-    if not has_schema(conn):
-        conn.execute(DDL(f"create schema {CUBEDASH_SCHEMA}"))
-
     # Add Postgis if needed
     #
     # Note that, as above, we deliberately don't use the built-in "if not exists"
@@ -462,7 +451,7 @@ def init_elements(conn: Connection, grouping_epsg_code: int):
     (Requires `create` permissions in the db)
     """
     # Add any missing schema items or patches.
-    create_schema(conn, epsg_code=grouping_epsg_code)
+    create_after_schema(conn, epsg_code=grouping_epsg_code)
 
     # If they specified an epsg code, make sure the existing schema uses it.
     srid = conn.execute(select(FOOTPRINT_SRID_EXPRESSION)).scalar()

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -29,7 +29,7 @@ from shapely.geometry.base import BaseGeometry
 from sqlalchemy import Row, RowMapping, func, select
 from sqlalchemy.dialects.postgresql import TSTZRANGE
 from sqlalchemy.sql import Select
-from sqlalchemy.sql.ddl import DropSchema
+from sqlalchemy.sql.ddl import CreateSchema, DropSchema
 
 try:
     from cubedash._version import version as explorer_version
@@ -300,6 +300,9 @@ class SummaryStore:
 
         (Requires `create` permissions in the db)
         """
+        self.e_index.execute_ddl(
+            CreateSchema(_schema.CUBEDASH_SCHEMA, if_not_exists=True)
+        )
         refresh_also = self.e_index.init_schema(grouping_epsg_code or DEFAULT_EPSG)
         if refresh_also:
             # Refresh product information after a schema update, plus the given kind of data.


### PR DESCRIPTION
There is already a DropSchema in
stores, so put the CreateSchema
in there as well.

The previous code has some comment
about being able to run things
without create permissions, but
the only caller is SummaryStore.init()
whose documentation states that
it requires create permissions,
so use the if_not_exists parameter
to CreateSchema instead of some
function that probes the database.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--846.org.readthedocs.build/en/846/

<!-- readthedocs-preview datacube-explorer end -->