### PR TITLE
tests: remove print statements

### DIFF
--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -1,7 +1,6 @@
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
-from pprint import pprint
 from textwrap import dedent
 from uuid import UUID
 
@@ -75,8 +74,6 @@ def test_eo3_extents(eo3_index: Index) -> None:
     [dataset_extent_row] = _extents.get_sample_dataset(
         [product], explorer_index(eo3_index)
     )
-    pprint(dataset_extent_row)
-
     assert dataset_extent_row["id"] == UUID("5b2f2c50-e618-4bef-ba1f-3d436d9aed14")
 
     # On older products, the center time was calculated from the range.
@@ -140,8 +137,6 @@ def test_eo3_dateless_extents(eo3_index: Index) -> None:
     [dataset_extent_row] = _extents.get_sample_dataset(
         [product], explorer_index(eo3_index)
     )
-    pprint(dataset_extent_row)
-
     assert dataset_extent_row["id"] == UUID("856e45bf-cd50-5a5a-b1cd-12b85df99b24")
 
     # Since it has no datetime, the chosen one should default to the start

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -2,7 +2,6 @@
 Tests that load pages and check the contained text.
 """
 
-import json
 from datetime import datetime, timezone
 from io import StringIO
 
@@ -567,7 +566,6 @@ def test_api_returns_limited_tile_regions(client: FlaskClient) -> None:
     geojson = get_geojson(client, "/api/regions/ga_ls8c_ard_3/2022/02")
     assert len(geojson["features"]) == 3, "Unexpected region month count"
     geojson = get_geojson(client, "/api/regions/ga_ls8c_ard_3/2022/02/26")
-    print(json.dumps(geojson, indent=4))
     assert len(geojson["features"]) == 1, "Unexpected region day count"
     geojson = get_geojson(client, "/api/regions/ga_ls8c_ard_3/2022/04/6")
     assert len(geojson["features"]) == 0, "Unexpected region count"
@@ -799,7 +797,6 @@ def test_show_summary_cli(clirunner, client: FlaskClient) -> None:
     """
     # ls7_nbar_scene, 2017, May
     res: Result = clirunner(show.cli, ["ls7_nbar_scene", "2017", "5"])
-    print(res.output)
 
     # Expect it to show the dates in local timezone.
     expected_from = datetime(2017, 4, 20, 0, 3, 26, tzinfo=tz.tzutc())

--- a/integration_tests/test_region_tiles.py
+++ b/integration_tests/test_region_tiles.py
@@ -92,8 +92,7 @@ def test_archived_dataset_is_excluded(client, run_generate, odc_test_db) -> None
         odc_test_db.index.datasets.archive(["974e1e89-3757-4d94-be8d-7acaeb7adf24"])
 
         # ... the next generation should catch it and update with one less dataset....
-        result = run_generate("ga_ls_wo_fq_nov_mar_3")
-        print(result)
+        _ = run_generate("ga_ls_wo_fq_nov_mar_3")
 
         rv = client.get("product/ga_ls_wo_fq_nov_mar_3/regions/x25y41")
         assert rv.status_code == 404, rv.data

--- a/integration_tests/test_s2_l2a_footprint.py
+++ b/integration_tests/test_s2_l2a_footprint.py
@@ -61,8 +61,6 @@ def test_product_audit(unpopulated_client: FlaskClient, run_generate) -> None:
     client = unpopulated_client
 
     res = get_html(client, "/product-audit/")
-    # print(res.html)
-
     assert (
         res.css_first(".unavailable-metadata .search-result .product-name").text(
             strip=True

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -604,8 +604,6 @@ def test_stac_links(stac_client: FlaskClient) -> None:
         href: str = child_link["href"]
         # ignore child links corresponding to catalogs
         if "catalogs" not in href:
-            print(f"Loading collection page for {product_name}: {href!r}")
-
             collection_data = get_collection(stac_client, href, validate=True)
             assert collection_data["id"] == product_name
             # TODO: assert items, properties, etc.

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -219,7 +219,6 @@ def test_dataset_changing_product(run_generate, summary_store: SummaryStore) -> 
         assert dataset.product.name == "ga_ls8c_ard_3"
 
         # Explorer should remove it too.
-        print(f"Test dataset: {dataset_id}")
         # TODO: Make this work without a force-refresh.
         #       It's hard because we're scanning for updated datasets in the product...
         #       but it's not in the product. And the incremental updater misses it.
@@ -288,7 +287,6 @@ def test_has_source_derived_product_links(
     ls8_ard = summary_store.get_product_summary("ga_ls8c_ard_3")
     assert ls8_ard is not None
 
-    print(repr([ls_fc_pc, ls_fc, ls8_ard]))
     assert ls_fc_pc.source_products == ["ga_ls_fc_3"]
     assert ls_fc_pc.derived_products == []
 

--- a/integration_tests/test_wagl_data.py
+++ b/integration_tests/test_wagl_data.py
@@ -65,8 +65,6 @@ def test_product_audit(unpopulated_client: FlaskClient, run_generate) -> None:
     client = unpopulated_client
 
     res = get_html(client, "/product-audit/?timings")
-    # print(res.html)
-
     largest_footprint_size = res.css(".footprint-size .search-result")
     assert len(largest_footprint_size) == 2
 
@@ -82,5 +80,4 @@ def test_product_audit(unpopulated_client: FlaskClient, run_generate) -> None:
 
     res = client.get("/audit/day-query-times.txt")
     plain_timing_results = res.data.decode("utf-8")
-    print(plain_timing_results)
     assert '"s2a_ard_granule"\t8\t' in plain_timing_results


### PR DESCRIPTION
These print statements have been
present for 5+ years during which
time the tests have been properly
debugged, so remove the print
statements.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--847.org.readthedocs.build/en/847/

<!-- readthedocs-preview datacube-explorer end -->