### PR TITLE
Add type ignores

### DIFF
--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -77,7 +77,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         (the ones returned by the Index are cached and so may be shared among callers)
         """
         # why not do md.dataset_fields?
-        return self.index._db.get_dataset_fields(md.definition)
+        return self.index._db.get_dataset_fields(md.definition)  # type: ignore[attr-defined]
 
     @override
     def ds_added_expr(self):
@@ -127,7 +127,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         What months have had dataset changes since they were last generated?
         """
         # Find the most-recently updated datasets and group them by month.
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     func.date_trunc(
@@ -151,7 +151,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         updated_months = aliased(TimeOverview, name="updated_months")
         years = aliased(TimeOverview, name="years_needing_update")
 
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 # Select years
                 select(years.start_day)
@@ -174,7 +174,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def product_ds_count_per_period(self) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     ProductSpatial.name,
@@ -202,7 +202,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         # is bad because there's only 32 k values in the sequence and we have run out
         # a couple of times! So, It appears that this update-else-insert must be done
         # in two statements...
-        with self.index._active_connection(transaction=True) as conn:
+        with self.index._active_connection(transaction=True) as conn:  # type: ignore[attr-defined]
             row = conn.execute(
                 select(ProductSpatial.id, ProductSpatial.last_refresh).where(
                     ProductSpatial.name == product_name
@@ -230,7 +230,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     def put_summary(
         self, product_id: int, start_day: date, period: str, summary_row: dict
     ) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 insert(TimeOverview)
                 .on_conflict_do_update(
@@ -253,7 +253,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def product_summary_cols(self, product_name: str) -> Row:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     ProductSpatial.dataset_count,
@@ -273,7 +273,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     @override
     def upsert_product_regions(self, product_id: int) -> CursorResult:
         # add new regions row and/or update existing regions based on dataset_spatial
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 text(f"""
             with srid_groups as (
@@ -308,7 +308,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def delete_product_empty_regions(self, product_id: int) -> CursorResult:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 text(f"""
             delete from cubedash.region
@@ -323,7 +323,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def product_time_overview(self, product_id: int) -> tuple[datetime, datetime, int]:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     func.min(DatasetSpatial.center_time),
@@ -336,7 +336,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     def product_time_summary(
         self, product_id: int, start_day: date, period: str
     ) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(TimeOverview).where(
                     and_(
@@ -427,7 +427,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
         query = query.limit(limit).offset(offset)
 
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(query)
 
     @override
@@ -460,7 +460,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def already_summarised_period(self, period: str, product_id: int) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(TimeOverview.start_day).where(
                     and_(
@@ -478,7 +478,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         if direction == "derived":
             to_ref, from_ref = from_ref, to_ref
 
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 text(f"""
                 with datasets as (
@@ -505,7 +505,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def product_region_summary(self, product_id: int) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     Region.region_code,
@@ -519,7 +519,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def dataset_footprint_region(self, dataset_id: UUID) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     func.ST_Transform(DatasetSpatial.footprint, 4326).label(
@@ -534,7 +534,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         # DATASET_SPATIAL doesn't keep track of when the dataset was indexed,
         # so we have to get that info from ODC_DATASET
         # join might not be necessary
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(func.max(ODC_DATASET.added))
                 .select_from(DatasetSpatial)
@@ -546,7 +546,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     def update_product_refresh_timestamp(
         self, product_id: int, refresh_timestamp: datetime
     ) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 update(ProductSpatial)
                 .where(ProductSpatial.id == product_id)
@@ -568,19 +568,19 @@ class ExplorerIndex(ExplorerAbstractIndex):
         candidate_fields: Sequence[tuple[str, Field]],
         sample_ids: Iterable[tuple],
     ) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     *[
                         (
                             func.every(
-                                field.alchemy_expression == field_values[field_name]
+                                field.alchemy_expression == field_values[field_name]  # type: ignore[attr-defined]
                             )
                         ).label(field_name)
                         if field.type_name != "datetime"
                         else (
                             func.every(
-                                cast(field.alchemy_expression, TIMESTAMP(timezone=True))
+                                cast(field.alchemy_expression, TIMESTAMP(timezone=True))  # type: ignore[attr-defined]
                                 == field_values[field_name]
                             )
                         ).label(field_name)
@@ -614,7 +614,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
             queries.append(subquery)
 
         if queries:  # Don't run invalid SQL on empty database
-            with self.index._active_connection() as conn:
+            with self.index._active_connection() as conn:  # type: ignore[attr-defined]
                 return conn.execute(union_all(*queries))
         else:
             raise EmptyDbError()
@@ -647,9 +647,9 @@ class ExplorerIndex(ExplorerAbstractIndex):
             .limit(bindparam("limit", limit))
             .offset(bindparam("offset", offset))
         )
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return (
-                self.index.datasets._make(res, full_info=True)
+                self.index.datasets._make(res, full_info=True)  # type: ignore[attr-defined]
                 for res in conn.execute(query).fetchall()
             )
 
@@ -672,14 +672,14 @@ class ExplorerIndex(ExplorerAbstractIndex):
             .limit(bindparam("limit", limit))
             .offset(bindparam("offset", offset))
         )
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return (res.product_ref for res in conn.execute(query).fetchall())
 
     @override
     def delete_datasets(
         self, product_id: int, after_date: datetime | None = None, full: bool = False
     ) -> int:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             # Forcing? Check every other dataset for removal, so we catch manually-deleted rows from the table.
             if full:
                 return conn.execute(
@@ -734,7 +734,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
                 ODC_DATASET.updated
                 > after_date  # updated should also capture added time
             )
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             stmt = insert(DatasetSpatial).from_select(
                 list(column_values.keys()),
                 select(*column_values.values()).where(and_(*only_where)),
@@ -803,7 +803,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def select_spatial_stats(self):
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     SpatialQualityStats.product_ref.label("product_ref"),
@@ -906,7 +906,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         )
 
         # Union all srid groups into one summary.
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     # do we still need .c. notation here?
@@ -926,7 +926,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def day_counts(self, grouping_time_zone, where_clause: ColumnElement):
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     func.date_trunc(
@@ -943,7 +943,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def region_counts(self, where_clause):
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(DatasetSpatial.region_code.label("region_code"), func.count())
                 .where(where_clause)
@@ -1034,7 +1034,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def sample_dataset(self, product_id: int, columns: Sequence[Label]) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             res = conn.execute(
                 select(ODC_DATASET.id, ODC_DATASET.product_ref, *columns)
                 .where(
@@ -1052,7 +1052,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def mapped_crses(self, product, srid_expression):
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             res = conn.execute(
                 select(literal(product.name).label("product"), srid_expression)
                 .where(ODC_DATASET.product_ref == product.id)

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -233,7 +233,6 @@ class ExplorerIndex(ExplorerAbstractIndex):
         with self.index._active_connection() as conn:
             return conn.execute(
                 insert(TimeOverview)
-                .returning(TimeOverview.generation_time)
                 .on_conflict_do_update(
                     index_elements=["product_ref", "start_day", "period_type"],
                     set_=summary_row,
@@ -243,6 +242,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
                         TimeOverview.period_type == period,
                     ),
                 )
+                .returning(TimeOverview.generation_time)
                 .values(
                     product_ref=product_id,
                     start_day=start_day,

--- a/cubedash/index/postgis/_schema.py
+++ b/cubedash/index/postgis/_schema.py
@@ -107,8 +107,8 @@ class Product:
         comment="The `last_refresh` time that was current when summaries "
         "were last *fully* generated successfully.",
     )
-    source_product_refs = Column(postgres.ARRAY(SmallInteger))
-    derived_product_refs = Column(postgres.ARRAY(SmallInteger))
+    source_product_refs = Column(postgres.ARRAY(SmallInteger))  # type: ignore[var-annotated]
+    derived_product_refs = Column(postgres.ARRAY(SmallInteger))  # type: ignore[var-annotated]
     time_earliest = Column(DateTime(timezone=True))
     time_latest = Column(DateTime(timezone=True))
     # A flat key-value set of metadata fields that are the same ("fixed") on every dataset.
@@ -130,22 +130,22 @@ class TimeOverview:
         {"schema": CUBEDASH_SCHEMA},
     )
     # Uniquely identified by three values:
-    product_ref = Column(None, ForeignKey(Product.id))
-    period_type = Column(SqlEnum("all", "year", "month", "day", name="overviewperiod"))
+    product_ref = Column(None, ForeignKey(Product.id))  # type: ignore[var-annotated]
+    period_type = Column(SqlEnum("all", "year", "month", "day", name="overviewperiod"))  # type: ignore[var-annotated]
     start_day = Column(Date)
     dataset_count = Column(Integer, nullable=False)
     # Time range (if there's at least one dataset)
     time_earliest = Column(DateTime(timezone=True))
     time_latest = Column(DateTime(timezone=True))
-    timeline_period = Column(
+    timeline_period = Column(  # type: ignore[var-annotated]
         SqlEnum("year", "month", "week", "day", name="timelineperiod"), nullable=False
     )
-    timeline_dataset_start_days = Column(
+    timeline_dataset_start_days = Column(  # type: ignore[var-annotated]
         postgres.ARRAY(DateTime(timezone=True)), nullable=False
     )
-    timeline_dataset_counts = Column(postgres.ARRAY(Integer), nullable=False)
-    regions = Column(postgres.ARRAY(String), nullable=False)
-    region_dataset_counts = Column(postgres.ARRAY(Integer), nullable=False)
+    timeline_dataset_counts = Column(postgres.ARRAY(Integer), nullable=False)  # type: ignore[var-annotated]
+    regions = Column(postgres.ARRAY(String), nullable=False)  # type: ignore[var-annotated]
+    region_dataset_counts = Column(postgres.ARRAY(Integer), nullable=False)  # type: ignore[var-annotated]
     # The most newly created dataset
     newest_dataset_creation_time = Column(DateTime(timezone=True))
     # When this summary was generated
@@ -162,7 +162,7 @@ class TimeOverview:
     footprint_count = Column(Integer, nullable=False)
     # SRID is overridden via config.
     footprint_geometry = Column(Geometry(srid=-999, spatial_index=False))
-    crses = Column(postgres.ARRAY(String))
+    crses = Column(postgres.ARRAY(String))  # type: ignore[var-annotated]
     # Size of this dataset in bytes, if the product includes it.
     size_bytes = Column(BigInteger)
 
@@ -261,7 +261,7 @@ def create_after_schema(conn: Connection, epsg_code: int) -> None:
         )
 
     # Our global SRID.
-    TimeOverview.footprint_geometry.type.srid = srid
+    TimeOverview.footprint_geometry.type.srid = srid  # type: ignore[attr-defined]
 
     # We want an index on the spatial_ref_sys table to do authority name/code lookups.
     # But in RDS environments we cannot add indexes to it.
@@ -292,10 +292,10 @@ def create_after_schema(conn: Connection, epsg_code: int) -> None:
 
     # is there a way to ensure orm_registry.metadata doesn't include the ref_table_metadata tables?
     non_ref_tables = [
-        DatasetSpatial.__table__,
-        Product.__table__,
-        TimeOverview.__table__,
-        Region.__table__,
+        DatasetSpatial.__table__,  # type: ignore[attr-defined]
+        Product.__table__,  # type: ignore[attr-defined]
+        TimeOverview.__table__,  # type: ignore[attr-defined]
+        Region.__table__,  # type: ignore[attr-defined]
     ]
     orm_registry.metadata.create_all(conn, tables=non_ref_tables, checkfirst=True)
 

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -279,7 +279,6 @@ class ExplorerIndex(ExplorerAbstractIndex):
         with self.index._active_connection() as conn:
             return conn.execute(
                 insert(TIME_OVERVIEW)
-                .returning(TIME_OVERVIEW.c.generation_time)
                 .on_conflict_do_update(
                     index_elements=["product_ref", "start_day", "period_type"],
                     set_=summary_row,
@@ -289,6 +288,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
                         TIME_OVERVIEW.c.period_type == period,
                     ),
                 )
+                .returning(TIME_OVERVIEW.c.generation_time)
                 .values(
                     product_ref=product_id,
                     start_day=start_day,

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -74,7 +74,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         (the ones returned by the Index are cached and so may be shared among callers)
         """
         # why not do md.dataset_fields?
-        return self.index._db.get_dataset_fields(md.definition)
+        return self.index._db.get_dataset_fields(md.definition)  # type: ignore[attr-defined]
 
     @override
     def ds_added_expr(self):
@@ -101,7 +101,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
             # We add one to detect if there are more records after out limit.
             query = query.limit(limit + 1)
 
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             source_ids = conn.execute(query).fetchall()
 
             if not source_ids:
@@ -145,7 +145,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
             # We add one to detect if there are more records after out limit.
             query = query.limit(limit + 1)
 
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             remaining_records = 0
             datasets = conn.execute(query).fetchall()
 
@@ -176,7 +176,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         What months have had dataset changes since they were last generated?
         """
         # Find the most-recently updated datasets and group them by month.
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     func.date_trunc(
@@ -196,7 +196,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         updated_months = TIME_OVERVIEW.alias("updated_months")
         years = TIME_OVERVIEW.alias("years_needing_update")
 
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 # Select years
                 select(years.c.start_day)
@@ -221,7 +221,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def product_ds_count_per_period(self) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     PRODUCT.c.name,
@@ -248,7 +248,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         # is bad because there's only 32 k values in the sequence and we have run out
         # a couple of times! So, It appears that this update-else-insert must be done
         # in two statements...
-        with self.index._active_connection(transaction=True) as conn:
+        with self.index._active_connection(transaction=True) as conn:  # type: ignore[attr-defined]
             row = conn.execute(
                 select(PRODUCT.c.id, PRODUCT.c.last_refresh).where(
                     PRODUCT.c.name == product_name
@@ -276,7 +276,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     def put_summary(
         self, product_id: int, start_day: date, period: str, summary_row: dict
     ) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 insert(TIME_OVERVIEW)
                 .on_conflict_do_update(
@@ -299,7 +299,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def product_summary_cols(self, product_name: str) -> Row:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     PRODUCT.c.dataset_count,
@@ -319,7 +319,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     @override
     def upsert_product_regions(self, product_id: int) -> CursorResult:
         # add new regions row and/or update existing regions based on dataset_spatial
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 text(f"""
             with srid_groups as (
@@ -354,7 +354,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def delete_product_empty_regions(self, product_id: int) -> CursorResult:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 text(f"""
             delete from cubedash.region
@@ -369,7 +369,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def product_time_overview(self, product_id: int) -> tuple[datetime, datetime, int]:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     func.min(DATASET_SPATIAL.c.center_time),
@@ -382,7 +382,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     def product_time_summary(
         self, product_id: int, start_day: date, period: str
     ) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(TIME_OVERVIEW).where(
                     and_(
@@ -472,7 +472,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
         query = query.limit(limit).offset(offset)
 
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(query)
 
     @override
@@ -505,7 +505,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def already_summarised_period(self, period: str, product_id: int) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(TIME_OVERVIEW.c.start_day).where(
                     and_(
@@ -524,7 +524,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
             to_ref, from_ref = from_ref, to_ref
 
         # surely we could use existing linked datasets logic as part of this?
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 text(f"""
                 with datasets as (
@@ -551,7 +551,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def product_region_summary(self, product_id: int) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     REGION.c.region_code,
@@ -565,7 +565,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def dataset_footprint_region(self, dataset_id: UUID) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     func.ST_Transform(DATASET_SPATIAL.c.footprint, 4326).label(
@@ -580,7 +580,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         # DATASET_SPATIAL doesn't keep track of when the dataset was indexed,
         # so we have to get that info from ODC_DATASET
         # join might not be necessary
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(func.max(ODC_DATASET.c.added))
                 .select_from(
@@ -595,7 +595,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     def update_product_refresh_timestamp(
         self, product_id: int, refresh_timestamp: datetime
     ) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 PRODUCT.update()
                 .where(PRODUCT.c.id == product_id)
@@ -617,13 +617,13 @@ class ExplorerIndex(ExplorerAbstractIndex):
         candidate_fields: Sequence[tuple[str, Field]],
         sample_ids: Iterable[tuple],
     ) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     *[
                         (
                             func.every(
-                                field.alchemy_expression == field_values[field_name]
+                                field.alchemy_expression == field_values[field_name]  # type: ignore[attr-defined]
                             )
                         ).label(field_name)
                         for field_name, field in candidate_fields
@@ -658,7 +658,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
         if queries:  # Don't run invalid SQL on empty database
             # surely there must be a better way to check the database isn't empty before we get to this point?
-            with self.index._active_connection() as conn:
+            with self.index._active_connection() as conn:  # type: ignore[attr-defined]
                 return conn.execute(union_all(*queries))
         else:
             raise EmptyDbError()
@@ -701,9 +701,9 @@ class ExplorerIndex(ExplorerAbstractIndex):
             .limit(bindparam("limit", limit))
             .offset(bindparam("offset", offset))
         )
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return (
-                self.index.datasets._make(res, full_info=True)
+                self.index.datasets._make(res, full_info=True)  # type: ignore[attr-defined]
                 for res in conn.execute(query).fetchall()
             )
 
@@ -730,14 +730,14 @@ class ExplorerIndex(ExplorerAbstractIndex):
             .limit(bindparam("limit", limit))
             .offset(bindparam("offset", offset))
         )
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return (res.dataset_type_ref for res in conn.execute(query).fetchall())
 
     @override
     def delete_datasets(
         self, product_id: int, after_date: datetime | None = None, full: bool = False
     ) -> int:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             # Forcing? Check every other dataset for removal, so we catch manually-deleted rows from the table.
             if full:
                 return conn.execute(
@@ -795,7 +795,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
             only_where.append(
                 or_(ODC_DATASET.c.added > after_date, column("updated") > after_date)
             )
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             stmt = insert(DATASET_SPATIAL).from_select(
                 list(column_values.keys()),
                 select(*column_values.values()).where(and_(*only_where)),
@@ -869,7 +869,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     @override
     def select_spatial_stats(self):
         # the only reason this needs to be in the api is because of the dataset_type_ref column
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     SPATIAL_QUALITY_STATS.c.dataset_type_ref.label("product_ref"),
@@ -969,7 +969,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         )
 
         # Union all srid groups into one summary.
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     func.sum(select_by_srid.c.dataset_count).label("dataset_count"),
@@ -988,7 +988,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def day_counts(self, grouping_time_zone, where_clause: ColumnElement):
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(
                     func.date_trunc(
@@ -1005,7 +1005,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def region_counts(self, where_clause):
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             return conn.execute(
                 select(DATASET_SPATIAL.c.region_code.label("region_code"), func.count())
                 .where(where_clause)
@@ -1095,7 +1095,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def sample_dataset(self, product_id: int, columns: Sequence[Label]) -> Result:
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             res = conn.execute(
                 select(
                     ODC_DATASET.c.id,
@@ -1117,7 +1117,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
     @override
     def mapped_crses(self, product, srid_expression):
-        with self.index._active_connection() as conn:
+        with self.index._active_connection() as conn:  # type: ignore[attr-defined]
             res = conn.execute(
                 select(literal(product.name).label("product"), srid_expression)
                 .where(ODC_DATASET.c.dataset_type_ref == product.id)

--- a/cubedash/index/postgres/_schema.py
+++ b/cubedash/index/postgres/_schema.py
@@ -285,7 +285,7 @@ def create_after_schema(conn: Connection, epsg_code: int) -> None:
         )
 
     # Our global SRID.
-    TIME_OVERVIEW.c.footprint_geometry.type.srid = srid
+    TIME_OVERVIEW.c.footprint_geometry.type.srid = srid  # type: ignore[attr-defined]
 
     # We want an index on the spatial_ref_sys table to do authority name/code lookups.
     # But in RDS environments we cannot add indexes to it.

--- a/integration_tests/dumpdatasets.py
+++ b/integration_tests/dumpdatasets.py
@@ -6,6 +6,7 @@ import gzip
 import random
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import click
 import yaml
@@ -65,7 +66,9 @@ def dump_datasets(
             )
 
 
-def _get_dumpable_doc(dc: Datacube, d: Dataset, include_sources=True):
+def _get_dumpable_doc(
+    dc: Datacube, d: Dataset, include_sources: bool = True
+) -> dict[str, Any]:
     if include_sources:
         dataset = dc.index.datasets.get(d.id, include_sources=include_sources)
         assert dataset is not None

--- a/integration_tests/test_pages_render.py
+++ b/integration_tests/test_pages_render.py
@@ -87,7 +87,7 @@ def test_allows_null_product_fixed_fields(
     )
 
     # AND there's some with null fixed_metadata (ie. pre-Explorer0-EO3-update)
-    with odc_test_db.index._active_connection() as conn:
+    with odc_test_db.index._active_connection() as conn:  # type: ignore[attr-defined]
         update_count = conn.execute(
             text("update cubedash.product set fixed_metadata = null")
         ).rowcount

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -251,7 +251,7 @@ def _change_dataset_product(
     else:
         table_name = "odc.dataset"
         ref_column = "product_ref"
-    with index._db._engine.begin() as conn:
+    with index._db._engine.begin() as conn:  # type: ignore[attr-defined]
         rows_changed = conn.execute(
             text(
                 f"update {table_name} set {ref_column}=:product_id where id=:dataset_id"
@@ -555,7 +555,7 @@ def test_cubedash_gen_refresh(
     """
 
     def _get_product_seq_value():
-        with odc_test_db.index._active_connection() as conn:
+        with odc_test_db.index._active_connection() as conn:  # type: ignore[attr-defined]
             [new_val] = conn.execute(
                 text(f"select last_value from {CUBEDASH_SCHEMA}.product_id_seq;")
             ).fetchone()


### PR DESCRIPTION
These type ignores are for things
we know exist, but cannot convince
the type checker of.

Also add a commit that adds a type
signature, and another commit that
fixes the method chaining order.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--857.org.readthedocs.build/en/857/

<!-- readthedocs-preview datacube-explorer end -->