### PR TITLE
tests: remove type annotations

### DIFF
--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -140,7 +140,7 @@ def test_eo3_dateless_extents(eo3_index: Index) -> None:
     assert dataset_extent_row["id"] == UUID("856e45bf-cd50-5a5a-b1cd-12b85df99b24")
 
     # Since it has no datetime, the chosen one should default to the start
-    time_record: datetime = dataset_extent_row["center_time"]
+    time_record = dataset_extent_row["center_time"]
     assert time_record.astimezone(tz.tzutc()) == datetime(
         2017, 7, 1, 0, 0, tzinfo=tz.tzutc()
     )

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -7,7 +7,6 @@ from datetime import date, datetime
 
 from datacube.model import Range
 from shapely.geometry import shape
-from shapely.geometry.base import BaseGeometry
 
 from cubedash._model import TimePeriodOverview
 from integration_tests.asserts import assert_shapes_mostly_equal
@@ -216,7 +215,7 @@ def test_footprint_normal(benchmark) -> None:
 
     o = _create_overview()
     o.footprint_geometry = normal_poly
-    res: BaseGeometry = benchmark(lambda: o.footprint_wgs84)
+    res = benchmark(lambda: o.footprint_wgs84)
     assert_shapes_mostly_equal(res, expected_poly, 0.001)
 
 

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -6,7 +6,6 @@ from datetime import datetime, timezone
 from io import StringIO
 
 import pytest
-from click.testing import Result
 from dateutil import tz
 from flask.testing import FlaskClient
 from ruamel.yaml import YAML, YAMLError
@@ -796,7 +795,7 @@ def test_show_summary_cli(clirunner, client: FlaskClient) -> None:
     You should be able to view a product with cubedash-view command-line program.
     """
     # ls7_nbar_scene, 2017, May
-    res: Result = clirunner(show.cli, ["ls7_nbar_scene", "2017", "5"])
+    res = clirunner(show.cli, ["ls7_nbar_scene", "2017", "5"])
 
     # Expect it to show the dates in local timezone.
     expected_from = datetime(2017, 4, 20, 0, 3, 26, tzinfo=tz.tzutc())
@@ -835,9 +834,7 @@ def test_show_summary_cli_out_of_bounds(clirunner, client: FlaskClient) -> None:
     Can you view a date that doesn't exist?
     """
     # A period that's out of bounds.
-    res: Result = clirunner(
-        show.cli, ["ga_ls8c_ard_3", "2030", "5"], expect_success=False
-    )
+    res = clirunner(show.cli, ["ga_ls8c_ard_3", "2030", "5"], expect_success=False)
     assert "No summary for chosen period." in res.output
 
 
@@ -847,8 +844,8 @@ def test_show_summary_cli_missing_product(clirunner, client: FlaskClient) -> Non
 
     (and error return code)
     """
-    res: Result = clirunner(show.cli, ["does_not_exist"], expect_success=False)
-    output: str = res.output
+    res = clirunner(show.cli, ["does_not_exist"], expect_success=False)
+    output = res.output
     assert output.strip().startswith("Unknown product 'does_not_exist'")
     assert res.exit_code != 0
 
@@ -861,7 +858,7 @@ def test_show_summary_cli_unsummarised_product(
 
     (and error return code)
     """
-    res: Result = clirunner(show.cli, ["ga_ls8c_ard_3"], expect_success=False)
+    res = clirunner(show.cli, ["ga_ls8c_ard_3"], expect_success=False)
     out = res.output.strip()
     assert out.startswith("No info: product 'ga_ls8c_ard_3' has not been summarised")
     assert res.exit_code != 0

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -600,8 +600,8 @@ def test_stac_links(stac_client: FlaskClient) -> None:
 
     found_collection_ids = set()
     for child_link in child_links:
-        product_name: str = child_link["title"]
-        href: str = child_link["href"]
+        product_name = child_link["title"]
+        href = child_link["href"]
         # ignore child links corresponding to catalogs
         if "catalogs" not in href:
             collection_data = get_collection(stac_client, href, validate=True)

--- a/integration_tests/test_utc_tst.py
+++ b/integration_tests/test_utc_tst.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pytest
-from click.testing import Result
 from datacube.model import Range
 from dateutil import tz
 from flask.testing import FlaskClient
@@ -90,7 +89,7 @@ def test_dataset_search_page_localised_time(client: FlaskClient) -> None:
 def test_clirunner_generate_grouping_timezone(
     odc_test_db, run_generate, empty_client
 ) -> None:
-    res: Result = run_generate("ga_ls9c_ard_3", grouping_time_zone="America/Chicago")
+    res = run_generate("ga_ls9c_ard_3", grouping_time_zone="America/Chicago")
     assert "2021" in res.output
 
     store = SummaryStore.create(odc_test_db.index, grouping_time_zone="America/Chicago")


### PR DESCRIPTION
These are not required and do not
help the type checker, so remove
them.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--859.org.readthedocs.build/en/859/

<!-- readthedocs-preview datacube-explorer end -->