### PR TITLE
Remove python-dateutil dependency

### DIFF
--- a/cubedash/_api.py
+++ b/cubedash/_api.py
@@ -1,8 +1,8 @@
 from datetime import date, datetime
+from zoneinfo import ZoneInfo
 
 import flask
 import structlog
-from dateutil import tz
 from flask import Blueprint, abort, request
 
 from cubedash import _utils
@@ -35,7 +35,7 @@ def datasets_geojson(
         limit = hard_limit
 
     time = _utils.as_time_range(
-        year, month, day, tzinfo=tz.gettz(_model.DEFAULT_GROUPING_TIMEZONE)
+        year, month, day, tzinfo=ZoneInfo(_model.DEFAULT_GROUPING_TIMEZONE)
     )
 
     return as_geojson(

--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -13,7 +13,6 @@ import orjson
 import structlog
 from datacube.index.fields import Field
 from datacube.model import Dataset, Product, Range
-from dateutil import tz
 from flask import Blueprint
 from markupsafe import Markup, escape
 from shapely.geometry import MultiPolygon
@@ -296,7 +295,7 @@ def timesince(dt, default="just now"):
     if dt is None:
         return "an unrecorded time ago"
 
-    now = datetime.now(timezone.utc).replace(tzinfo=tz.tzutc())
+    now = datetime.now(timezone.utc)
     diff = now - utils.default_utc(dt)
 
     periods = (
@@ -317,7 +316,7 @@ def timesince(dt, default="just now"):
 
 
 def _time(label: str, actual_time: datetime) -> Markup:
-    as_utc = actual_time.astimezone(tz.tzutc())
+    as_utc = actual_time.astimezone(timezone.utc)
     return Markup(
         f"<time datetime={as_utc.isoformat()}"
         f' title="{actual_time.strftime("%a, %d %b %Y %H:%M:%S%Z")}">'

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -1,14 +1,13 @@
 import decimal
 import re
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import datacube
 import flask
 import structlog
 from datacube.model import Product, Range
 from datacube.scripts.dataset import build_dataset_info
-from dateutil import tz
-from dateutil.parser import ParserError
 from flask import (
     Blueprint,
     abort,
@@ -167,13 +166,13 @@ def search_page(
         time_selector_summary,
     ) = _load_product(product_name, year, month, day)
     time_range = utils.as_time_range(
-        year, month, day, tzinfo=tz.gettz(_model.DEFAULT_GROUPING_TIMEZONE)
+        year, month, day, tzinfo=ZoneInfo(_model.DEFAULT_GROUPING_TIMEZONE)
     )
 
     args = MultiDict(flask.request.args)
     try:
         query = utils.query_to_search(args, product=product)
-    except ParserError:
+    except ZoneInfoNotFoundError:
         abort(400, "Invalid datetime format")
     except ValueError as e:  # invalid query val
         abort(400, str(e))
@@ -488,7 +487,7 @@ def inject_globals():
         current_time=datetime.now(timezone.utc),
         datacube_version=datacube.__version__,
         app_version=cubedash.__version__,
-        grouping_timezone=tz.gettz(_model.DEFAULT_GROUPING_TIMEZONE),
+        grouping_timezone=ZoneInfo(_model.DEFAULT_GROUPING_TIMEZONE),
         last_updated_time=last_updated,
         explorer_instance_title=current_app.config.get("CUBEDASH_INSTANCE_TITLE")
         or current_app.config.get("STAC_ENDPOINT_TITLE", ""),

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from collections.abc import Callable, Mapping, Sequence
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from datetime import time as dt_time
 from functools import partial
 from typing import Any, Union
@@ -11,7 +11,6 @@ import pystac
 import structlog
 from datacube.model import Range
 from datacube.utils import DocReader, parse_time
-from dateutil.tz import tz
 from eodatasets3 import serialise
 from eodatasets3 import stac as eo3stac
 from eodatasets3.model import AccessoryDoc, DatasetDoc, MeasurementDoc, ProductDoc
@@ -89,8 +88,8 @@ def dissoc_in(d: dict, key: str):
 
 def utc(d: datetime):
     if d.tzinfo is None:
-        return d.replace(tzinfo=tz.tzutc())
-    return d.astimezone(tz.tzutc())
+        return d.replace(tzinfo=timezone.utc)
+    return d.astimezone(timezone.utc)
 
 
 def _parse_time_range(time: str) -> tuple[datetime, datetime] | None:

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -26,7 +26,6 @@ from datacube.index.eo3 import is_doc_eo3
 from datacube.index.fields import Field
 from datacube.model import Dataset, MetadataType, Product, Range
 from datacube.utils import InvalidDocException, jsonify_document
-from dateutil import tz
 from dateutil.relativedelta import relativedelta
 from eodatasets3 import serialise
 from flask_themer import render_template
@@ -430,7 +429,7 @@ def _unchanged_value(a):
 
 def default_utc(d: datetime) -> datetime:
     if d.tzinfo is None:
-        return d.replace(tzinfo=tz.tzutc())
+        return d.replace(tzinfo=timezone.utc)
     return d
 
 

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -26,7 +26,6 @@ from datacube.index.eo3 import is_doc_eo3
 from datacube.index.fields import Field
 from datacube.model import Dataset, MetadataType, Product, Range
 from datacube.utils import InvalidDocException, jsonify_document
-from dateutil.relativedelta import relativedelta
 from eodatasets3 import serialise
 from flask_themer import render_template
 from odc.geo import Geometry, geom
@@ -39,12 +38,6 @@ from sqlalchemy import TIMESTAMP, func
 from werkzeug.datastructures import MultiDict
 
 _TARGET_CRS = "EPSG:4326"
-
-DEFAULT_PLATFORM_END_DATE = {
-    "LANDSAT_8": datetime.now() - relativedelta(months=2),
-    "LANDSAT_7": datetime.now() - relativedelta(months=2),
-    "LANDSAT_5": datetime(2011, 11, 30),
-}
 
 NEAR_ANTIMERIDIAN = shape(
     {

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -13,7 +13,6 @@ from zoneinfo import ZoneInfo
 
 import structlog
 from cachetools.func import ttl_cache
-from dateutil import tz
 from eodatasets3.stac import MAPPING_EO3_TO_STAC
 from geoalchemy2 import WKBElement
 from geoalchemy2 import shape as geo_shape
@@ -794,7 +793,7 @@ class SummaryStore:
     @property
     def grouping_timezone(self) -> tzinfo | None:
         """Timezone used for day/month/year grouping."""
-        return tz.gettz(self._summariser.grouping_time_zone)
+        return ZoneInfo(self._summariser.grouping_time_zone)
 
     def _persist_product_extent(self, product: ProductSummary) -> None:
         source_product_ids = [

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -1,11 +1,11 @@
 import os
 from collections import Counter
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 import structlog
 from datacube.model import Range
-from dateutil import tz
 from geoalchemy2 import shape as geo_shape
 
 from cubedash import _utils
@@ -43,7 +43,7 @@ class Summariser:
         # Aus data comes from Alice Springs
         self.grouping_time_zone = grouping_time_zone
         # cache
-        self._grouping_time_zone_tz = tz.gettz(self.grouping_time_zone)
+        self._grouping_time_zone_tz = ZoneInfo(self.grouping_time_zone)
 
     def calculate_summary(
         self,

--- a/integration_tests/asserts.py
+++ b/integration_tests/asserts.py
@@ -1,7 +1,7 @@
 import json
 import re
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from pprint import pformat, pprint
 from textwrap import indent
@@ -11,7 +11,6 @@ import jsonschema
 import pytest
 from datacube.model import Range
 from datacube.utils import InvalidDocException, validate_document
-from dateutil.tz import tzutc
 from deepdiff import DeepDiff
 from flask.testing import FlaskClient
 from selectolax.lexbor import LexborHTMLParser, LexborNode
@@ -278,9 +277,9 @@ def expect_values(
         dataset_count {s.dataset_count}
         footprint_count {s.footprint_count}
         time range:
-            - {s.time_range.begin.astimezone(tzutc())!r}
-            - {s.time_range.end.astimezone(tzutc())!r}
-        newest: {s.newest_dataset_creation_time.astimezone(tzutc())!r}
+            - {s.time_range.begin.astimezone(timezone.utc)!r}
+            - {s.time_range.end.astimezone(timezone.utc)!r}
+        newest: {s.newest_dataset_creation_time.astimezone(timezone.utc)!r}
         crses: {s.crses!r}
         size_bytes: {s.size_bytes}
         timeline

--- a/integration_tests/test_dataset_listing.py
+++ b/integration_tests/test_dataset_listing.py
@@ -6,7 +6,11 @@ from datacube.index import Index
 from datacube.model import Range
 from werkzeug.datastructures import MultiDict
 
-from cubedash._utils import DEFAULT_PLATFORM_END_DATE, query_to_search
+from cubedash._utils import query_to_search
+
+DEFAULT_PLATFORM_END_DATE = {
+    "LANDSAT_5": datetime(2011, 11, 30),
+}
 
 METADATA_TYPES = ["metadata/eo3_landsat_ard.odc-type.yaml"]
 PRODUCTS = [

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -1,5 +1,5 @@
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import dedent
 from uuid import UUID
@@ -8,8 +8,6 @@ import pytest
 from datacube import Datacube
 from datacube.index import Index
 from datacube.utils import parse_time
-from dateutil import tz
-from dateutil.tz import tzutc
 from flask.testing import FlaskClient
 from geoalchemy2.shape import to_shape
 from ruamel.yaml import YAML
@@ -79,11 +77,11 @@ def test_eo3_extents(eo3_index: Index) -> None:
     # On older products, the center time was calculated from the range.
     # But on EO3 we have a singular 'datetime' to use directly.
     assert dataset_extent_row["center_time"] == datetime(
-        1988, 3, 30, 1, 41, 16, 892044, tzinfo=tz.tzutc()
+        1988, 3, 30, 1, 41, 16, 892044, tzinfo=timezone.utc
     )
 
     assert dataset_extent_row["creation_time"] == datetime(
-        2020, 6, 5, 7, 15, 26, 599544, tzinfo=tz.tzutc()
+        2020, 6, 5, 7, 15, 26, 599544, tzinfo=timezone.utc
     )
     product = eo3_index.products.get_by_name("ga_ls5t_ard_3")
     assert product is not None
@@ -141,8 +139,8 @@ def test_eo3_dateless_extents(eo3_index: Index) -> None:
 
     # Since it has no datetime, the chosen one should default to the start
     time_record = dataset_extent_row["center_time"]
-    assert time_record.astimezone(tz.tzutc()) == datetime(
-        2017, 7, 1, 0, 0, tzinfo=tz.tzutc()
+    assert time_record.astimezone(timezone.utc) == datetime(
+        2017, 7, 1, 0, 0, tzinfo=timezone.utc
     )
 
     # Dataset has no creation time, but will fall back to index time.
@@ -228,7 +226,7 @@ def with_parsed_datetimes(v: dict | str | datetime | list, name=""):
         dt = parse_time(v)
         # Strip/normalise timezone to match default yaml.load()
         if dt.tzinfo:
-            dt = dt.astimezone(tzutc()).replace(tzinfo=None)
+            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
         return dt
     elif isinstance(v, dict):
         return {k: with_parsed_datetimes(v, name=k) for k, v in v.items()}

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -4,10 +4,10 @@ Tests that load pages and check the contained text.
 
 from datetime import datetime, timezone
 from io import StringIO
+from zoneinfo import ZoneInfo
 
 import flask
 import pytest
-from dateutil import tz
 from flask.testing import FlaskClient
 from ruamel.yaml import YAML, YAMLError
 
@@ -27,7 +27,7 @@ from integration_tests.asserts import (
     get_text_response,
 )
 
-DEFAULT_TZ = tz.gettz("Australia/Darwin")
+DEFAULT_TZ = ZoneInfo("Australia/Darwin")
 
 METADATA_TYPES = [
     "metadata/eo3_landsat_ard.odc-type.yaml",
@@ -798,8 +798,8 @@ def test_show_summary_cli(clirunner, client: FlaskClient) -> None:
     res = clirunner(show.cli, ["ls7_nbar_scene", "2017", "5"])
 
     # Expect it to show the dates in local timezone.
-    expected_from = datetime(2017, 4, 20, 0, 3, 26, tzinfo=tz.tzutc())
-    expected_to = datetime(2017, 5, 3, 1, 6, 41, 500000, tzinfo=tz.tzutc())
+    expected_from = datetime(2017, 4, 20, 0, 3, 26, tzinfo=timezone.utc)
+    expected_to = datetime(2017, 5, 3, 1, 6, 41, 500000, tzinfo=timezone.utc)
 
     expected_header = "\n".join(
         (

--- a/integration_tests/test_s2_l2a_footprint.py
+++ b/integration_tests/test_s2_l2a_footprint.py
@@ -2,12 +2,11 @@
 Tests that load pages and check the contained text.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 from datacube.model import Range
-from dateutil.tz import tzutc
 from flask.testing import FlaskClient
 
 from cubedash.summary import SummaryStore
@@ -45,10 +44,10 @@ def test_s2_l2a_summary(run_generate, summary_store: SummaryStore) -> None:
         dataset_count=4,
         footprint_count=4,
         time_range=Range(
-            begin=datetime(2016, 10, 31, 14, 30, tzinfo=tzutc()),
-            end=datetime(2019, 6, 30, 14, 30, tzinfo=tzutc()),
+            begin=datetime(2016, 10, 31, 14, 30, tzinfo=timezone.utc),
+            end=datetime(2019, 6, 30, 14, 30, tzinfo=timezone.utc),
         ),
-        newest_creation_time=datetime(2019, 6, 20, 11, 57, 34, tzinfo=tzutc()),
+        newest_creation_time=datetime(2019, 6, 20, 11, 57, 34, tzinfo=timezone.utc),
         timeline_period="day",
         timeline_count=91,
         crses={"EPSG:32632", "EPSG:32630", "EPSG:32627"},

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -12,12 +12,12 @@ from pathlib import Path
 from pprint import pformat
 from urllib.parse import urlsplit
 from urllib.request import urlopen
+from zoneinfo import ZoneInfo
 
 import jsonschema
 import pytest
 from datacube.migration import ODC2DeprecationWarning
 from datacube.utils import is_url, read_documents
-from dateutil import tz
 from flask.testing import FlaskClient
 from jsonschema import SchemaError
 from referencing import Registry, Resource
@@ -37,7 +37,7 @@ from integration_tests.asserts import (
 
 ALLOW_INTERNET = True
 
-DEFAULT_TZ = tz.gettz("Australia/Darwin")
+DEFAULT_TZ = ZoneInfo("Australia/Darwin")
 
 # Smaller values to ease testing.
 OUR_DATASET_LIMIT = 20

--- a/integration_tests/test_stores.py
+++ b/integration_tests/test_stores.py
@@ -5,7 +5,6 @@ from datetime import date, datetime, timezone
 
 import pytest
 from datacube.model import Range
-from dateutil import tz
 from shapely import geometry as geo
 
 from cubedash.summary import SummaryStore, TimePeriodOverview
@@ -33,17 +32,17 @@ def _overview(
         dataset_count=4,
         timeline_dataset_counts=Counter(
             [
-                datetime(2017, 1, 2, tzinfo=tz.tzutc()),
-                datetime(2017, 1, 3, tzinfo=tz.tzutc()),
-                datetime(2017, 1, 3, tzinfo=tz.tzutc()),
-                datetime(2017, 1, 1, tzinfo=tz.tzutc()),
+                datetime(2017, 1, 2, tzinfo=timezone.utc),
+                datetime(2017, 1, 3, tzinfo=timezone.utc),
+                datetime(2017, 1, 3, tzinfo=timezone.utc),
+                datetime(2017, 1, 1, tzinfo=timezone.utc),
             ]
         ),
         region_dataset_counts=Counter(["1_2", "1_2", "3_4", "4_5"]),
         timeline_period="day",
         time_range=Range(
-            datetime(2017, 1, 2, tzinfo=tz.tzutc()),
-            datetime(2017, 2, 3, tzinfo=tz.tzutc()),
+            datetime(2017, 1, 2, tzinfo=timezone.utc),
+            datetime(2017, 2, 3, tzinfo=timezone.utc),
         ),
         footprint_geometry=geo.Polygon(
             [
@@ -59,10 +58,10 @@ def _overview(
         ),
         footprint_crs="EPSG:3577",
         footprint_count=3,
-        newest_dataset_creation_time=datetime(2018, 1, 1, 1, 1, 1, tzinfo=tz.tzutc()),
+        newest_dataset_creation_time=datetime(2018, 1, 1, 1, 1, 1, tzinfo=timezone.utc),
         crses={"epsg:1234"},
         size_bytes=123_400_000,
-        product_refresh_time=datetime(2018, 2, 3, 1, 1, 1, tzinfo=tz.tzutc()),
+        product_refresh_time=datetime(2018, 2, 3, 1, 1, 1, tzinfo=timezone.utc),
     )
     return orig
 
@@ -224,7 +223,7 @@ def test_put_get_summaries(summary_store: SummaryStore) -> None:
     assert loaded.footprint_geometry.area == pytest.approx(o.footprint_geometry.area)
 
     o.dataset_count = 4321
-    o.newest_dataset_creation_time = datetime(2018, 2, 2, 2, 2, 2, tzinfo=tz.tzutc())
+    o.newest_dataset_creation_time = datetime(2018, 2, 2, 2, 2, 2, tzinfo=timezone.utc)
     time.sleep(1)
     summary_store._put(o)
     assert o.summary_gen_time != original_gen_time
@@ -232,7 +231,7 @@ def test_put_get_summaries(summary_store: SummaryStore) -> None:
     loaded = summary_store.get(product_name, 2017, None, None)
     assert loaded.dataset_count == 4321
     assert loaded.newest_dataset_creation_time == datetime(
-        2018, 2, 2, 2, 2, 2, tzinfo=tz.tzutc()
+        2018, 2, 2, 2, 2, 2, tzinfo=timezone.utc
     )
     assert loaded.summary_gen_time != original_gen_time, (
         "An update should update the generation time"

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -4,15 +4,14 @@ Load a lot of real-world DEA datasets (very slow)
 And then check their statistics match expected.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
+from zoneinfo import ZoneInfo
 
 import pytest
 from datacube import Datacube
 from datacube.index import Index
 from datacube.model import Product, Range
-from dateutil import tz
-from dateutil.tz import tzutc
 from sqlalchemy import text
 
 from cubedash.summary import SummaryStore
@@ -21,7 +20,7 @@ from cubedash.summary._schema import CUBEDASH_SCHEMA
 
 from .asserts import expect_values as _expect_values
 
-DEFAULT_TZ = tz.gettz("Australia/Darwin")
+DEFAULT_TZ = ZoneInfo("Australia/Darwin")
 
 METADATA_TYPES = [
     "metadata/eo3_landsat_ard.odc-type.yaml",
@@ -61,7 +60,7 @@ def test_generate_month(run_generate, summary_store: SummaryStore) -> None:
             begin=datetime(2017, 4, 1, 0, 0, tzinfo=DEFAULT_TZ),
             end=datetime(2017, 5, 1, 0, 0, tzinfo=DEFAULT_TZ),
         ),
-        newest_creation_time=datetime(2017, 7, 4, 11, 18, 20, tzinfo=tzutc()),
+        newest_creation_time=datetime(2017, 7, 4, 11, 18, 20, tzinfo=timezone.utc),
         timeline_period="day",
         timeline_count=30,
         crses={
@@ -90,7 +89,7 @@ def test_generate_scene_year(run_generate, summary_store: SummaryStore) -> None:
             begin=datetime(2017, 1, 1, 0, 0, tzinfo=DEFAULT_TZ),
             end=datetime(2018, 1, 1, 0, 0, tzinfo=DEFAULT_TZ),
         ),
-        newest_creation_time=datetime(2018, 1, 10, 3, 11, 56, tzinfo=tzutc()),
+        newest_creation_time=datetime(2018, 1, 10, 3, 11, 56, tzinfo=timezone.utc),
         timeline_period="day",
         timeline_count=365,
         crses={
@@ -126,7 +125,7 @@ def test_generate_scene_all_time(run_generate, summary_store: SummaryStore) -> N
             begin=datetime(2016, 1, 1, 0, 0, tzinfo=DEFAULT_TZ),
             end=datetime(2018, 1, 1, 0, 0, tzinfo=DEFAULT_TZ),
         ),
-        newest_creation_time=datetime(2018, 1, 10, 3, 11, 56, tzinfo=tzutc()),
+        newest_creation_time=datetime(2018, 1, 10, 3, 11, 56, tzinfo=timezone.utc),
         timeline_period="month",
         timeline_count=24,
         crses={
@@ -427,7 +426,7 @@ def test_generate_telemetry(run_generate, summary_store: SummaryStore) -> None:
             "115": 27,
             "88": 27,
         },
-        newest_creation_time=datetime(2017, 12, 31, 3, 38, 43, tzinfo=tzutc()),
+        newest_creation_time=datetime(2017, 12, 31, 3, 38, 43, tzinfo=timezone.utc),
         timeline_period="month",
         timeline_count=24,
         crses={"EPSG:4326"},
@@ -446,7 +445,9 @@ def test_generate_day(run_generate, summary_store: SummaryStore) -> None:
             begin=datetime(2022, 7, 19, 0, 0, tzinfo=DEFAULT_TZ),
             end=datetime(2022, 7, 20, 0, 0, tzinfo=DEFAULT_TZ),
         ),
-        newest_creation_time=datetime(2022, 8, 23, 14, 56, 45, 940_847, tzinfo=tzutc()),
+        newest_creation_time=datetime(
+            2022, 8, 23, 14, 56, 45, 940_847, tzinfo=timezone.utc
+        ),
         timeline_period="day",
         timeline_count=1,
         crses={"EPSG:32656", "EPSG:32652"},
@@ -522,7 +523,9 @@ def test_calc_albers_summary_with_storage(summary_store: SummaryStore) -> None:
             begin=datetime(2017, 4, 1, 0, 0, tzinfo=DEFAULT_TZ),
             end=datetime(2017, 6, 1, 0, 0, tzinfo=DEFAULT_TZ),
         ),
-        newest_creation_time=datetime(2017, 10, 25, 23, 9, 2, 486_851, tzinfo=tzutc()),
+        newest_creation_time=datetime(
+            2017, 10, 25, 23, 9, 2, 486_851, tzinfo=timezone.utc
+        ),
         timeline_period="day",
         # Data spans 61 days in 2017
         timeline_count=61,

--- a/integration_tests/test_utc_tst.py
+++ b/integration_tests/test_utc_tst.py
@@ -8,7 +8,6 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from datacube.model import Range
-from dateutil import tz
 from flask.testing import FlaskClient
 
 from cubedash._utils import datetime_from_metadata, default_utc
@@ -101,10 +100,10 @@ def test_clirunner_generate_grouping_timezone(
                 "product": "ga_ls9c_ard_3",
                 "time": Range(
                     begin=datetime(
-                        2021, 12, 27, 0, 0, tzinfo=tz.gettz("America/Chicago")
+                        2021, 12, 27, 0, 0, tzinfo=ZoneInfo("America/Chicago")
                     ),
                     end=datetime(
-                        2021, 12, 28, 0, 0, tzinfo=tz.gettz("America/Chicago")
+                        2021, 12, 28, 0, 0, tzinfo=ZoneInfo("America/Chicago")
                     ),
                 ),
             },
@@ -121,9 +120,9 @@ def test_clirunner_generate_grouping_timezone(
                 "product": "ga_ls9c_ard_3",
                 "time": Range(
                     begin=datetime(
-                        2021, 12, 31, 0, 0, tzinfo=tz.gettz("America/Chicago")
+                        2021, 12, 31, 0, 0, tzinfo=ZoneInfo("America/Chicago")
                     ),
-                    end=datetime(2022, 1, 1, 0, 0, tzinfo=tz.gettz("America/Chicago")),
+                    end=datetime(2022, 1, 1, 0, 0, tzinfo=ZoneInfo("America/Chicago")),
                 ),
             },
             limit=5,

--- a/integration_tests/test_wagl_data.py
+++ b/integration_tests/test_wagl_data.py
@@ -2,11 +2,10 @@
 Tests that load pages and check the contained text.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from datacube.model import Range
-from dateutil.tz import tzutc
 from flask.testing import FlaskClient
 
 from cubedash.summary import SummaryStore
@@ -29,10 +28,12 @@ def test_s2_ard_summary(run_generate, summary_store: SummaryStore) -> None:
         dataset_count=8,
         footprint_count=8,
         time_range=Range(
-            begin=datetime(2017, 9, 30, 14, 30, tzinfo=tzutc()),
-            end=datetime(2017, 10, 31, 14, 30, tzinfo=tzutc()),
+            begin=datetime(2017, 9, 30, 14, 30, tzinfo=timezone.utc),
+            end=datetime(2017, 10, 31, 14, 30, tzinfo=timezone.utc),
         ),
-        newest_creation_time=datetime(2018, 7, 26, 23, 49, 25, 684_327, tzinfo=tzutc()),
+        newest_creation_time=datetime(
+            2018, 7, 26, 23, 49, 25, 684_327, tzinfo=timezone.utc
+        ),
         timeline_period="day",
         timeline_count=31,
         crses={"EPSG:32753"},
@@ -48,10 +49,10 @@ def test_s2a_l1_summary(run_generate, summary_store: SummaryStore) -> None:
         dataset_count=8,
         footprint_count=8,
         time_range=Range(
-            begin=datetime(2017, 9, 30, 14, 30, tzinfo=tzutc()),
-            end=datetime(2017, 10, 31, 14, 30, tzinfo=tzutc()),
+            begin=datetime(2017, 9, 30, 14, 30, tzinfo=timezone.utc),
+            end=datetime(2017, 10, 31, 14, 30, tzinfo=timezone.utc),
         ),
-        newest_creation_time=datetime(2017, 10, 23, 1, 13, 7, tzinfo=tzutc()),
+        newest_creation_time=datetime(2017, 10, 23, 1, 13, 7, tzinfo=timezone.utc),
         timeline_period="day",
         timeline_count=31,
         crses={"EPSG:32753"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "pyorbital",
     "pyproj",
     "pystac",
-    "python-dateutil",
     "sentry-sdk[flask]",
     "shapely",
     "simplekml",
@@ -99,7 +98,6 @@ test = [
     "selectolax",
     "types-cachetools",
     "types-docker",
-    "types-python-dateutil",
     "types-pyyaml"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -683,7 +683,6 @@ dependencies = [
     { name = "pyproj", version = "3.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pyproj", version = "3.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pystac" },
-    { name = "python-dateutil" },
     { name = "sentry-sdk", extra = ["flask"] },
     { name = "shapely" },
     { name = "simplekml" },
@@ -724,7 +723,6 @@ test = [
     { name = "setproctitle" },
     { name = "types-cachetools" },
     { name = "types-docker" },
-    { name = "types-python-dateutil" },
     { name = "types-pyyaml" },
 ]
 
@@ -796,7 +794,6 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'" },
     { name = "pytest-benchmark", marker = "extra == 'test'" },
     { name = "pytest-cov", marker = "extra == 'test'" },
-    { name = "python-dateutil" },
     { name = "ruff", marker = "extra == 'test'" },
     { name = "selectolax", marker = "extra == 'test'" },
     { name = "sentry-sdk", extras = ["flask"] },
@@ -807,7 +804,6 @@ requires-dist = [
     { name = "structlog", specifier = ">=20.2.0" },
     { name = "types-cachetools", marker = "extra == 'test'" },
     { name = "types-docker", marker = "extra == 'test'" },
-    { name = "types-python-dateutil", marker = "extra == 'test'" },
     { name = "types-pyyaml", marker = "extra == 'test'" },
 ]
 provides-extras = ["deployment", "test"]
@@ -3836,15 +3832,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/05/074063f0dbb7861d3bf73d72394671c7b0e19f6adb212ea5ae1a911471ca/types_docker-7.1.0.20250907.tar.gz", hash = "sha256:148654b2749914b6b5a0776bec7fbfa700cfcc5028add5f2c55e396509e4fda3", size = 31085, upload-time = "2025-09-07T02:56:32.169Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/8d/4da1a91bb0bcfbde29df8ffdb4b3c268156822311f374ec0618fc0e1b3d2/types_docker-7.1.0.20250907-py3-none-any.whl", hash = "sha256:aa415c62591eeaabfaa59481d4264f378938cc54e0c7ae645211cd1b451261d5", size = 45834, upload-time = "2025-09-07T02:56:31.051Z" },
-]
-
-[[package]]
-name = "types-python-dateutil"
-version = "2.9.0.20250822"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/0a/775f8551665992204c756be326f3575abba58c4a3a52eef9909ef4536428/types_python_dateutil-2.9.0.20250822.tar.gz", hash = "sha256:84c92c34bd8e68b117bff742bc00b692a1e8531262d4507b33afcc9f7716cd53", size = 16084, upload-time = "2025-08-22T03:02:00.613Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/d9/a29dfa84363e88b053bf85a8b7f212a04f0d7343a4d24933baa45c06e08b/types_python_dateutil-2.9.0.20250822-py3-none-any.whl", hash = "sha256:849d52b737e10a6dc6621d2bd7940ec7c65fcb69e6aa2882acf4e56b2b508ddc", size = 17892, upload-time = "2025-08-22T03:01:59.436Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Python 3.9 got a lot of the required support, and 3.10 got the remaining parts that Explorer is using. Switch to the standard library functions since this package requires Python 3.10.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--861.org.readthedocs.build/en/861/

<!-- readthedocs-preview datacube-explorer end -->