### PR TITLE
Allow running tests outside of, and without docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ refer to [deployment instructions](https://datacube-explorer.readthedocs.io/en/l
 
 ### How do I modify the CSS/Javascript?
 
-The CSS is compiled from [Sass](https://sass-lang.com/), and the Javascript is compiled from
+The CSS is compiled from [Sass](https://sass-lang.com/), and the JavaScript is compiled from
 [Typescript](https://www.typescriptlang.org/).
 
 Install [npm](https://www.npmjs.com/get-npm), and then install them both:
@@ -178,6 +178,35 @@ be available, but no further database setup is required.
 Install the test dependencies: `pip install -e .[test]`
 
 The run the tests with: `pytest integration_tests`
+
+**Docker Compose alternative:**
+See below for running the tests using `docker compose`.
+
+**Without Docker alternative:**
+
+Assuming you have a PostgreSQL server running locally, that you're setup to log into.
+
+```
+# Create a test database to use
+$ createdb odc-explorer-testing
+
+# Add the PostGIS extensions to it
+$ psql odc-explorer-testing
+odc-explorer-testing=# create extension if not exists postgis;
+CREATE EXTENSION
+
+# Export environment variables so that the tests know which Database to use
+$ export ODC_DEFAULT_INDEX_DRIVER=postgres
+$ export ODC_POSTGIS_INDEX_DRIVER=postgis
+$ export ODC_DEFAULT_DB_URL=postgresql://localhost/odc-explorer-testing
+$ export ODC_POSTGIS_DB_URL=postgresql://localhost/odc-explorer-testing
+$ export CUBEDASH_BYPASS_DOCKER=True
+
+# Finally, run the tests
+$ uv run pytest integration_tests/
+
+```
+
 
 ### How do I add test data for the automated tests?
 

--- a/cubedash/testutils/database.py
+++ b/cubedash/testutils/database.py
@@ -38,8 +38,10 @@ def postgresql_server():
     # If we're running inside docker already, don't attempt to start a container!
     # Hopefully we're using the `with-test-db` script and can use *that* database.
     # I think this may be copypasta from odc-tools
-    if Path("/.dockerenv").exists() and (
-        "ODC_DEFAULT_DB_URL" in os.environ or "ODC_POSTGIS_DB_URL" in os.environ
+    if (
+        "CUBEDASH_BYPASS_DOCKER" in os.environ
+        or Path("/.dockerenv").exists()
+        and ("ODC_DEFAULT_DB_URL" in os.environ or "ODC_POSTGIS_DB_URL" in os.environ)
     ):
         yield GET_DB_FROM_ENV
     else:
@@ -136,7 +138,6 @@ def odc_test_db(cfg_env):
     the default ODC DB by setting environment variables.
     :return: Datacube instance
     """
-
     index = index_connect(cfg_env, validate_connection=False)
     index.init_db()
 


### PR DESCRIPTION
Set `CUBEDASH_BYPASS_DOCKER=True` as an environment variable along with DB access environment variables to allow running the integration tests outside of docker, and without spawning PostGIS containers.

Also document this in the README

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--869.org.readthedocs.build/en/869/

<!-- readthedocs-preview datacube-explorer end -->