### PR TITLE
Fix timezone sensitive tests

### DIFF
--- a/cubedash/testutils/database.py
+++ b/cubedash/testutils/database.py
@@ -147,6 +147,12 @@ def odc_test_db(cfg_env):
     # during testing, and need any performance gains we can get.
 
     with index._db._engine.begin() as conn:  # type: ignore[attr-defined]
+        # Some tests are sensitive to the timezone of the database, and expect it to be UTC
+        quoted_db_name = conn.dialect.identifier_preparer.quote(
+            index._db._engine.url.database  # type: ignore[attr-defined]
+        )
+        conn.execute(text(f"ALTER DATABASE {quoted_db_name} SET timezone TO 'UTC'"))
+
         if index.name == "pg_index":
             for table in [
                 "agdc.dataset_location",

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from textwrap import indent
@@ -140,6 +142,26 @@ def client(unpopulated_client: FlaskClient) -> FlaskClient:
             _model.STORE.refresh(product.name)
 
     return unpopulated_client
+
+
+@pytest.fixture()
+def fix_utc_timezone():
+    """Set the timezone to UTC."""
+    original_tz = os.environ.get("TZ")
+    os.environ["TZ"] = "UTC"
+
+    # tzset isn't available in Windows
+    if hasattr(time, "tzset"):
+        time.tzset()
+
+    yield
+
+    if original_tz is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = original_tz
+    if hasattr(time, "tzset"):
+        time.tzset()
 
 
 def pytest_assertrepr_compare(

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -790,9 +790,11 @@ def test_invalid_product_returns_not_found(client: FlaskClient) -> None:
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_show_summary_cli(clirunner, client: FlaskClient, fix_utc_timezone) -> None:
+def test_show_summary_cli(clirunner, client: FlaskClient) -> None:
     """
     You should be able to view a product with cubedash-view command-line program.
+
+    This test expects the database timezone to be UTC
     """
     # ls7_nbar_scene, 2017, May
     res = clirunner(show.cli, ["ls7_nbar_scene", "2017", "5"])
@@ -810,7 +812,8 @@ def test_show_summary_cli(clirunner, client: FlaskClient, fix_utc_timezone) -> N
             f"  to {expected_to.isoformat()} ",
         )
     )
-    assert res.output.startswith(expected_header)
+    result_header = "\n".join(res.output.splitlines()[:5])
+    assert expected_header == result_header
     expected_metadata = "\n".join(  # noqa: FLY002
         (
             "Metadata",

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -790,7 +790,7 @@ def test_invalid_product_returns_not_found(client: FlaskClient) -> None:
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_show_summary_cli(clirunner, client: FlaskClient) -> None:
+def test_show_summary_cli(clirunner, client: FlaskClient, fix_utc_timezone) -> None:
     """
     You should be able to view a product with cubedash-view command-line program.
     """

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -632,10 +632,12 @@ def test_arrivals_page_validation(stac_client: FlaskClient) -> None:
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_collection(stac_client: FlaskClient, fix_utc_timezone):
+def test_stac_collection(stac_client: FlaskClient):
     """
     Follow the links to the "high_tide_comp_20p" collection and ensure it includes
     all of our tests data.
+
+    This test expects the database timezone to be UTC
     """
 
     collections = get_json(stac_client, "/stac")

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -632,7 +632,7 @@ def test_arrivals_page_validation(stac_client: FlaskClient) -> None:
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_collection(stac_client: FlaskClient):
+def test_stac_collection(stac_client: FlaskClient, fix_utc_timezone):
     """
     Follow the links to the "high_tide_comp_20p" collection and ensure it includes
     all of our tests data.

--- a/integration_tests/test_stores.py
+++ b/integration_tests/test_stores.py
@@ -120,7 +120,7 @@ def test_add_no_periods(summary_store: SummaryStore) -> None:
     assert summary_store.get("ga_ls8c_level1_3", 2015, 7, None) is None
 
 
-def test_month_iteration() -> None:
+def test_month_iteration(fix_utc_timezone) -> None:
     def assert_month_iteration(
         start: datetime, end: datetime, expected_months: list[date]
     ) -> None:


### PR DESCRIPTION
These tests started failing when I started running them outside the usual docker container, or with a different database configuration.

While it's possible there are bugs with the exact bounds of summary data generation, and not just in the test code, I absolutely do not want to go there this week.

The goal here is to make the tests more useful by being less flaky and move onto actual bugs/features/performance improvements.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--870.org.readthedocs.build/en/870/

<!-- readthedocs-preview datacube-explorer end -->