### PR TITLE
Speedup STAC collections endpoint

### DIFF
--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -283,11 +283,7 @@ def as_stac_collection(res: CollectionItem) -> pystac.Collection:
         providers=[],
         extent=Extent(
             pystac.SpatialExtent(
-                bboxes=[
-                    res.footprint_wgs84.bounds
-                    if res.footprint_wgs84
-                    else [-180.0, -90.0, 180.0, 90.0]
-                ]
+                bboxes=[res.bbox if res.bbox else [-180.0, -90.0, 180.0, 90.0]]
             ),
             temporal=pystac.TemporalExtent(
                 intervals=[

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -283,7 +283,10 @@ def as_stac_collection(res: CollectionItem) -> pystac.Collection:
         providers=[],
         extent=Extent(
             pystac.SpatialExtent(
-                bboxes=[res.bbox if res.bbox else [-180.0, -90.0, 180.0, 90.0]]
+                # TODO: Find a nicer way to make the typechecker happier
+                # pystac is too specific in wanting a list[float | int]
+                # odc-geo BoundingBox class is a Sequence[float]
+                bboxes=[list(res.bbox) if res.bbox else [-180.0, -90.0, 180.0, 90.0]]
             ),
             temporal=pystac.TemporalExtent(
                 intervals=[

--- a/cubedash/index/api.py
+++ b/cubedash/index/api.py
@@ -141,10 +141,6 @@ class ExplorerAbstractIndex(ABC):
     def product_summary_cols(self, product_name: str) -> Row: ...
 
     @abstractmethod
-    def collection_cols(self) -> Select:
-        """Get all columns necessary for creating a Collection"""
-
-    @abstractmethod
     def collections_search_query(
         self,
         limit: int,

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -42,7 +42,7 @@ from sqlalchemy import (
     union_all,
     update,
 )
-from sqlalchemy.dialects.postgresql import TSTZRANGE, insert
+from sqlalchemy.dialects.postgresql import TSTZRANGE, array, insert
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import ColumnElement
 from sqlalchemy.types import TIMESTAMP
@@ -347,27 +347,6 @@ class ExplorerIndex(ExplorerAbstractIndex):
             )
 
     @override
-    def collection_cols(self) -> Select:
-        product_overview = (
-            select(
-                ProductSpatial.name,
-                TimeOverview.footprint_geometry,
-                ProductSpatial.time_earliest,
-                ProductSpatial.time_latest,
-                TimeOverview.period_type,
-            )
-            .select_from(TimeOverview)
-            .join(ProductSpatial)
-            .cte("product_overview")
-        )
-
-        return (
-            select(ODC_PRODUCT.definition, product_overview)
-            .select_from(product_overview)
-            .join(ODC_PRODUCT, product_overview.c.name == ODC_PRODUCT.name)
-        )
-
-    @override
     def collections_search_query(
         self,
         limit: int,
@@ -376,23 +355,49 @@ class ExplorerIndex(ExplorerAbstractIndex):
         bbox: tuple[float, float, float, float] | None = None,
         time: tuple[datetime, datetime] | None = None,
         q: Sequence[str] | None = None,
-    ) -> Result:
-        collection = self.collection_cols().subquery()
-        query = select(collection).where(collection.c.period_type == "all")
-
+    ) -> list[Row]:
+        # STAC Collections only hold a bounding box in EPSG:4326, no geometry
+        # Calculate the bounding box on the server, it's far more efficient
+        collection_bbox = func.Box2D(
+            func.ST_Transform(TimeOverview.footprint_geometry, 4326)
+        )
+        bbox_array = array(
+            [
+                func.ST_XMin(collection_bbox),
+                func.ST_YMin(collection_bbox),
+                func.ST_XMax(collection_bbox),
+                func.ST_YMax(collection_bbox),
+            ]
+        )
+        bbox_or_null = case(
+            (func.ST_XMin(collection_bbox).is_(None), None), else_=bbox_array
+        )
+        query = (
+            select(
+                ODC_PRODUCT.definition,
+                ProductSpatial.name,
+                bbox_or_null.label("bbox"),
+                ProductSpatial.time_earliest,
+                ProductSpatial.time_latest,
+            )
+            .select_from(TimeOverview)
+            .join(ProductSpatial, ProductSpatial.id == TimeOverview.product_ref)
+            .join(ODC_PRODUCT, ProductSpatial.name == ODC_PRODUCT.name)
+            .where(TimeOverview.period_type == "all")
+        )
         if name:
-            query = query.where(collection.c.name == name)
+            query = query.where(ProductSpatial.name == name)
 
         if bbox:
             query = query.where(
-                collection.c.footprint_geometry.intersects(func.ST_MakeEnvelope(*bbox))
+                TimeOverview.footprint_geometry.intersects(func.ST_MakeEnvelope(*bbox))
             )
 
         if time:
             query = query.where(
                 and_(
-                    default_utc(time[0]) <= default_utc(collection.c.time_latest),
-                    default_utc(collection.c.time_earliest) <= default_utc(time[1]),
+                    default_utc(time[0]) <= default_utc(ProductSpatial.time_latest),
+                    default_utc(ProductSpatial.time_earliest) <= default_utc(time[1]),
                 )
             )
 
@@ -400,7 +405,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
             title = SimpleDocField(
                 name="title",
                 description="product title",
-                alchemy_column=collection.c.definition,
+                alchemy_column=ODC_PRODUCT.definition,
                 indexed=False,
                 offset=("metadata", "title"),
             )
@@ -408,7 +413,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
             description = SimpleDocField(
                 name="description",
                 description="product description",
-                alchemy_column=collection.c.definition,
+                alchemy_column=ODC_PRODUCT.definition,
                 indexed=False,
                 offset=("description"),
             )
@@ -419,7 +424,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
                     [
                         title.alchemy_expression.icontains(value),
                         description.alchemy_expression.icontains(value),
-                        collection.c.name.icontains(value),
+                        ODC_PRODUCT.name.icontains(value),
                     ]
                 )
             query = query.where(or_(*expressions))

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -356,8 +356,13 @@ class ExplorerIndex(ExplorerAbstractIndex):
         time: tuple[datetime, datetime] | None = None,
         q: Sequence[str] | None = None,
     ) -> list[Row]:
-        # STAC Collections only hold a bounding box in EPSG:4326, no geometry
+        # STAC Collections only hold a bounding box in EPSG:4326, no polygons
         # Calculate the bounding box on the server, it's far more efficient
+
+        # The Cubedash Product (which maps to a STAC Collection) doesn't have
+        # any bounding box or geometry attached, all the geometries are in the
+        # TimeOverview table, grouped by different `period_types`. In this case
+        # we use the `period_type=="all"` to get the one that covers all time.
         collection_bbox = func.Box2D(
             func.ST_Transform(TimeOverview.footprint_geometry, 4326)
         )
@@ -369,14 +374,13 @@ class ExplorerIndex(ExplorerAbstractIndex):
                 func.ST_YMax(collection_bbox),
             ]
         )
-        bbox_or_null = case(
-            (func.ST_XMin(collection_bbox).is_(None), None), else_=bbox_array
-        )
         query = (
             select(
                 ODC_PRODUCT.definition,
                 ProductSpatial.name,
-                bbox_or_null.label("bbox"),
+                case(
+                    (func.ST_XMin(collection_bbox).is_(None), None), else_=bbox_array
+                ).label("bbox"),
                 ProductSpatial.time_earliest,
                 ProductSpatial.time_latest,
             )
@@ -395,10 +399,8 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
         if time:
             query = query.where(
-                and_(
-                    default_utc(time[0]) <= default_utc(ProductSpatial.time_latest),
-                    default_utc(ProductSpatial.time_earliest) <= default_utc(time[1]),
-                )
+                default_utc(time[0]) <= ProductSpatial.time_latest,
+                ProductSpatial.time_earliest <= default_utc(time[1]),
             )
 
         if q:
@@ -415,7 +417,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
                 description="product description",
                 alchemy_column=ODC_PRODUCT.definition,
                 indexed=False,
-                offset=("description"),
+                offset=("description",),
             )
 
             expressions = []

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -41,7 +41,7 @@ from sqlalchemy import (
     text,
     union_all,
 )
-from sqlalchemy.dialects.postgresql import TSTZRANGE, insert
+from sqlalchemy.dialects.postgresql import TSTZRANGE, array, insert
 from sqlalchemy.sql import ColumnElement
 
 import cubedash.summary._schema as _schema
@@ -402,12 +402,27 @@ class ExplorerIndex(ExplorerAbstractIndex):
         time: tuple[datetime, datetime] | None = None,
         q: Sequence[str] | None = None,
     ) -> Result:
-        # Direct query without CTE (potentially faster)
+        # STAC Collections only hold a bounding box in EPSG:4326, no geometry
+        # Calculate the bounding box on the server, it's far more efficient
+        collection_bbox = func.Box2D(
+            func.ST_Transform(TIME_OVERVIEW.c.footprint_geometry, 4326)
+        )
+        bbox_array = array(
+            [
+                func.ST_XMin(collection_bbox),
+                func.ST_YMin(collection_bbox),
+                func.ST_XMax(collection_bbox),
+                func.ST_YMax(collection_bbox),
+            ]
+        )
+        bbox_or_null = case(
+            (func.ST_XMin(collection_bbox).is_(None), None), else_=bbox_array
+        )
         query = (
             select(
                 ODC_PRODUCT.c.definition,
                 PRODUCT.c.name,
-                func.Box2D(func.ST_Transform(TIME_OVERVIEW.c.footprint_geometry, 4326)).label('bbox'),
+                bbox_or_null.label("bbox"),
                 PRODUCT.c.time_earliest,
                 PRODUCT.c.time_latest,
             )
@@ -418,6 +433,8 @@ class ExplorerIndex(ExplorerAbstractIndex):
             )
             .where(TIME_OVERVIEW.c.period_type == "all")
         )
+        logger.info('basic stac collections query', query=str(query))
+        #                func.Box2D(func.ST_Transform(TIME_OVERVIEW.c.footprint_geometry, 4326)).label('bbox'),
 
         if name:
             query = query.where(PRODUCT.c.name == name)
@@ -467,7 +484,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
         query = query.limit(limit).offset(offset)
 
-        with self.index._active_connection() as conn:
+        with self.engine.begin() as conn:
             return conn.execute(query)
 
     @override

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -393,26 +393,6 @@ class ExplorerIndex(ExplorerAbstractIndex):
             )
 
     @override
-    def collection_cols(self) -> Select:
-        product_overview = (
-            select(
-                PRODUCT.c.name,
-                TIME_OVERVIEW.c.footprint_geometry,
-                PRODUCT.c.time_earliest,
-                PRODUCT.c.time_latest,
-                TIME_OVERVIEW.c.period_type,
-            )
-            .select_from(TIME_OVERVIEW.join(PRODUCT))
-            .cte("product_overview")
-        )
-
-        return select(ODC_PRODUCT.c.definition, product_overview).select_from(
-            product_overview.join(
-                ODC_PRODUCT, product_overview.c.name == ODC_PRODUCT.c.name
-            )
-        )
-
-    @override
     def collections_search_query(
         self,
         limit: int,
@@ -422,22 +402,38 @@ class ExplorerIndex(ExplorerAbstractIndex):
         time: tuple[datetime, datetime] | None = None,
         q: Sequence[str] | None = None,
     ) -> Result:
-        collection = self.collection_cols().alias("collection")
-        query = select(collection).where(collection.c.period_type == "all")
+        # Direct query without CTE (potentially faster)
+        query = (
+            select(
+                ODC_PRODUCT.c.definition,
+                PRODUCT.c.name,
+                func.Box2D(func.ST_Transform(TIME_OVERVIEW.c.footprint_geometry, 4326)).label('bbox'),
+                PRODUCT.c.time_earliest,
+                PRODUCT.c.time_latest,
+            )
+            .select_from(
+                TIME_OVERVIEW.join(
+                    PRODUCT, PRODUCT.c.id == TIME_OVERVIEW.c.product_ref
+                ).join(ODC_PRODUCT, PRODUCT.c.name == ODC_PRODUCT.c.name)
+            )
+            .where(TIME_OVERVIEW.c.period_type == "all")
+        )
 
         if name:
-            query = query.where(collection.c.name == name)
+            query = query.where(PRODUCT.c.name == name)
 
         if bbox:
             query = query.where(
-                collection.c.footprint_geometry.intersects(func.ST_MakeEnvelope(*bbox))
+                TIME_OVERVIEW.c.footprint_geometry.intersects(
+                    func.ST_MakeEnvelope(*bbox)
+                )
             )
 
         if time:
             query = query.where(
                 and_(
-                    default_utc(time[0]) <= default_utc(collection.c.time_latest),
-                    default_utc(collection.c.time_earliest) <= default_utc(time[1]),
+                    default_utc(time[0]) <= default_utc(PRODUCT.c.time_latest),
+                    default_utc(PRODUCT.c.time_earliest) <= default_utc(time[1]),
                 )
             )
 
@@ -445,7 +441,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
             title = SimpleDocField(
                 name="title",
                 description="product title",
-                alchemy_column=collection.c.definition,
+                alchemy_column=ODC_PRODUCT.c.definition,
                 indexed=False,
                 offset=("metadata", "title"),
             )
@@ -453,9 +449,9 @@ class ExplorerIndex(ExplorerAbstractIndex):
             description = SimpleDocField(
                 name="description",
                 description="product description",
-                alchemy_column=collection.c.definition,
+                alchemy_column=ODC_PRODUCT.c.definition,
                 indexed=False,
-                offset=("description"),
+                offset=("description",),
             )
 
             expressions = []
@@ -464,7 +460,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
                     [
                         title.alchemy_expression.icontains(value),
                         description.alchemy_expression.icontains(value),
-                        collection.c.name.icontains(value),
+                        ODC_PRODUCT.c.name.icontains(value),
                     ]
                 )
             query = query.where(or_(*expressions))

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -402,8 +402,14 @@ class ExplorerIndex(ExplorerAbstractIndex):
         time: tuple[datetime, datetime] | None = None,
         q: Sequence[str] | None = None,
     ) -> Result:
-        # STAC Collections only hold a bounding box in EPSG:4326, no geometry
-        # Calculate the bounding box on the server, it's far more efficient
+        # STAC Collections only hold a bounding box in EPSG:4326, no polygons
+        # Calculate the bounding box on the server, it's far more efficient.
+
+        # The Cubedash Product (which maps to a STAC Collection) doesn't have
+        # any bounding box or geometry attached, all the geometries are in the
+        # TimeOverview table, grouped by different `period_types`. In this case
+        # we use the `period_type=="all"` to get the one that covers all time.
+
         collection_bbox = func.Box2D(
             func.ST_Transform(TIME_OVERVIEW.c.footprint_geometry, 4326)
         )
@@ -415,14 +421,13 @@ class ExplorerIndex(ExplorerAbstractIndex):
                 func.ST_YMax(collection_bbox),
             ]
         )
-        bbox_or_null = case(
-            (func.ST_XMin(collection_bbox).is_(None), None), else_=bbox_array
-        )
         query = (
             select(
                 ODC_PRODUCT.c.definition,
                 PRODUCT.c.name,
-                bbox_or_null.label("bbox"),
+                case(
+                    (func.ST_XMin(collection_bbox).is_(None), None), else_=bbox_array
+                ).label("bbox"),
                 PRODUCT.c.time_earliest,
                 PRODUCT.c.time_latest,
             )
@@ -446,10 +451,8 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
         if time:
             query = query.where(
-                and_(
-                    default_utc(time[0]) <= PRODUCT.c.time_latest,
-                    PRODUCT.c.time_earliest <= default_utc(time[1]),
-                )
+                default_utc(time[0]) <= PRODUCT.c.time_latest,
+                PRODUCT.c.time_earliest <= default_utc(time[1]),
             )
 
         if q:
@@ -482,7 +485,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
         query = query.limit(limit).offset(offset)
 
-        with self.engine.begin() as conn:
+        with self.index._active_connection() as conn:
             return conn.execute(query)
 
     @override

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -433,8 +433,6 @@ class ExplorerIndex(ExplorerAbstractIndex):
             )
             .where(TIME_OVERVIEW.c.period_type == "all")
         )
-        logger.info('basic stac collections query', query=str(query))
-        #                func.Box2D(func.ST_Transform(TIME_OVERVIEW.c.footprint_geometry, 4326)).label('bbox'),
 
         if name:
             query = query.where(PRODUCT.c.name == name)
@@ -449,8 +447,8 @@ class ExplorerIndex(ExplorerAbstractIndex):
         if time:
             query = query.where(
                 and_(
-                    default_utc(time[0]) <= default_utc(PRODUCT.c.time_latest),
-                    default_utc(PRODUCT.c.time_earliest) <= default_utc(time[1]),
+                    default_utc(time[0]) <= PRODUCT.c.time_latest,
+                    PRODUCT.c.time_earliest <= default_utc(time[1]),
                 )
             )
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -17,13 +17,12 @@ from eodatasets3.stac import MAPPING_EO3_TO_STAC
 from geoalchemy2 import WKBElement
 from geoalchemy2 import shape as geo_shape
 from geoalchemy2.shape import from_shape, to_shape
-from odc.geo import MaybeCRS
+from odc.geo import BoundingBox, MaybeCRS
 from pygeofilter.backends.sqlalchemy.evaluate import (
     SQLAlchemyFilterEvaluator as FilterEvaluator,
 )
 from pygeofilter.parsers.cql2_json import parse as parse_cql2_json
 from pygeofilter.parsers.cql2_text import parse as parse_cql2_text
-from shapely.geometry import MultiPolygon
 from shapely.geometry.base import BaseGeometry
 from sqlalchemy import Row, RowMapping, func, select
 from sqlalchemy.dialects.postgresql import TSTZRANGE
@@ -187,22 +186,7 @@ class CollectionItem:
     definition: dict[str, Any]
     time_earliest: datetime | None
     time_latest: datetime | None
-    footprint_geometry: Geometry | None
-    footprint_crs: str | None
-
-    @property
-    def footprint_wgs84(self) -> MultiPolygon | None:
-        if not self.footprint_geometry:
-            return None
-        if not self.footprint_crs:
-            _LOG.warning(f"Geometry without a crs for {self.name}", stacklevel=2)
-            return None
-
-        return (
-            Geometry(self.footprint_geometry, crs=self.footprint_crs)
-            .to_crs("EPSG:4326", wrapdateline=True)
-            .geom
-        )
+    bbox: BoundingBox | None
 
     @property
     def title(self) -> str:
@@ -1602,6 +1586,9 @@ def _summary_from_row(
 def _row_to_collection(
     res: Row, grouping_timezone: tzinfo = default_timezone
 ) -> CollectionItem:
+    # the 'res' at the moment has
+    # ('definition', 'name', 'bbox', 'time_earliest', 'time_latest')
+
     return CollectionItem(
         name=res.name,
         time_earliest=res.time_earliest.astimezone(grouping_timezone)
@@ -1610,16 +1597,7 @@ def _row_to_collection(
         time_latest=res.time_latest.astimezone(grouping_timezone)
         if res.time_latest
         else None,
-        footprint_geometry=(
-            None
-            if res.footprint_geometry is None
-            else geo_shape.to_shape(res.footprint_geometry)
-        ),
-        footprint_crs=(
-            None
-            if res.footprint_geometry is None or res.footprint_geometry.srid == -1
-            else "EPSG:{}".format(res.footprint_geometry.srid)
-        ),
+        bbox=res.bbox,
         definition=res.definition,
     )
 

--- a/integration_tests/asserts.py
+++ b/integration_tests/asserts.py
@@ -101,7 +101,7 @@ def get_json(client: FlaskClient, url: str, expect_status_code=200) -> dict:
             f"Expected status {expect_status_code} not {rv.status_code}."
             f"\nGot:\n{indent(rv.data.decode('utf-8'), ' ' * 6)}"
         )
-        assert rv.is_json, "Expected json content type in response"
+        assert rv.is_json, "Expected JSON content type in response"
         data = rv.json
         assert data is not None, "Empty response from server"
     except AssertionError:

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -707,6 +707,38 @@ def test_stac_collection(stac_client: FlaskClient):
     validate_items(_iter_items_across_pages(stac_client, item_links), expect_count=306)
 
 
+# TODO
+# We probably should check the conformance classes being returned.
+# They're in the root /stac/ response under the `conformsTo` item.
+# They are also served up at /stac/conformance in recent releases
+
+#######
+# Tests for STAC API - Features/Collections
+# https://api.stacspec.org/v1.0.0/ogcapi-features/
+# https://github.com/radiantearth/stac-api-spec/tree/release/v1.0.0/ogcapi-features
+#
+# These cover the responses available at /stac/collections/*
+# The spec offers either a cut down version called 'Collections', but Explorer
+# supports the full 'Features' specification.
+
+
+@pytest.mark.parametrize("env_name", ("default",), indirect=True)
+@pytest.mark.benchmark
+def test_stac_collection_toplevel(stac_client: FlaskClient) -> None:
+    # Retrieve the top level response and check that it's JSON
+    res = get_json(stac_client, "/stac/collections")
+    # The response must include some links
+    assert "links" in res
+    # Must have a root and self link
+    link_rels = set(link["rel"] for link in res["links"])
+    assert "root" in link_rels
+    assert "self" in link_rels
+    # The response must include a set of collections
+    assert "collections" in res
+    for collection in res["collections"]:
+        assert_collection(collection)
+
+
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
 def test_stac_collection_query(stac_client: FlaskClient) -> None:
     res = get_json(stac_client, "/stac/collections?q=ard")


### PR DESCRIPTION
As reported in #802, we were experiencing timeouts or extremely slow responses to the `/stac/collections` endpoint. The implementation was doing a lot of extra data transfer and work, by transferring full geometries from PostGIS into Python before simplifying them down to a bbox.

This moves the processing up into PostGIS, and in my testing gives a speedup between 10x and 121x, and potentially more in different environments. I only tested on my laptop.

Running with local PostGIS server, M4 MacBook Pro.

## pytest-benchmark
Loading `/stac/collections` with the data loaded in `test_stac.py`

<img width="1841" height="114" alt="image" src="https://github.com/user-attachments/assets/bdf7f158-baa0-4dcd-92e9-52210cc69f0a" />

Small dataset, but about 10x faster.

## Running datacube-explorer locally
Using a copy of our database with the horrendously complex geometries

Run the server:
```
uv run gunicorn -w 3 --threads 2 -k gthread --config python:cubedash.gunicorn_config 'cubedash:create_app()'
```

Run benchmark with [hey](https://github.com/rakyll/hey)

Before this change:
```
# 2 workers, 4 requests
$ hey -c 2 -n 4 -t 30 http://127.0.0.1:8000/stac/collections

Summary:
  Total:        23.5620 secs
  Slowest:      11.9025 secs
  Fastest:      11.6424 secs
  Average:      11.7767 secs
  Requests/sec: 0.1698
```

After this change:
```
# For fast, defaults to 50 workers and 200 requests
$ hey -t 30 http://127.0.0.1:8000/stac/collections

Summary:
  Total:        9.8161 secs
  Slowest:      2.6334 secs
  Fastest:      0.2301 secs
  Average:      1.8218 secs
  Requests/sec: 20.3746
```

121x faster.

I haven't added any request caching discussed in the issue, that can be done separately.

Fixes #802 

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--871.org.readthedocs.build/en/871/

<!-- readthedocs-preview datacube-explorer end -->