### PR TITLE
Db connection tidying in CLI apps

### DIFF
--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -235,6 +235,7 @@ def _load_products(store: SummaryStore, product_names) -> Generator[Product]:
             yield store.get_product(product_name)
         except KeyError:
             possible_product_names = "\n\t".join(p.name for p in store.all_products())
+            store.close()
             raise click.BadParameter(
                 f"Unknown product {product_name!r}.\n\n"
                 f"Possibilities:\n\t{possible_product_names}",
@@ -464,6 +465,7 @@ def cli(
     if drop_database:
         user_message("Dropping all Explorer additions to the database")
         store.drop_all()
+        store.close()
         user_message("Done. Goodbye.")
         sys.exit(0)
 
@@ -475,12 +477,14 @@ def cli(
             style("No cubedash schema exists. ", fg="red")
             + "Please rerun with --init to create one"
         )
+        store.close()
         sys.exit(-1)
     elif not store.is_schema_compatible(for_writing_operations_too=True):
         user_message(
             style("Cubedash schema is out of date. ", fg="red")
             + "Please rerun with --init to apply updates."
         )
+        store.close()
         sys.exit(-2)
 
     if generate_all_products:
@@ -505,6 +509,7 @@ def cli(
         store.refresh_stats(concurrently=force_concurrently)
         user_message("done", fg="green")
         _LOG.info("stats.refresh")
+    store.close()
     sys.exit(failures)
 
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -328,7 +328,12 @@ class SummaryStore:
         )
 
     def close(self) -> None:  # do we still need this?
-        """Close any pooled/open connections. Necessary before forking."""
+        """Close any pooled/open connections. Necessary before forking.
+
+        Also useful during testing.
+        """
+        # This is going to do the same .dispose() twice, but, it's a noop the second time
+        # and will be safer until we can tidy up handling of the SQLAlchemy connections
         self.index.close()
         self.e_index.engine.dispose()
 

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -86,10 +86,12 @@ def cli(
         store.get_product(product_name)
     except KeyError:
         echo(f"Unknown product {product_name!r}", err=True)
+        store.close()
         sys.exit(-1)
     product = store.get_product_summary(product_name)
     if product is None:
         echo(f"No info: product {product_name!r} has not been summarised", err=True)
+        store.close()
         sys.exit(-1)
 
     secho(product_name, bold=True)
@@ -141,6 +143,7 @@ def cli(
 
     echo()
     echo(f"(fetched in {round(t_end - t, 2)} seconds)")
+    store.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Close DB connections after we're done with them, even in relatively short lived CLI applications.

It's not strictly necessary in general use, but it is useful when they're run within tests as part of a long lived Python process. And it's tidier anyway.

More pieces split out from #860 .



<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--872.org.readthedocs.build/en/872/

<!-- readthedocs-preview datacube-explorer end -->