### PR TITLE
Reduce schema checking functions

### DIFF
--- a/cubedash/index/api.py
+++ b/cubedash/index/api.py
@@ -7,11 +7,11 @@ from uuid import UUID
 from datacube.index import Index
 from datacube.model import Dataset, MetadataType, Product, Range
 from datacube.model.fields import Field
-from sqlalchemy import CursorResult, Result, Row, Select
+from sqlalchemy import CursorResult, Result, Row, Select, inspect
 from sqlalchemy.sql import ColumnElement
 from sqlalchemy.sql.elements import ClauseElement, Label
 
-from cubedash.summary._schema import PleaseRefresh
+from cubedash.summary._schema import CUBEDASH_SCHEMA, PleaseRefresh
 
 
 class EmptyDbError(Exception):
@@ -215,8 +215,8 @@ class ExplorerAbstractIndex(ABC):
     @abstractmethod
     def select_spatial_stats(self) -> Result: ...
 
-    @abstractmethod
-    def schema_initialised(self) -> bool: ...
+    def schema_initialised(self) -> bool:
+        return inspect(self.engine).has_schema(CUBEDASH_SCHEMA)
 
     @abstractmethod
     def schema_compatible_info(

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -816,14 +816,6 @@ class ExplorerIndex(ExplorerAbstractIndex):
             )
 
     @override
-    def schema_initialised(self) -> bool:
-        """
-        Do our DB schemas exist?
-        """
-        with self.engine.begin() as conn:
-            return _schema.has_schema(conn)
-
-    @override
     def schema_compatible_info(self, for_writing_operations_too=False):
         """
         Schema compatibility information

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -882,14 +882,6 @@ class ExplorerIndex(ExplorerAbstractIndex):
             )
 
     @override
-    def schema_initialised(self) -> bool:
-        """
-        Do our DB schemas exist?
-        """
-        with self.engine.begin() as conn:
-            return _schema.has_schema(conn)
-
-    @override
     def schema_compatible_info(
         self, for_writing_operations_too=False
     ) -> tuple[str, bool]:

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -11,13 +11,6 @@ METADATA = MetaData(schema=CUBEDASH_SCHEMA)
 REF_TABLE_METADATA = MetaData(schema=CUBEDASH_SCHEMA)
 
 
-def has_schema(conn: Connection) -> bool:
-    """
-    Does the cubedash schema already exist?
-    """
-    return conn.dialect.has_schema(conn, CUBEDASH_SCHEMA)
-
-
 def is_compatible_schema(
     conn: Connection, odc_table_name: str, generate: bool = False
 ) -> bool:


### PR DESCRIPTION
- Remove the `has_schema()` function from `cubedash/summary/_schema.py`, it was unused.
- Merge the duplicate `schema_initialised()` methods into the parent class, and use the newer SQLAlchemy introspection `identify()` function.


There's much more of these files that should and could be merged, but this was a trivial one to start with. Slow steps.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--873.org.readthedocs.build/en/873/

<!-- readthedocs-preview datacube-explorer end -->