### PR TITLE
Update to Click 8.3.1+patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "cachetools",
     # Tests fail with "ValueError: I/O operation on closed file" with Click
     # 8.2.0 and later.
-    "click<8.2.0",
+    "click @ git+https://github.com/pjonsson/click.git@one-close-only",
     "datacube[postgres]>=1.9.13,<1.10.0",
     "eodatasets3>=1.9",
     "fiona>=1.10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -522,14 +522,10 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
+version = "8.3.1"
+source = { git = "https://github.com/pjonsson/click.git?rev=one-close-only#17680224aa471016d7e53d00c8f17562b386993a" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
@@ -921,7 +917,7 @@ requires-dist = [
     { name = "bottleneck", marker = "extra == 'deployment'" },
     { name = "cachetools" },
     { name = "ciso8601", marker = "extra == 'deployment'" },
-    { name = "click", specifier = "<8.2.0" },
+    { name = "click", git = "https://github.com/pjonsson/click.git?rev=one-close-only" },
     { name = "datacube", extras = ["postgres"], specifier = ">=1.9.13,<1.10.0" },
     { name = "datacube-explorer", extras = ["deployment"], marker = "extra == 'test'" },
     { name = "deepdiff", marker = "extra == 'test'" },
@@ -1522,7 +1518,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [


### PR DESCRIPTION
This should fix the IO errors
that were happening with 8.2
and 8.3.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--876.org.readthedocs.build/en/876/

<!-- readthedocs-preview datacube-explorer end -->