### PR TITLE
cli: fix type of verbose flag

### DIFF
--- a/cubedash/run.py
+++ b/cubedash/run.py
@@ -74,7 +74,7 @@ def cli(
     debug_mode: bool,
     workers: int,
     event_log_file: str,
-    verbose: bool,
+    verbose: int,
 ) -> None:
     from cubedash import create_app
     from cubedash.logs import init_logging

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -67,7 +67,7 @@ def cli(
     month: int,
     day: int,
     event_log_file: str,
-    verbose: bool,
+    verbose: int,
 ) -> None:
     """
     Print the recorded summary information for the given product


### PR DESCRIPTION
This is a counting flag, so it must
be int.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--877.org.readthedocs.build/en/877/

<!-- readthedocs-preview datacube-explorer end -->