### PR TITLE
model: fix log call

### DIFF
--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -128,8 +128,8 @@ def create_app(test_config=None) -> flask.Flask:
             GunicornInternalPrometheusMetrics,
         )
 
-        metrics = GunicornInternalPrometheusMetrics(app, group_by="endpoint")
-        _LOG.info("Prometheus metrics enabled : {metrics}", extra=dict(metrics=metrics))
+        GunicornInternalPrometheusMetrics(app, group_by="endpoint")
+        _LOG.info("Prometheus metrics enabled")
 
     # Add server timings to http headers.
     if app.config.get("CUBEDASH_SHOW_PERF_TIMES", False):


### PR DESCRIPTION
This looks like something that was meant
to be an f-string.

Logging the object does not really make
sense, so remove both the f-string parts
and the logging of the object.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--880.org.readthedocs.build/en/880/

<!-- readthedocs-preview datacube-explorer end -->