### PR TITLE
Remove default parameter values

### DIFF
--- a/cubedash/_audit.py
+++ b/cubedash/_audit.py
@@ -1,5 +1,5 @@
 import time
-from collections.abc import Iterable
+from collections.abc import Generator
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
@@ -19,11 +19,11 @@ bp = Blueprint("audit", __name__)
 class ProductTiming:
     name: str
     dataset_count: int
-    time_seconds: float | None = None
+    time_seconds: float | None
     selection_date: datetime | None = None
 
 
-def product_timings() -> Iterable[ProductTiming]:
+def product_timings() -> Generator[ProductTiming]:
     """
     How long does it take to query a day?
     Useful for finding missing time indexes.
@@ -37,7 +37,7 @@ def product_timings() -> Iterable[ProductTiming]:
             _LOG.info("product_no_summarised", product_name=product_name)
             continue
         if not p.dataset_count or p.duration is None:
-            yield ProductTiming(product_name, dataset_count=0)
+            yield ProductTiming(product_name, dataset_count=0, time_seconds=None)
             continue
         done += 1
         time_earliest, time_latest = p.duration

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -166,10 +166,7 @@ _LOG = structlog.stdlib.get_logger()
 
 @cache.memoize(timeout=60)
 def get_time_summary(
-    product_name: str,
-    year: int | None = None,
-    month: int | None = None,
-    day: int | None = None,
+    product_name: str, year: int | None, month: int | None, day: int | None = None
 ) -> TimePeriodOverview | None:
     return STORE.get(product_name, year, month, day)
 
@@ -212,10 +209,7 @@ def get_products_with_summaries() -> list[ProductWithSummary]:
 
 @cache.memoize(timeout=60)
 def get_footprint_geojson(
-    product_name: str,
-    year: int | None = None,
-    month: int | None = None,
-    day: int | None = None,
+    product_name: str, year: int | None, month: int | None, day: int | None
 ) -> dict | None:
     period = get_time_summary(product_name, year, month, day)
     if period is None:
@@ -238,10 +232,7 @@ def get_footprint_geojson(
 
 @cache.memoize(timeout=60)
 def get_regions_geojson(
-    product_name: str,
-    year: int | None = None,
-    month: int | None = None,
-    day: int | None = None,
+    product_name: str, year: int | None, month: int | None, day: int | None
 ) -> dict | None:
     product = STORE.get_product(product_name)
 

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -588,7 +588,7 @@ def _get_grouped_products() -> list[tuple[str, list[ProductWithSummary]]]:
 
 def _partition_default(
     grouped_product_summarise: list[tuple[str, list[ProductWithSummary]]],
-    remainder_group_size=5,
+    remainder_group_size: int,
 ) -> list[tuple[str, list[ProductWithSummary]]]:
     """
     For default items and place them at the end in batches.

--- a/cubedash/_product.py
+++ b/cubedash/_product.py
@@ -199,7 +199,7 @@ def raw_all_metadata_types_doc():
     return resp
 
 
-def _iso8601_duration(tdelta: timedelta):
+def _iso8601_duration(tdelta: timedelta) -> str:
     """
     Format a timedelta as an iso8601 duration
 

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -555,7 +555,7 @@ def _handle_search_request(
     method: str,
     request_args: TypeConversionDict,
     product_names: list[str],
-    include_total_count: bool = True,
+    include_total_count: bool,
 ) -> ItemCollection:
     bbox = request_args.get(
         "bbox", type=partial(_array_arg, expect_size=4, expect_type=float)
@@ -823,8 +823,8 @@ def _handle_fields_extension(items: Sequence[Item], fields: dict) -> Sequence[It
 
 def search_stac_items(
     get_next_url: Callable[[int], str],
-    limit: int = 0,
-    offset: int = 0,
+    limit: int,
+    offset: int,
     dataset_ids: Sequence[uuid.UUID] | None = None,
     product_names: list[str] | None = None,
     bbox: tuple[float, float, float, float] | None = None,
@@ -913,11 +913,11 @@ def search_stac_items(
 
 def search_stac_collections(
     get_next_url: Callable[[int], str],
-    limit: int = 0,
-    offset: int = 0,
-    bbox: tuple[float, float, float, float] | None = None,
-    time: tuple[datetime, datetime] | None = None,
-    q: list[str] | None = None,
+    limit: int,
+    offset: int,
+    bbox: tuple[float, float, float, float] | None,
+    time: tuple[datetime, datetime] | None,
+    q: list[str] | None,
 ) -> tuple[list[Collection], dict[str, Any]]:
     if limit < 1:
         limit = get_default_limit()
@@ -1095,7 +1095,7 @@ def stac_search():
         products.append(args.get("collection"))
 
     return _geojson_stac_response(
-        _handle_search_request(request.method, args, products)
+        _handle_search_request(request.method, args, products, True)
     )
 
 

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -11,6 +11,7 @@ import re
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import datetime, timedelta, timezone
+from datetime import tzinfo as e_tzinfo
 from io import StringIO
 from typing import Any
 from urllib.parse import urljoin, urlparse
@@ -346,10 +347,10 @@ def _next_month(date: datetime) -> datetime:
 
 
 def as_time_range(
-    year: int | None = None,
+    year: int | None,
     month: int | None = None,
     day: int | None = None,
-    tzinfo=None,
+    tzinfo: e_tzinfo | None = None,
 ) -> Range | None:
     """
     >>> as_time_range(2018)
@@ -358,8 +359,6 @@ def as_time_range(
     Range(begin=datetime.datetime(2018, 2, 1, 0, 0), end=datetime.datetime(2018, 3, 1, 0, 0))
     >>> as_time_range(2018, 8, 3)
     Range(begin=datetime.datetime(2018, 8, 3, 0, 0), end=datetime.datetime(2018, 8, 4, 0, 0))
-    >>> # Unbounded:
-    >>> as_time_range()
     """
     if year and month and day:
         start = datetime(year, month, day)
@@ -514,7 +513,7 @@ def _json_fallback(o, *args, **kwargs):
     )
 
 
-def as_geojson(o, downloadable_filename_prefix: str | None = None):
+def as_geojson(o, downloadable_filename_prefix: str | None):
     """
     Serialise the given object into a GeoJSON flask response.
 

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -96,7 +96,7 @@ class GenerateSettings:
     force_refresh: bool
     recreate_dataset_extents: bool
     reset_incremental_position: bool
-    minimum_change_scan_window: timedelta | None = None
+    minimum_change_scan_window: timedelta | None
 
 
 # pylint: disable=broad-except
@@ -111,9 +111,9 @@ def generate_report(
     def print_status(
         product_name: str,
         year: int | None,
-        month: int | None = None,
-        day: int | None = None,
-        summary: TimePeriodOverview | None = None,
+        month: int | None,
+        day: int | None,
+        summary: TimePeriodOverview | None,
     ) -> None:
         """Print status each time we start a year."""
         if year:
@@ -161,8 +161,8 @@ def _get_index(config: ODCEnvironment, variant: str) -> Index:
 def run_generation(
     settings: GenerateSettings,
     products: Sequence[Product],
-    grouping_time_zone=DEFAULT_TIMEZONE,
-    workers=3,
+    grouping_time_zone: str,
+    workers: int,
 ) -> tuple[int, int]:
     user_message(
         f"Updating {len(products)} products for "

--- a/cubedash/index/api.py
+++ b/cubedash/index/api.py
@@ -145,10 +145,10 @@ class ExplorerAbstractIndex(ABC):
         self,
         limit: int,
         offset: int,
-        name: str | None = None,
-        bbox: tuple[float, float, float, float] | None = None,
-        time: tuple[datetime, datetime] | None = None,
-        q: Sequence[str] | None = None,
+        name: str | None,
+        bbox: tuple[float, float, float, float] | None,
+        time: tuple[datetime, datetime] | None,
+        q: Sequence[str] | None,
     ) -> Result: ...
 
     @abstractmethod
@@ -185,7 +185,7 @@ class ExplorerAbstractIndex(ABC):
 
     @abstractmethod
     def all_products_location_samples(
-        self, products: Sequence[Product], sample_size: int = 50
+        self, products: Sequence[Product], sample_size: int
     ) -> Result: ...
 
     @abstractmethod
@@ -223,7 +223,7 @@ class ExplorerAbstractIndex(ABC):
     def init_schema(self, grouping_epsg_code: int) -> set[PleaseRefresh]: ...
 
     @abstractmethod
-    def refresh_stats(self, concurrently: bool = False) -> None: ...
+    def refresh_stats(self, concurrently: bool) -> None: ...
 
     @abstractmethod
     def get_srid_name(self, srid: int) -> str | None: ...

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -351,10 +351,10 @@ class ExplorerIndex(ExplorerAbstractIndex):
         self,
         limit: int,
         offset: int,
-        name: str | None = None,
-        bbox: tuple[float, float, float, float] | None = None,
-        time: tuple[datetime, datetime] | None = None,
-        q: Sequence[str] | None = None,
+        name: str | None,
+        bbox: tuple[float, float, float, float] | None,
+        time: tuple[datetime, datetime] | None,
+        q: Sequence[str] | None,
     ) -> list[Row]:
         # STAC Collections only hold a bounding box in EPSG:4326, no polygons
         # Calculate the bounding box on the server, it's far more efficient
@@ -600,7 +600,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     # does this really add much value? and if so, is there a better way to do it?
     @override
     def all_products_location_samples(
-        self, products: Sequence[Product], sample_size: int = 50
+        self, products: Sequence[Product], sample_size: int
     ) -> Result:
         queries = []
         for product in products:
@@ -845,7 +845,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
             return init_elements(conn, grouping_epsg_code)
 
     @override
-    def refresh_stats(self, concurrently=False) -> None:
+    def refresh_stats(self, concurrently: bool) -> None:
         """
         Refresh general statistics tables that cover all products.
 

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -397,10 +397,10 @@ class ExplorerIndex(ExplorerAbstractIndex):
         self,
         limit: int,
         offset: int,
-        name: str | None = None,
-        bbox: tuple[float, float, float, float] | None = None,
-        time: tuple[datetime, datetime] | None = None,
-        q: Sequence[str] | None = None,
+        name: str | None,
+        bbox: tuple[float, float, float, float] | None,
+        time: tuple[datetime, datetime] | None,
+        q: Sequence[str] | None,
     ) -> Result:
         # STAC Collections only hold a bounding box in EPSG:4326, no polygons
         # Calculate the bounding box on the server, it's far more efficient.
@@ -649,7 +649,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     # does this really add much value? and if so, is there a better way to do it?
     @override
     def all_products_location_samples(
-        self, products: Sequence[Product], sample_size: int = 50
+        self, products: Sequence[Product], sample_size: int
     ) -> Result:
         queries = []
         for product in products:
@@ -915,7 +915,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
             return init_elements(conn, grouping_epsg_code)
 
     @override
-    def refresh_stats(self, concurrently=False) -> None:
+    def refresh_stats(self, concurrently: bool) -> None:
         """
         Refresh general statistics tables that cover all products.
 

--- a/cubedash/logs.py
+++ b/cubedash/logs.py
@@ -12,8 +12,8 @@ from typing_extensions import override
 
 
 def init_logging(
-    output_file: BinaryIO | None = None,
-    verbosity: int = 0,
+    output_file: BinaryIO | None,
+    verbosity: int,
     cache_logger_on_first_use: bool = True,
     write_as_json: bool | None = None,
 ) -> None:

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -176,8 +176,8 @@ def _gis_point(doc, doc_offset):
 def refresh_spatial_extents(
     e_index: ExplorerIndex,
     product: Product,
-    clean_up_deleted: bool = False,
-    assume_after_date: datetime | None = None,
+    clean_up_deleted: bool,
+    assume_after_date: datetime | None,
 ) -> int:
     """
     Update the spatial extents to match any changes upstream in ODC.

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -11,9 +11,7 @@ METADATA = MetaData(schema=CUBEDASH_SCHEMA)
 REF_TABLE_METADATA = MetaData(schema=CUBEDASH_SCHEMA)
 
 
-def is_compatible_schema(
-    conn: Connection, odc_table_name: str, generate: bool = False
-) -> bool:
+def is_compatible_schema(conn: Connection, odc_table_name: str, generate: bool) -> bool:
     """
     Do we have the latest schema changes?
     If generate: Is the schema complete enough to run generate/refresh commands?
@@ -50,11 +48,7 @@ class PleaseRefresh(Enum):
 
 
 def pg_create_index(
-    conn,
-    idx_name: str,
-    table_name: str,
-    col_expr: str | None = None,
-    unique: bool = False,
+    conn, idx_name: str, table_name: str, col_expr: str | None, unique: bool = False
 ) -> None:
     conn.execute(
         text(
@@ -116,7 +110,7 @@ def epsg_to_srid(conn: Connection, code: int) -> int | None:
     ).scalar()
 
 
-def refresh_supporting_views(conn, concurrently=False) -> None:
+def refresh_supporting_views(conn, concurrently: bool) -> None:
     args = "concurrently" if concurrently else ""
     conn.execute(
         text(f"""

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -221,9 +221,9 @@ class ChangeListener(Protocol):
         self,
         product_name: str,
         year: int | None,
-        month: int | None = None,
-        day: int | None = None,
-        summary: TimePeriodOverview | None = None,
+        month: int | None,
+        day: int | None,
+        summary: TimePeriodOverview | None,
     ) -> None: ...
 
 
@@ -265,7 +265,7 @@ class SummaryStore:
         """
         return self.e_index.schema_initialised()
 
-    def is_schema_compatible(self, for_writing_operations_too: bool = False) -> bool:
+    def is_schema_compatible(self, for_writing_operations_too: bool) -> bool:
         """
         Have all schema updates been applied?
         """
@@ -275,7 +275,7 @@ class SummaryStore:
         _LOG.debug("software.version", postgis=postgis_ver, explorer=explorer_version)
         return is_compatible
 
-    def init(self, grouping_epsg_code: int | None = None) -> None:
+    def init(self, grouping_epsg_code: int | None) -> None:
         """
         Initialise any schema elements that don't exist.
 
@@ -502,7 +502,7 @@ class SummaryStore:
         self.e_index.refresh_stats(concurrently)
 
     def _find_product_fixed_metadata(
-        self, product: Product, sample_datasets_size: int = 1000
+        self, product: Product, sample_datasets_size: int
     ) -> dict[str, Any]:
         """
         Find metadata fields that have an identical value in every dataset of the product.
@@ -560,8 +560,8 @@ class SummaryStore:
     def _get_linked_products(
         self,
         product: Product,
-        kind: Literal["source", "derived"] = "source",
-        sample_percentage: float = 0.05,
+        kind: Literal["source", "derived"],
+        sample_percentage: float,
     ) -> list[str]:
         """
         Find products with upstream or downstream datasets from this product.
@@ -861,11 +861,7 @@ class SummaryStore:
             summary.summary_gen_time = ret[0]
 
     def has(
-        self,
-        product_name: str,
-        year: int | None = None,
-        month: int | None = None,
-        day: int | None = None,
+        self, product_name: str, year: int | None, month: int | None, day: int | None
     ) -> bool:
         return self.get(product_name, year, month, day) is not None
 
@@ -904,11 +900,11 @@ class SummaryStore:
         self,
         query: Select,
         field_exprs,
-        product_names: list[str] | None = None,
-        time: tuple[datetime, datetime] | None = None,
-        bbox: tuple[float, float, float, float] | None = None,
-        intersects: BaseGeometry | None = None,
-        dataset_ids: Sequence[UUID] | None = None,
+        product_names: list[str] | None,
+        time: tuple[datetime, datetime] | None,
+        bbox: tuple[float, float, float, float] | None,
+        intersects: BaseGeometry | None,
+        dataset_ids: Sequence[UUID] | None,
     ) -> Select:
         if dataset_ids is not None:
             query = query.where(field_exprs["id"].in_(dataset_ids))
@@ -936,9 +932,7 @@ class SummaryStore:
 
         return query
 
-    def _get_field_exprs(
-        self, product_names: list[str] | None = None
-    ) -> dict[str, Any]:
+    def _get_field_exprs(self, product_names: list[str] | None) -> dict[str, Any]:
         """
         Map properties to their sqlalchemy expressions.
         Allow for properties to be provided as their STAC property name (ex: created),
@@ -1037,13 +1031,13 @@ class SummaryStore:
 
     def get_count(
         self,
-        product_names: list[str] | None = None,
-        time: tuple[datetime, datetime] | None = None,
-        bbox: tuple[float, float, float, float] | None = None,
-        intersects: BaseGeometry | None = None,
-        dataset_ids: Sequence[UUID] | None = None,
-        filter_lang: str | None = None,
-        filter_cql: str | dict | None = None,
+        product_names: list[str] | None,
+        time: tuple[datetime, datetime] | None,
+        bbox: tuple[float, float, float, float] | None,
+        intersects: BaseGeometry | None,
+        dataset_ids: Sequence[UUID] | None,
+        filter_lang: str | None,
+        filter_cql: str | dict | None,
     ) -> int:
         """
         Do the base select query to get the count of matching datasets.
@@ -1446,7 +1440,7 @@ class SummaryStore:
         month: int | None,
         day: int | None,
         limit: int,
-        offset: int = 0,
+        offset: int,
     ) -> Generator[Dataset]:
         time_range = _utils.as_time_range(
             year, month, day, tzinfo=self.grouping_timezone
@@ -1462,7 +1456,7 @@ class SummaryStore:
         month: int | None,
         day: int | None,
         limit: int,
-        offset: int = 0,
+        offset: int,
     ) -> Iterable[Product]:
         time_range = _utils.as_time_range(
             year, month, day, tzinfo=self.grouping_timezone

--- a/cubedash/warmup.py
+++ b/cubedash/warmup.py
@@ -198,7 +198,7 @@ def cli(
     sys.exit(len(failures))
 
 
-def _format_time(t: float):
+def _format_time(t: float) -> str:
     """
     >>> _format_time(0.31)
     '310ms'

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -50,7 +50,9 @@ def summary_store(odc_test_db: Datacube) -> SummaryStore:
 @pytest.fixture(autouse=True, scope="session")
 def _init_logs(pytestconfig) -> None:
     logs.init_logging(
-        verbosity=pytestconfig.getoption("verbose"), cache_logger_on_first_use=False
+        None,
+        verbosity=pytestconfig.getoption("verbose"),
+        cache_logger_on_first_use=False,
     )
 
 


### PR DESCRIPTION
Callers for most of these already
specify the values so they can be
removed without any other changes.
A few callers were missing some
parameter, so add the default
value in those places.

This will make the type checker
give an error in future refactorings
if some parameter is missing instead
of (hopefully) failing in some test.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--883.org.readthedocs.build/en/883/

<!-- readthedocs-preview datacube-explorer end -->