### PR TITLE
test_stac: various cleanups

### DIFF
--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -280,8 +280,7 @@ def _iter_items_across_pages(client: FlaskClient, url: str | None) -> Generator[
 
 
 def assert_stac_extensions(doc: dict) -> None:
-    stac_extensions = doc.get("stac_extensions", ())
-    for extension_name in stac_extensions:
+    for extension_name in doc.get("stac_extensions", ()):
         get_extension(extension_name).validate(doc)
 
 

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -147,9 +147,6 @@ def _web_reference(ref: str):
 
 
 def load_validator(schema_location: Path) -> jsonschema.Draft7Validator:
-    if not schema_location.exists():
-        raise NoSuchResource(f"No jsonschema file found at {schema_location}")
-
     with schema_location.open("r") as s:
         try:
             schema = loads(s.read())

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -2,7 +2,6 @@
 Tests that hit the stac api
 """
 
-import json
 import urllib.parse
 import warnings
 from collections import Counter, defaultdict
@@ -20,6 +19,7 @@ from datacube.migration import ODC2DeprecationWarning
 from datacube.utils import is_url, read_documents
 from flask.testing import FlaskClient
 from jsonschema import SchemaError
+from orjson import JSONDecodeError, dumps, loads
 from referencing import Registry, Resource
 from referencing.exceptions import NoSuchResource
 from referencing.typing import URI
@@ -178,8 +178,8 @@ def load_validator(schema_location: Path) -> jsonschema.Draft7Validator:
 
     with schema_location.open("r") as s:
         try:
-            schema = json.load(s)
-        except json.JSONDecodeError as e:
+            schema = loads(s.read())
+        except JSONDecodeError as e:
             # Some in the repo have not been valid before...
             raise RuntimeError(
                 f"Invalid json, cannot load schema {schema_location}"
@@ -1062,7 +1062,7 @@ def test_stac_search_by_intersects(stac_client: FlaskClient) -> None:
     """
     rv = stac_client.post(
         "/stac/search",
-        data=json.dumps(
+        data=dumps(
             {
                 "collections": ["wofs_albers"],
                 # Does it intersect the region 16_-33 geojson?
@@ -1108,7 +1108,7 @@ def test_stac_search_by_intersects_paging(stac_client: FlaskClient) -> None:
     """
     rv = stac_client.post(
         "/stac/search",
-        data=json.dumps(
+        data=dumps(
             {
                 # Roughly the whole region of Australia.
                 "intersects": {
@@ -1227,7 +1227,7 @@ def test_stac_search_by_post(stac_client: FlaskClient) -> None:
     # Test POST, product, and assets
     rv = stac_client.post(
         "/stac/search",
-        data=json.dumps(
+        data=dumps(
             {
                 "collections": ["wofs_albers"],
                 "bbox": [114, -33, 153, -10],
@@ -1249,7 +1249,7 @@ def test_stac_search_by_post(stac_client: FlaskClient) -> None:
     # Test high_tide_comp_20p with POST and assets
     rv = stac_client.post(
         "/stac/search",
-        data=json.dumps(
+        data=dumps(
             {
                 "collections": ["high_tide_comp_20p"],
                 "bbox": [114, -40, 147, -32],
@@ -1295,7 +1295,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     fields = {"include": ["properties.dea:dataset_maturity"]}
     rv = stac_client.post(
         "/stac/search",
-        data=json.dumps(
+        data=dumps(
             {
                 "collections": ["ga_ls8c_ard_3"],
                 "datetime": "2022-01-01T00:00:00/2022-12-31T00:00:00",
@@ -1330,7 +1330,7 @@ def test_stac_fields_extension(stac_client: FlaskClient) -> None:
     fields = {"exclude": ["properties.title"]}
     rv = stac_client.post(
         "/stac/search",
-        data=json.dumps(
+        data=dumps(
             {
                 "collections": ["ga_ls8c_ard_3"],
                 "datetime": "2022-01-01T00:00:00/2022-12-31T00:00:00",
@@ -1398,7 +1398,7 @@ def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
     sortby = [{"field": "properties.datetime", "direction": "asc"}]
     rv = stac_client.post(
         "/stac/search",
-        data=json.dumps(
+        data=dumps(
             {
                 "collections": ["ga_ls8c_ard_3"],
                 "datetime": "2022-01-01T00:00:00/2022-12-31T00:00:00",
@@ -1422,7 +1422,7 @@ def test_stac_sortby_extension(stac_client: FlaskClient) -> None:
     sortby = [{"field": "properties.datetime", "direction": "desc"}]
     rv = stac_client.post(
         "/stac/search",
-        data=json.dumps(
+        data=dumps(
             {
                 "collections": ["ga_ls8c_ard_3"],
                 "datetime": "2022-01-01T00:00:00/2022-12-31T00:00:00",
@@ -1488,7 +1488,7 @@ def test_stac_filter_extension(stac_client: FlaskClient) -> None:
     }
     rv = stac_client.post(
         "/stac/search",
-        data=json.dumps(
+        data=dumps(
             {
                 "collections": ["ga_ls8c_ard_3"],
                 "datetime": "2022-01-01T00:00:00/2022-12-31T00:00:00",
@@ -1534,7 +1534,7 @@ def test_stac_filter_extension(stac_client: FlaskClient) -> None:
     # test lang mismatch
     rv = stac_client.post(
         "/stac/search",
-        data=json.dumps(
+        data=dumps(
             {
                 "collections": ["ga_ls8c_ard_3"],
                 "datetime": "2022-01-01T00:00:00/2022-12-31T00:00:00",
@@ -1551,7 +1551,7 @@ def test_stac_filter_extension(stac_client: FlaskClient) -> None:
     # filter-crs invalid value
     rv = stac_client.post(
         "/stac/search",
-        data=json.dumps(
+        data=dumps(
             {
                 "collections": ["ga_ls8c_ard_3"],
                 "datetime": "2022-01-01T00:00:00/2022-12-31T00:00:00",
@@ -1572,7 +1572,7 @@ def test_stac_query_extension_errors(stac_client: FlaskClient) -> None:
     query = {"cloud_cover": {"lt": 1}}
     rv = stac_client.post(
         "/stac/search",
-        data=json.dumps(
+        data=dumps(
             {
                 "collections": ["ga_ls8c_ard_3"],
                 "datetime": "2022-01-01T00:00:00/2022-12-31T00:00:00",

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -635,7 +635,7 @@ def test_arrivals_page_validation(stac_client: FlaskClient) -> None:
 def test_stac_collection(stac_client: FlaskClient):
     """
     Follow the links to the "high_tide_comp_20p" collection and ensure it includes
-    all of our tests data.
+    all of our test data.
 
     This test expects the database timezone to be UTC
     """
@@ -649,16 +649,7 @@ def test_stac_collection(stac_client: FlaskClient):
         raise AssertionError("high_tide_comp_20p not found in collection list")
 
     scene_collection = get_collection(stac_client, collection_href, validate=False)
-    # HACK: Heavy handed bypass for pytest approximate
-    import copy
-
-    proxy_scene_collection = copy.deepcopy(scene_collection)
-    proxy_scene_collection["extent"]["spatial"]["bbox"][0] = [
-        pytest.approx(p, abs=0.001)
-        for p in scene_collection["extent"]["spatial"]["bbox"][0]
-    ]
-
-    assert proxy_scene_collection == {
+    assert scene_collection == {
         "stac_version": "1.1.0",
         "type": "Collection",
         "id": "high_tide_comp_20p",
@@ -669,10 +660,10 @@ def test_stac_collection(stac_client: FlaskClient):
             "spatial": {
                 "bbox": [
                     [
-                        pytest.approx(112.223_058_990_767_51, abs=0.001),
-                        pytest.approx(-43.829_196_553_065_4, abs=0.001),
-                        pytest.approx(153.985_054_424_922_77, abs=0.001),
-                        pytest.approx(-10.237_104_814_250_783, abs=0.001),
+                        112.223_058_990_767_51,
+                        -43.829_196_553_065_4,
+                        153.985_054_424_922_77,
+                        -10.237_104_814_250_783,
                     ]
                 ]
             },
@@ -697,7 +688,6 @@ def test_stac_collection(stac_client: FlaskClient):
         # "providers": [], // FIXME: These disappeared somewhere along the way ?
         # "stac_extensions": [],
     }
-    # HACK: Make things float again
     assert_collection(scene_collection)
     item_links = None
     for link in scene_collection["links"]:

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -146,16 +146,6 @@ def _web_reference(ref: str):
     return read_document(path)
 
 
-# Allow schemas to reference other schemas in the same folder.
-def _local_reference(schema_location: Path, ref):
-    relative_path = schema_location.parent.joinpath(ref)
-    if relative_path.exists():
-        return read_document(relative_path)
-    raise NoSuchResource(
-        f"Schema reference not found: {ref!r} (within {schema_location})"
-    )
-
-
 def load_validator(schema_location: Path) -> jsonschema.Draft7Validator:
     if not schema_location.exists():
         raise NoSuchResource(f"No jsonschema file found at {schema_location}")
@@ -181,7 +171,9 @@ def load_schema_doc(schema: dict, location: str | Path) -> jsonschema.Draft7Vali
         parsed = urlsplit(uri)
         if parsed.scheme == "https" or parsed.scheme == "http":
             return Resource.from_contents(_web_reference(uri))
-        return Resource.from_contents(_local_reference(Path(location), uri))
+        return Resource.from_contents(
+            read_document(Path(location).parent.joinpath(uri))
+        )
 
     return jsonschema.Draft7Validator(
         schema,

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -4,7 +4,7 @@ Tests that hit the stac api
 
 import urllib.parse
 import warnings
-from collections import Counter, defaultdict
+from collections import Counter
 from collections.abc import Generator, Iterable
 from functools import lru_cache
 from pathlib import Path
@@ -46,10 +46,6 @@ OUR_PAGE_SIZE = 4
 _SCHEMA_BASE = Path(__file__).parent / "schemas"
 # Can't import STAC_VERSION from cubedash._stac since that needs app context
 _STAC_SCHEMA_BASE = _SCHEMA_BASE / f"stac/{_stac.STAC_VERSION}"
-
-_SCHEMAS_BY_NAME = defaultdict(list)
-for schema_path in _SCHEMA_BASE.rglob("*.json"):
-    _SCHEMAS_BY_NAME[schema_path.name].append(schema_path)
 
 METADATA_TYPES = [
     "metadata/eo3_landsat_ard.odc-type.yaml",
@@ -155,18 +151,6 @@ def _local_reference(schema_location: Path, ref):
     relative_path = schema_location.parent.joinpath(ref)
     if relative_path.exists():
         return read_document(relative_path)
-
-    # This is a sloppy workaround.
-    # Python jsonschema strips all parent-folder references ("../../"), so none of the relative
-    # paths in stac work. We fallback to matching based on filename.
-    similar_schemas = _SCHEMAS_BY_NAME.get(Path(ref).name)
-    if similar_schemas:
-        if len(similar_schemas) > 1:
-            raise NotImplementedError(
-                f"cannot distinguish schema {ref!r} (within {schema_location}"
-            )
-        [presumed_schema] = similar_schemas
-        return read_document(presumed_schema)
     raise NoSuchResource(
         f"Schema reference not found: {ref!r} (within {schema_location})"
     )

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -10,7 +10,6 @@ from functools import lru_cache
 from pathlib import Path
 from pprint import pformat
 from urllib.parse import urlsplit
-from urllib.request import urlopen
 from zoneinfo import ZoneInfo
 
 import jsonschema
@@ -34,8 +33,6 @@ from integration_tests.asserts import (
     get_json,
     get_text_response,
 )
-
-ALLOW_INTERNET = True
 
 DEFAULT_TZ = ZoneInfo("Australia/Darwin")
 
@@ -132,18 +129,7 @@ def _web_reference(ref: str):
     _, netloc, offset, _, _, _ = urllib.parse.urlparse(ref)
     # We used `wget -r` to download the remote schemas locally.
     # It puts into hostname/path folders by default. E.g 'geojson.org/schema/Feature.json'
-    path = _SCHEMA_BASE / f"{netloc}{offset}"
-    if not path.exists():
-        if ALLOW_INTERNET:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_bytes(urlopen(ref).read())
-        else:
-            raise NoSuchResource(
-                f"No local copy exists of schema {ref!r}.\n"
-                "\tPerhaps we need to add it to ./update.sh in the tests folder?\n"
-                f"\t(looked in {path})"
-            )
-    return read_document(path)
+    return read_document(_SCHEMA_BASE / f"{netloc}{offset}")
 
 
 def load_validator(schema_location: Path) -> jsonschema.Draft7Validator:

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -223,10 +223,6 @@ _ITEM_COLLECTION_SCHEMA = load_validator(
 
 @lru_cache
 def get_extension(url: str) -> jsonschema.Draft7Validator:
-    if not is_url(url):
-        raise ValueError(
-            f"stac extensions are now expected to be URLs in 1.0.0. Got {url!r}"
-        )
     return load_schema_doc(_web_reference(url), location=url)
 
 

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -369,10 +369,10 @@ def validate_items(
     # ("already seen this dataset id")
     # So we perform this length check in the same method and afterwards.
     if expect_count is not None:
-        printable_product_counts = "\n\t".join(
-            f"{k}: {v}" for k, v in product_counts.items()
-        )
         if isinstance(expect_count, int):
+            printable_product_counts = "\n\t".join(
+                f"{k}: {v}" for k, v in product_counts.items()
+            )
             assert i == expect_count, (
                 f"Expected {expect_count} items.\nGot:\n\t{printable_product_counts}"
             )


### PR DESCRIPTION
The test_stac tests are slow, so I started trying to pin this down, but I just ended up with a bunch of cleanups so far.

This removes the ability to have the test suite fetch a schema on its own, so everything will always use the schema found in the local file system from now on. This choice makes a bunch of validation in the test suite redundant, so remove those checks which saves us from various slow syscalls that poke around in the file system and similar things.

Also use the fast orjson, remove a deepcopy, remove some calls to pytest.approx which all contribute to marginally better performance. And do a couple of minor cleanups along the way as well.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--906.org.readthedocs.build/en/906/

<!-- readthedocs-preview datacube-explorer end -->