### PR TITLE
Ensure consistent fixed fields in test

### DIFF
--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -345,7 +345,7 @@ def test_sampled_product_fixed_fields(summary_store: SummaryStore) -> None:
     product = summary_store.index.products.get_by_name("ga_ls9c_ard_3")
     assert product is not None
     fixed_fields = summary_store._find_product_fixed_metadata(
-        product, sample_datasets_size=5
+        product, sample_datasets_size=6
     )
 
     assert fixed_fields == {


### PR DESCRIPTION
Should fix #743 
The set of `ga_ls9c_ard_3` datasets just happens to have 5 datasets with identical `fmask_snow` values, so it will be included in the `fixed_fields` if those datasets happen to be selected. Increase `sample_datasets_size` to 6 for consistent test results.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--908.org.readthedocs.build/en/908/

<!-- readthedocs-preview datacube-explorer end -->