### PR TITLE
Fix sortby format in next link

### DIFF
--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -513,7 +513,12 @@ def _sort_arg(arg: str | list[str] | list[dict[str, Any]]) -> list[dict[str, Any
         # default is ascending
         return {"field": val.strip(), "direction": "asc"}
 
-    arg_work = arg.split(",") if isinstance(arg, str) else arg
+    if isinstance(arg, str):
+        arg_work = (
+            json.loads(arg.replace("'", '"')) if arg.startswith("[") else arg.split(",")
+        )
+    else:
+        arg_work = arg
     if len(arg_work):
         if isinstance(arg_work[0], str):
             return [_format(a) for a in arg_work]  # type: ignore[arg-type]
@@ -643,8 +648,8 @@ def _handle_search_request(
             _o=next_offset,
             _full=full_information,
             intersects=intersects,
-            fields=fields,
-            sortby=sortby,
+            fields=str(fields) if fields else None,
+            sortby=str(sortby) if sortby else None,
             # so that it doesn't get named 'filter_lang'
             **{"filter-lang": filter_lang},
             filter=filter_cql,

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -648,7 +648,7 @@ def _handle_search_request(
             _o=next_offset,
             _full=full_information,
             intersects=intersects,
-            fields=str(fields) if fields else None,
+            fields=fields,
             sortby=str(sortby) if sortby else None,
             # so that it doesn't get named 'filter_lang'
             **{"filter-lang": filter_lang},

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -521,7 +521,7 @@ def _sort_arg(arg: str | list[str] | list[dict[str, Any]]) -> list[dict[str, Any
         arg_work = arg
     if len(arg_work):
         if isinstance(arg_work[0], str):
-            return [_format(a) for a in arg_work]  # type: ignore[arg-type]
+            return [_format(a) for a in arg_work]
         if isinstance(arg_work[0], dict):
             for a in arg_work:
                 assert isinstance(a, dict)


### PR DESCRIPTION
Hopefully resolves #742 
The value of `sortby` was not being represented (or subsequently parsed) correctly in the `next` link of GET requests as it was being passed to `flask.url_for` as a list object. It's likely this was the reason why the test result was inconsistent.
Convert to a string and add corresponding logic to the request arg parser to resolve. 

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--909.org.readthedocs.build/en/909/

<!-- readthedocs-preview datacube-explorer end -->