### PR TITLE
tests: include error message for cli

### DIFF
--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -850,7 +850,7 @@ def test_show_summary_cli_missing_product(clirunner, client: FlaskClient) -> Non
     res = clirunner(show.cli, ["does_not_exist"], expect_success=False)
     output = res.output
     assert output.strip().startswith("Unknown product 'does_not_exist'")
-    assert res.exit_code != 0
+    assert res.exit_code != 0, f"Output: {res.output}"
 
 
 def test_show_summary_cli_unsummarised_product(
@@ -864,7 +864,7 @@ def test_show_summary_cli_unsummarised_product(
     res = clirunner(show.cli, ["ga_ls8c_ard_3"], expect_success=False)
     out = res.output.strip()
     assert out.startswith("No info: product 'ga_ls8c_ard_3' has not been summarised")
-    assert res.exit_code != 0
+    assert res.exit_code != 0, f"Output: {res.output}"
 
 
 def test_extent_debugging_method(odc_test_db, client: FlaskClient) -> None:

--- a/integration_tests/test_raw_yaml.py
+++ b/integration_tests/test_raw_yaml.py
@@ -106,7 +106,7 @@ def test_update_type(type_yaml_from_raw) -> None:
     )
 
     assert 'Updated "eo_plus"\n' in result.output
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
@@ -119,7 +119,7 @@ def test_update_product(product_yaml_from_raw) -> None:
     assert 'Updated "dsm1sv10"\n' in result.output
     assert 'Updated "ga_s2a_ard_nbar_granule"\n' in result.output
     assert 'Updated "s2a_ard_granule"\n' in result.output
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
@@ -132,4 +132,4 @@ def test_update_dataset(dataset_yaml_from_raw) -> None:
         "Updated 290eca22-defc-43b4-998f-eaf56e1fd211\n1 successful, 0 failed\n"
         in result.output
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"


### PR DESCRIPTION
Asserting on the exit code is robust,
but it's difficult to understand why
tests fail when they fail, so add
the CLI output to the assert message.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--910.org.readthedocs.build/en/910/

<!-- readthedocs-preview datacube-explorer end -->