### PR TITLE
Improve check_page_limit behaviour

### DIFF
--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -56,16 +56,15 @@ def get_default_limit() -> int:
     return current_app.config.get("STAC_DEFAULT_PAGE_SIZE", DEFAULT_PAGE_SIZE)
 
 
-def check_page_limit(limit: int) -> None:
+def check_page_limit(limit: int) -> int:
+    if limit < 1:
+        return get_default_limit()
     page_size_limit = current_app.config.get(
         "STAC_PAGE_SIZE_LIMIT", DEFAULT_PAGE_SIZE_LIMIT
     )
     if limit > page_size_limit:
-        abort(
-            400,
-            f"Max page size is {page_size_limit}. "
-            "Use the next links instead of a large limit.",
-        )
+        return page_size_limit
+    return limit
 
 
 def dissoc_in(d: dict, key: str):
@@ -569,7 +568,7 @@ def _handle_search_request(
     time = request_args.get("datetime")
 
     limit = request_args.get("limit", default=get_default_limit(), type=int)
-    check_page_limit(limit)
+    limit = check_page_limit(limit)
 
     ids = request_args.get(
         "ids", default=None, type=partial(_array_arg, expect_type=uuid.UUID)
@@ -709,7 +708,7 @@ def _handle_collection_search(
     q = request_args.get("q", default=None, type=partial(_array_arg, expect_type=str))
 
     limit = request_args.get("limit", default=get_default_limit(), type=int)
-    check_page_limit(limit)
+    limit = check_page_limit(limit)
 
     offset = request_args.get("_o", default=0, type=int)
 
@@ -840,9 +839,6 @@ def search_stac_items(
 
     :param get_next_url: A function that calculates a page url for the given offset.
     """
-    if limit < 1:
-        limit = get_default_limit()
-
     offset = offset or 0
     items = list(
         _model.STORE.search_items(
@@ -917,9 +913,6 @@ def search_stac_collections(
     time: tuple[datetime, datetime] | None,
     q: list[str] | None,
 ) -> tuple[list[Collection], dict[str, Any]]:
-    if limit < 1:
-        limit = get_default_limit()
-
     collections = list(
         _model.STORE.search_collections(
             time=time, bbox=bbox, q=q, limit=limit + 1, offset=offset
@@ -1370,7 +1363,7 @@ def arrivals_items():
     """
     limit = request.args.get("limit", default=get_default_limit(), type=int)
     offset = request.args.get("_o", default=0, type=int)
-    check_page_limit(limit)
+    limit = check_page_limit(limit)
 
     def next_page_url(next_offset):
         return url_for(".arrivals_items", limit=limit, _o=next_offset)

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -62,9 +62,7 @@ def check_page_limit(limit: int) -> int:
     page_size_limit = current_app.config.get(
         "STAC_PAGE_SIZE_LIMIT", DEFAULT_PAGE_SIZE_LIMIT
     )
-    if limit > page_size_limit:
-        return page_size_limit
-    return limit
+    return min(limit, page_size_limit)
 
 
 def dissoc_in(d: dict, key: str):
@@ -567,8 +565,9 @@ def _handle_search_request(
 
     time = request_args.get("datetime")
 
-    limit = request_args.get("limit", default=get_default_limit(), type=int)
-    limit = check_page_limit(limit)
+    limit = check_page_limit(
+        request_args.get("limit", default=get_default_limit(), type=int)
+    )
 
     ids = request_args.get(
         "ids", default=None, type=partial(_array_arg, expect_type=uuid.UUID)
@@ -707,8 +706,9 @@ def _handle_collection_search(
 
     q = request_args.get("q", default=None, type=partial(_array_arg, expect_type=str))
 
-    limit = request_args.get("limit", default=get_default_limit(), type=int)
-    limit = check_page_limit(limit)
+    limit = check_page_limit(
+        request_args.get("limit", default=get_default_limit(), type=int)
+    )
 
     offset = request_args.get("_o", default=0, type=int)
 
@@ -1361,9 +1361,10 @@ def arrivals_items():
 
     This returns a Stac FeatureCollection of complete Stac Items, with paging links.
     """
-    limit = request.args.get("limit", default=get_default_limit(), type=int)
+    limit = check_page_limit(
+        request.args.get("limit", default=get_default_limit(), type=int)
+    )
     offset = request.args.get("_o", default=0, type=int)
-    limit = check_page_limit(limit)
 
     def next_page_url(next_offset):
         return url_for(".arrivals_items", limit=limit, _o=next_offset)

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -416,17 +416,12 @@ def test_stac_loading_all_pages(stac_client: FlaskClient) -> None:
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
 def test_huge_page_request(stac_client: FlaskClient) -> None:
-    """Return an error if they try to request beyond max-page-size limit"""
-    error_message_json = get_json(
+    """Return max items if limit requested is beyond max-page-size"""
+    data = get_json(
         stac_client,
         f"/stac/search?&limit={OUR_DATASET_LIMIT + 1}",
-        expect_status_code=400,
     )
-    assert error_message_json == {
-        "code": 400,
-        "name": "Bad Request",
-        "description": f"Max page size is {OUR_DATASET_LIMIT}. Use the next links instead of a large limit.",
-    }
+    assert data.get("numberReturned") == OUR_DATASET_LIMIT
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -415,16 +415,6 @@ def test_stac_loading_all_pages(stac_client: FlaskClient) -> None:
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_huge_page_request(stac_client: FlaskClient) -> None:
-    """Return max items if limit requested is beyond max-page-size"""
-    data = get_json(
-        stac_client,
-        f"/stac/search?&limit={OUR_DATASET_LIMIT + 1}",
-    )
-    assert data.get("numberReturned") == OUR_DATASET_LIMIT
-
-
-@pytest.mark.parametrize("env_name", ("default",), indirect=True)
 def test_returns_404s(stac_client: FlaskClient) -> None:
     """
     We should get 404 messages, not exceptions, for missing things.
@@ -884,11 +874,9 @@ def test_stac_item(stac_client: FlaskClient, odc_test_db) -> None:
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)
 def test_stac_search_limits(stac_client: FlaskClient) -> None:
-    # Tell user with error if they request too much.
-    large_limit = OUR_DATASET_LIMIT + 1
-    rv = stac_client.get(f"/stac/search?&limit={large_limit}")
-    assert rv.status_code == 400
-    assert b"Max page size" in rv.data
+    # Return max items if user requests limit beyond max page size
+    geojson = get_items(stac_client, f"/stac/search?&limit={OUR_DATASET_LIMIT + 1}")
+    assert len(geojson.get("features", [])) == OUR_DATASET_LIMIT
 
     # Without limit, it should use the default page size
     geojson = get_items(
@@ -901,13 +889,9 @@ def test_stac_search_limits(stac_client: FlaskClient) -> None:
     )
     assert len(geojson.get("features", [])) == OUR_PAGE_SIZE
 
-
-@pytest.mark.parametrize("env_name", ("default",), indirect=True)
-def test_stac_search_zero(stac_client: FlaskClient) -> None:
-    # Zero limit is a valid query
-    zero_limit = 0
-    rv = stac_client.get(f"/stac/search?&limit={zero_limit}")
-    assert rv.status_code == 200
+    # Zero limit is a valid query, and should return default page size
+    geojson = get_items(stac_client, "/stac/search?&limit=0")
+    assert len(geojson.get("features", [])) == OUR_PAGE_SIZE
 
 
 @pytest.mark.parametrize("env_name", ("default",), indirect=True)


### PR DESCRIPTION
According to the [Item Search STAC spec](https://api.stacspec.org/v1.0.0/item-search/#tag/Item-Search/operation/postItemSearch):
>  If the limit parameter value is greater than advertised limit maximum, the server must return the maximum possible number of items, rather than responding with an error.

Update `check_page_limit` to reflect this, and include handling for `limit < 1` for it to be more comprehensive and consistent. This new behaviour extends to Collection Search and /catalogs/arrivals/items  - api.stacspec.org does not seem to document the expected behaviour for Collection Search but it seems reasonable to assume it would be the same across the board.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--923.org.readthedocs.build/en/923/

<!-- readthedocs-preview datacube-explorer end -->