### PR TITLE
Fix version number in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,10 @@ docker-compose.*.yml
 **/__pycache__
 **/*.py[cod]
 
+#Git/VCS
+.git
+.jj
+
 # CI / distribution / packaging
 **/*.egg-info
 .github

--- a/.github/workflows/deployment_test.yaml
+++ b/.github/workflows/deployment_test.yaml
@@ -34,6 +34,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get and log unstable git tag
+        run: |
+          set -ex
+          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
+          echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
@@ -42,6 +48,8 @@ jobs:
         with:
           file: Dockerfile
           context: .
+          build-args: |
+            EXPLORER_VERSION=${{ env.UNSTABLE_TAG }}
           tags: ${{ env.DOCKER_IMAGE }}
           load: true
           cache-from: type=gha

--- a/.github/workflows/deployment_test.yaml
+++ b/.github/workflows/deployment_test.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Get and log unstable git tag
         run: |
           set -ex
-          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
+          UNSTABLE_TAG=$(uvx setuptools-scm)
           echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Get and log unstable git tag
         run: |
           set -ex
-          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
+          UNSTABLE_TAG=$(uvx setuptools-scm)
           echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
 
       - name: Build and Push unstable + latest Docker image tag

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Get and log unstable git tag
         run: |
           set -ex
-          UNSTABLE_TAG=$(git describe --tags)
+          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
           echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
 
       - name: Build and Push unstable + latest Docker image tag
@@ -51,25 +51,27 @@ jobs:
           username: gadockersvc
           image_tag: ${{ env.UNSTABLE_TAG }},latest
           password: "${{ secrets.DockerPassword }}"
-          build_extra_args: "--build-arg=ENVIRONMENT=deployment"
+          build_extra_args: "--build-arg=ENVIRONMENT=deployment --build-arg=EXPLORER_VERSION=${{ env.UNSTABLE_TAG }}"
 
-      # This section is for releases
+      ##############################
+      # Only For GitHub Releases!  #
+      ##############################
       - name: Get and log tag for this build if it exists
         if: github.event_name == 'release'
         run: |
           set -ex
-          RELEASE=$(git describe --abbrev=0 --tags)
-          echo "RELEASE=$RELEASE" >> $GITHUB_ENV
+          RELEASE_VERSION=$(git describe --abbrev=0 --tags)
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
 
       - name: Build and Push release if we have a tag
         uses: whoan/docker-build-with-cache-action@d8d3ad518e7ac382b880720d0751815e656fe032 # v8.1.0
         if: github.event_name == 'release'
         with:
           image_name: ${{ env.IMAGE_NAME }}
-          image_tag: ${{ env.RELEASE }}
+          image_tag: ${{ env.RELEASE_VERSION }}
           username: gadockersvc
           password: "${{ secrets.DockerPassword }}"
-          build_extra_args: "--build-arg=ENVIRONMENT=deployment"
+          build_extra_args: "--build-arg=ENVIRONMENT=deployment --build-arg=EXPLORER_VERSION=${{ env.RELEASE_VERSION }}"
 
       - name: Update Docker Hub Description
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get and log unstable git tag
         run: |
           set -ex
-          UNSTABLE_TAG=$(git describe --tags)
+          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
           echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
@@ -45,6 +45,8 @@ jobs:
         with:
           file: Dockerfile
           context: .
+          build-args: |
+            EXPLORER_VERSION=${{ env.UNSTABLE_TAG }}
           tags: ${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}
           load: true
           cache-from: type=gha

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get and log unstable git tag
         run: |
           set -ex
-          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
+          UNSTABLE_TAG=$(uvx setuptools-scm)
           echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,8 @@ jobs:
         run: |
           TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock cubedash)
           echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
+          echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
 
       - name: Build Docker
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -67,6 +69,7 @@ jobs:
           context: .
           build-args: |
             ENVIRONMENT=test
+            EXPLORER_VERSION=${{ env.UNSTABLE_TAG }}
           tags: ${{ env.DOCKER_IMAGE }}
           load: true
           cache-from: type=gha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock cubedash)
           echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
-          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
+          UNSTABLE_TAG=$(uvx setuptools-scm)
           echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
 
       - name: Build Docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,9 @@ RUN --mount=type=cache,id=opendatacube-uv-cache,target=/root/.cache \
 COPY --link . /build/
 
 ARG ENVIRONMENT=deployment
+ARG EXPLORER_VERSION=""
+
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${EXPLORER_VERSION}
 # The deployment image should not have binaries that aid an attacker to get their
 # rootkit in place, and uv downloads over the network. There is no conditional
 # copy in Docker, so truncate the uv binaries to 0 bytes to render them harmless
@@ -66,6 +69,7 @@ ARG ENVIRONMENT=deployment
 RUN --mount=type=cache,id=opendatacube-uv-cache,target=/root/.cache \
     EXTRAS=$( ([ "$ENVIRONMENT" = "deployment" ] && echo "--extra=deployment --no-dev") || \
                  echo "--extra=test") \
+    && export SETUPTOOLS_SCM_PRETEND_VERSION="${EXPLORER_VERSION}" \
     && uv sync --frozen $EXTRAS --no-editable \
     && ([ "$ENVIRONMENT" != "deployment" ] || \
         (chmod 644 /usr/local/bin/uv* && \
@@ -73,6 +77,9 @@ RUN --mount=type=cache,id=opendatacube-uv-cache,target=/root/.cache \
          echo "" > /usr/local/bin/uvx))
 
 FROM base
+
+ARG EXPLORER_VERSION=""
+LABEL org.opencontainers.image.version=${EXPLORER_VERSION}
 
 # Add login-script for UID/GID-remapping.
 COPY --chown=root:root --link docker/files/remap-user.sh /usr/local/bin/remap-user.sh

--- a/Makefile
+++ b/Makefile
@@ -70,25 +70,30 @@ clean:  ## Clean all working/temporary files
 
 # DOCKER STUFF
 up: ## Start server using Docker
-	docker compose up --quiet-pull
+	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	  docker compose up --quiet-pull
 
 up-d: ## Start server using Docker in background
-	docker compose up -d --wait --quiet-pull
+	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	  docker compose up -d --wait --quiet-pull
 
 build: ## Build the dev Docker image
-	docker compose build
+	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	  docker compose build
 
 docker-clean: ## Get rid of the local docker env and DB
 	docker compose down
 
 # These rules pass --file to avoid loading docker-compose.override.yml.
 build-prod: ## Build the prod Docker image
-	docker compose \
+	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	  docker compose \
 		--file docker-compose.yml \
 		build
 
 up-prod: ## Start using the prod Docker image
-	docker compose \
+	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	  docker compose \
 		--file docker-compose.yml \
 		up -d --wait --quiet-pull
 

--- a/Makefile
+++ b/Makefile
@@ -70,15 +70,15 @@ clean:  ## Clean all working/temporary files
 
 # DOCKER STUFF
 up: ## Start server using Docker
-	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	export EXPLORER_VERSION=$$(uvx setuptools-scm) && \
 	  docker compose up --quiet-pull
 
 up-d: ## Start server using Docker in background
-	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	export EXPLORER_VERSION=$$(uvx setuptools-scm) && \
 	  docker compose up -d --wait --quiet-pull
 
 build: ## Build the dev Docker image
-	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	export EXPLORER_VERSION=$$(uvx setuptools-scm) && \
 	  docker compose build
 
 docker-clean: ## Get rid of the local docker env and DB
@@ -86,13 +86,13 @@ docker-clean: ## Get rid of the local docker env and DB
 
 # These rules pass --file to avoid loading docker-compose.override.yml.
 build-prod: ## Build the prod Docker image
-	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	export EXPLORER_VERSION=$$(uvx setuptools-scm) && \
 	  docker compose \
 		--file docker-compose.yml \
 		build
 
 up-prod: ## Start using the prod Docker image
-	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	export EXPLORER_VERSION=$$(uvx setuptools-scm) && \
 	  docker compose \
 		--file docker-compose.yml \
 		up -d --wait --quiet-pull

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         ENVIRONMENT: deployment
+        EXPLORER_VERSION: ${EXPLORER_VERSION}
     image: ghcr.io/opendatacube/explorer:tests
     ports:
       - "80:8080"


### PR DESCRIPTION
We were getting an unclean git repo inside of the Docker build which is where setuptools_scm determines the version number.  This happend because our .dockerignore was excluding some directories that  exist in the git repo but aren't required in the docker image.

That's reasonable, but it makes it impossible to determine the version number correctly inside of the docker build.

This change add a docker ARG, and determines the version number in the GitHub Actions workflow before building the image.

Closes #897

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--933.org.readthedocs.build/en/933/

<!-- readthedocs-preview datacube-explorer end -->