### PR TITLE
Make .dockerignore not ignore anything extra than .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,33 +1,45 @@
-# Files that are only used by docker/docker compose.
-docker-compose.yaml
-docker-compose.*.yaml
-docker-compose.yml
-docker-compose.*.yml
-.docker
-.dockerignore
-
 # Byte-compiled / optimized / DLL files
-**/__pycache__
+**/__pycache__/
+**/.pytest_cache/
 **/*.py[cod]
 
-# CI / distribution / packaging
-**/*.egg-info
-.github
-.gitignore
-.mergify.yml
-.pre-commit-config.yaml
-.readthedocs.yaml
-.stylelintrc
-.venv
-.yamllint
-build
-dist
-Makefile
-pylintrc
+**/.mypy_cache/
+**/.DS_Store
 
-# Test and coverage reports
-**/htmlcov
-**/.tox
+# C extensions
+**/*.so
+
+# Distribution / packaging
+**/.Python
+**/env/
+**/build/
+**/develop-eggs/
+**/dist/
+**/downloads/
+**/eggs/
+**/.eggs/
+**/lib/
+**/lib64/
+**/parts/
+**/sdist/
+**/var/
+**/*.egg-info/
+**/.installed.cfg
+**/*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+**/*.manifest
+**/*.spec
+
+# Installer logs
+**/pip-log.txt
+**/pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+**/htmlcov/
+**/.tox/
 **/.coverage
 **/.coverage.*
 **/.cache
@@ -35,25 +47,20 @@ pylintrc
 **/coverage.xml
 **/*.cover
 **/.hypothesis
-.mypy_cache
-.pytest_cache
-.ruff_cache
-conftest.py
-integration_tests
-tests
+
+# Translations
+**/*.mo
+**/*.pot
 
 # Django stuff:
 **/*.log
 
-# Documentation
-*.md
-*.png
-*.rst
-docs
-LICENSE
+# Sphinx documentation
+**/docs/_build/
 
 # PyBuilder
-**/target
+**/target/
+**/.idea/
 
 # iPython Notebook
 **/.ipynb_checkpoints
@@ -62,9 +69,19 @@ LICENSE
 **/.DS_Store
 
 # Environment-specific templates
+**/.env
+**/.envrc
 **/*.env.html
 **/settings.env.py
 
-# IDE settings
-.idea
-.vscode
+**/node_modules
+**/certs
+
+# Let setuptools_scm manage the _version.py file
+**/cubedash/_version.py
+
+# Ignore vscode
+**/.vscode
+
+# Any uv (or otherwise) generated virtual environments
+**/.venv

--- a/.gitignore
+++ b/.gitignore
@@ -66,12 +66,16 @@ target/
 .DS_Store
 
 # Environment-specific templates
+.envrc
+.env
 *.env.html
 settings.env.py
 
 node_modules
-
 certs
+
+# Uv venvs
+.venv
 
 # Let setuptools_scm manage the _version.py file
 cubedash/_version.py


### PR DESCRIPTION
Otherwise setuptools_scm can't work out version numbers correctly when building or installing the package within a docker build.

There's a couple of tools for doing this that I tried:

```
uvx --from generate-dockerignore-from-gitignore generate-dockerignore

# OR

npx gitignore-to-dockerignore
```

In the hope of making this automatic, but, they both insist on putting `.git` into the dockerignore, which completely defeats the purpose here.


Replaces #933 , #935 

Closes #897

I have been testing locally with the following Dockerfile by running `docker build -t tempdocker -f ../Dockerfile-temp --progress plain .`

```dockerfile
# Use a lightweight Debian-based image
FROM alpine/git

# Install Git
# RUN apt update && apt install -y git

# Set the working directory inside the container
WORKDIR /app

RUN --mount=type=bind,source=.,dst=/bindmount \
    cd /bindmount; ls -la; git status

# Copy the entire current directory (your Git repo) into the container
# This includes the .git folder, which is essential for git commands
COPY . /app

RUN git status
# Define the command to run when the container starts
# It will execute 'git status' in the /app directory
CMD ["git", "status"]
```

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--936.org.readthedocs.build/en/936/

<!-- readthedocs-preview datacube-explorer end -->