### PR TITLE
CI: use anchors for paths

### DIFF
--- a/.github/workflows/deployment_test.yaml
+++ b/.github/workflows/deployment_test.yaml
@@ -3,15 +3,14 @@ name: Docker Image
 
 on: # yamllint disable-line rule:truthy
   pull_request:
-    paths:
+    paths: &paths
       - '**'
 
   push:
     branches:
       - develop
       - integrate_1.9
-    paths:
-      - '**'
+    paths: *paths
 
 env:
   DOCKER_IMAGE: ghcr.io/opendatacube/explorer:tests

--- a/.github/workflows/deployment_test.yaml
+++ b/.github/workflows/deployment_test.yaml
@@ -5,6 +5,12 @@ on: # yamllint disable-line rule:truthy
   pull_request:
     paths: &paths
       - '**'
+      - '!docs/**'
+      - '!integration_tests/**'
+      - '!*.rst'
+      - '!*.md'
+      - '!.github/**'
+      - '.github/workflows/deployment_test.yaml'
 
   push:
     branches:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,15 +3,14 @@ name: Code Linting
 
 on:
   pull_request:
-    paths:
+    paths: &paths
       - '**'
 
   push:
     branches:
       - develop
       - integrate_1.9
-    paths:
-      - '**'
+    paths: *paths
 
 permissions: {}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
     paths: &paths
       - '**'
+      - '!docs/**'
+      - '!*.rst'
+      - '!*.md'
+      - '!.github/**'
+      - '.github/workflows/lint.yml'
 
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
     paths: &paths
       - '**'
+      - '!docs/**'
+      - '!*.rst'
+      - '!*.md'
+      - '!.github/**'
+      - '.github/workflows/test.yml'
 
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,15 +3,14 @@ name: Tests
 
 on:
   pull_request:
-    paths:
+    paths: &paths
       - '**'
 
   push:
     branches:
       - develop
       - integrate_1.9
-    paths:
-      - '**'
+    paths: *paths
 
   release:
     types:


### PR DESCRIPTION
The path lists are meant to be identical,
so use the new yaml anchors to ensure that.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--941.org.readthedocs.build/en/941/

<!-- readthedocs-preview datacube-explorer end -->