### PR TITLE
dependabot: group action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  groups:
+    actions-deps:
+      patterns:
+        - "*"
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION
This is the same grouping as is done
in core and OWS.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--948.org.readthedocs.build/en/948/

<!-- readthedocs-preview datacube-explorer end -->