### PR TITLE
stores: add missing None check

### DIFF
--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -756,6 +756,7 @@ class SummaryStore:
             for [uri] in self.e_index.ds_search_returning(
                 fields=("uri",), limit=sample_size, args=search_args
             )
+            if uri is not None
         )
 
         return list(_common_paths_for_uris(uri_samples))

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -743,7 +743,7 @@ class SummaryStore:
         Sample some dataset locations for the given product, and return
         the common location.
 
-        Returns one row for each uri scheme found (http, file etc).
+        Returns one row for each uri scheme found (http, file etc.).
         """
         search_args: dict[str, str | Range] = {"product": name}
         if year or month or day:


### PR DESCRIPTION
The uri can be None, so filter
out the Nones since they can't
be ordered.

Fixes #952

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--953.org.readthedocs.build/en/953/

<!-- readthedocs-preview datacube-explorer end -->