### PR TITLE
pages: catch ProgrammingError

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -17,7 +17,7 @@ from flask import (
     request,
     url_for,
 )
-from sqlalchemy.exc import DataError
+from sqlalchemy.exc import DataError, ProgrammingError
 from werkzeug.datastructures import MultiDict
 
 import cubedash
@@ -230,7 +230,7 @@ def search_page(
             index.datasets.search(**query, limit=hard_search_limit + 1),
             key=lambda d: default_utc(d.center_time),
         )
-    except DataError:
+    except (DataError, ProgrammingError):
         abort(400, "Invalid field value provided in query")
 
     more_datasets_exist = False


### PR DESCRIPTION
This happens with psycopg3
if the user provides a search
parameter with a bad type,
such as:

/products/ga_ls8c_ard_3/datasets?indexed_time=asdf

as done by the test
test_invalid_query_gives_400.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--961.org.readthedocs.build/en/961/

<!-- readthedocs-preview datacube-explorer end -->