### PR TITLE
Include psycopg3 in dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN --mount=type=cache,id=opendatacube-uv-cache,target=/root/.cache \
     uv sync --frozen --extra=deployment --no-install-project \
       --no-binary-package fiona \
       --no-binary-package netcdf4 \
+      --no-binary-package psycopg \
       --no-binary-package psycopg2 \
       --no-binary-package rasterio \
       --no-binary-package shapely

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # Tests fail with "ValueError: I/O operation on closed file" with Click
     # 8.2.0 and later.
     "click<8.2.0",
-    "datacube[postgres]>=1.9.10,<1.10.0",
+    "datacube[postgres,psycopg3]>=1.9.10,<1.10.0",
     "eodatasets3>=1.9",
     "fiona>=1.10.0",
     "flask",

--- a/uv.lock
+++ b/uv.lock
@@ -798,6 +798,9 @@ wheels = [
 postgres = [
     { name = "psycopg2" },
 ]
+psycopg3 = [
+    { name = "psycopg" },
+]
 
 [[package]]
 name = "datacube-explorer"
@@ -805,7 +808,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
-    { name = "datacube", extra = ["postgres"] },
+    { name = "datacube", extra = ["postgres", "psycopg3"] },
     { name = "eodatasets3" },
     { name = "fiona" },
     { name = "flask" },
@@ -902,7 +905,7 @@ requires-dist = [
     { name = "cachetools" },
     { name = "ciso8601", marker = "extra == 'deployment'" },
     { name = "click", specifier = "<8.2.0" },
-    { name = "datacube", extras = ["postgres"], specifier = ">=1.9.10,<1.10.0" },
+    { name = "datacube", extras = ["postgres", "psycopg3"], specifier = ">=1.9.10,<1.10.0" },
     { name = "datacube-explorer", extras = ["deployment"], marker = "extra == 'test'" },
     { name = "deepdiff", marker = "extra == 'test'" },
     { name = "docker", marker = "extra == 'test'" },
@@ -2610,6 +2613,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/95/992c8816a74016eb095e73585d747e0a8ea21a061ed3689474fabb29a395/psutil-7.1.3-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56d974e02ca2c8eb4812c3f76c30e28836fffc311d55d979f1465c1feeb2b68b", size = 264635, upload-time = "2025-11-02T12:26:31.74Z" },
     { url = "https://files.pythonhosted.org/packages/55/4c/c3ed1a622b6ae2fd3c945a366e64eb35247a31e4db16cf5095e269e8eb3c/psutil-7.1.3-cp37-abi3-win_amd64.whl", hash = "sha256:f39c2c19fe824b47484b96f9692932248a54c43799a84282cfe58d05a6449efd", size = 247633, upload-time = "2025-11-02T12:26:33.887Z" },
     { url = "https://files.pythonhosted.org/packages/c9/ad/33b2ccec09bf96c2b2ef3f9a6f66baac8253d7565d8839e024a6b905d45d/psutil-7.1.3-cp37-abi3-win_arm64.whl", hash = "sha256:bd0d69cee829226a761e92f28140bec9a5ee9d5b4fb4b0cc589068dbfff559b1", size = 244608, upload-time = "2025-11-02T12:26:36.136Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.2.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/05/d4a05988f15fcf90e0088c735b1f2fc04a30b7fc65461d6ec278f5f2f17a/psycopg-3.2.13.tar.gz", hash = "sha256:309adaeda61d44556046ec9a83a93f42bbe5310120b1995f3af49ab6d9f13c1d", size = 160626, upload-time = "2025-11-21T22:34:32.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/14/f2724bd1986158a348316e86fdd0837a838b14a711df3f00e47fba597447/psycopg-3.2.13-py3-none-any.whl", hash = "sha256:a481374514f2da627157f767a9336705ebefe93ea7a0522a6cbacba165da179a", size = 206797, upload-time = "2025-11-21T22:29:39.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Make it possible to use psycopg3
with the default packages of
Explorer.

Nothing will use this by default,
but this will make it easier for
people to test psycopg3 with
the next release of Explorer.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--962.org.readthedocs.build/en/962/

<!-- readthedocs-preview datacube-explorer end -->