### PR TITLE
dependabot: fix syntax error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       patterns:
         - "*"
   cooldown:
-    default-days: "10"
+    default-days: 10
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION


<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--971.org.readthedocs.build/en/971/

<!-- readthedocs-preview datacube-explorer end -->