### PR TITLE
Update docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - develop
-      - integrate_1.9
     paths:
       - "**"
 
@@ -16,6 +15,7 @@ on:
 
 env:
   IMAGE_NAME: opendatacube/explorer
+  REGISTRY: ghcr.io
 
 permissions: {}
 
@@ -31,13 +31,35 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop' || github.event_name == 'release'
 
+    permissions:
+      id-token: write   # This is required for requesting the JWT
+      contents: read    # This is required for actions/checkout
+      packages: write  # This is required for pushing to ghcr
+      attestations: write # This is required for pushing the attestation
+
     steps:
       - name: Checkout git
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
 
+      - name: Log in to GHCR
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Get Git commit timestamps
+        run: |
+          TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock cubedash)
+          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+
       - name: Get and log unstable git tag
+        if: github.event_name != 'release'
         run: |
           set -ex
           UNSTABLE_TAG=$(git describe --tags)
@@ -45,13 +67,18 @@ jobs:
 
       - name: Build and Push unstable + latest Docker image tag
         if: github.event_name != 'release'
-        uses: whoan/docker-build-with-cache-action@d8d3ad518e7ac382b880720d0751815e656fe032 # v8.1.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
-          image_name: ${{ env.IMAGE_NAME }}
-          username: gadockersvc
-          image_tag: ${{ env.UNSTABLE_TAG }},latest
-          password: "${{ secrets.DockerPassword }}"
-          build_extra_args: "--build-arg=ENVIRONMENT=deployment"
+          context: .
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: ENVIRONMENT=deployment
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
       # This section is for releases
       - name: Get and log tag for this build if it exists
@@ -62,20 +89,24 @@ jobs:
           echo "RELEASE=$RELEASE" >> $GITHUB_ENV
 
       - name: Build and Push release if we have a tag
-        uses: whoan/docker-build-with-cache-action@d8d3ad518e7ac382b880720d0751815e656fe032 # v8.1.0
         if: github.event_name == 'release'
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: push
         with:
-          image_name: ${{ env.IMAGE_NAME }}
-          image_tag: ${{ env.RELEASE }}
-          username: gadockersvc
-          password: "${{ secrets.DockerPassword }}"
-          build_extra_args: "--build-arg=ENVIRONMENT=deployment"
+          context: .
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: ENVIRONMENT=deployment
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE }}
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
-      - name: Update Docker Hub Description
-        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+      - name: Attest Docker image
+        if: github.event_name == 'release'
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
-          username: gadockersvc
-          password: ${{ secrets.DockerPassword }}
-          repository: ${{ env.IMAGE_NAME }}
-          readme-filepath: README.md
-          short-description: Open Data Cube Explorer Image
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Update the docker workflow to push to GHCR instead of DockerHub (as per #896), switch to using `docker/build-push-action` and add attestation to be more in line with other ODC packages (e.g. OWS)

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1001.org.readthedocs.build/en/1001/

<!-- readthedocs-preview datacube-explorer end -->