### PR TITLE
Fix version number in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,10 @@ docker-compose.*.yml
 **/__pycache__
 **/*.py[cod]
 
+#Git/VCS
+.git
+.jj
+
 # CI / distribution / packaging
 **/*.egg-info
 .github

--- a/.github/workflows/deployment_test.yaml
+++ b/.github/workflows/deployment_test.yaml
@@ -39,6 +39,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get and log unstable git tag
+        run: |
+          set -ex
+          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
+          echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
@@ -47,6 +53,8 @@ jobs:
         with:
           file: Dockerfile
           context: .
+          build-args: |
+            EXPLORER_VERSION=${{ env.UNSTABLE_TAG }}
           tags: ${{ env.DOCKER_IMAGE }}
           load: true
           cache-from: type=gha

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,7 +62,7 @@ jobs:
         if: github.event_name != 'release'
         run: |
           set -ex
-          UNSTABLE_TAG=$(git describe --tags)
+          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
           echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
 
       - name: Build and Push unstable + latest Docker image tag
@@ -73,7 +73,9 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: ENVIRONMENT=deployment
+          build-args: |
+            ENVIRONMENT=deployment
+            EXPLORER_VERSION=${{ env.UNSTABLE_TAG }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
@@ -85,8 +87,8 @@ jobs:
         if: github.event_name == 'release'
         run: |
           set -ex
-          RELEASE=$(git describe --abbrev=0 --tags)
-          echo "RELEASE=$RELEASE" >> $GITHUB_ENV
+          RELEASE_VERSION=$(git describe --abbrev=0 --tags)
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
 
       - name: Build and Push release if we have a tag
         if: github.event_name == 'release'
@@ -97,7 +99,9 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: ENVIRONMENT=deployment
+          build-args: |
+            ENVIRONMENT=deployment
+            EXPLORER_VERSION=${{ env.RELEASE_VERSION }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE }}
         env:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Get and log unstable git tag
         run: |
           set -ex
-          UNSTABLE_TAG=$(git describe --tags)
+          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
           echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
@@ -47,6 +47,8 @@ jobs:
         with:
           file: Dockerfile
           context: .
+          build-args: |
+            EXPLORER_VERSION=${{ env.UNSTABLE_TAG }}
           tags: ${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}
           load: true
           cache-from: type=gha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,8 @@ jobs:
         run: |
           TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock cubedash)
           echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
+          echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
 
       - name: Build Docker
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -71,6 +73,7 @@ jobs:
           context: .
           build-args: |
             ENVIRONMENT=test
+            EXPLORER_VERSION=${{ env.UNSTABLE_TAG }}
           tags: ${{ env.DOCKER_IMAGE }}
           load: true
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN --mount=type=cache,id=opendatacube-uv-cache,target=/root/.cache \
 COPY --link . /build/
 
 ARG ENVIRONMENT=deployment
+ARG EXPLORER_VERSION=""
 # The deployment image should not have binaries that aid an attacker to get their
 # rootkit in place, and uv downloads over the network. There is no conditional
 # copy in Docker, so truncate the uv binaries to 0 bytes to render them harmless
@@ -68,6 +69,7 @@ ARG ENVIRONMENT=deployment
 RUN --mount=type=cache,id=opendatacube-uv-cache,target=/root/.cache \
     EXTRAS=$( ([ "$ENVIRONMENT" = "deployment" ] && echo "--extra=deployment --no-dev") || \
                  echo "--extra=test") \
+    && export SETUPTOOLS_SCM_PRETEND_VERSION="${EXPLORER_VERSION}" \
     && uv sync --frozen $EXTRAS --no-editable \
     && ([ "$ENVIRONMENT" != "deployment" ] || \
         (chmod 644 /usr/local/bin/uv* && \
@@ -75,6 +77,9 @@ RUN --mount=type=cache,id=opendatacube-uv-cache,target=/root/.cache \
          echo "" > /usr/local/bin/uvx))
 
 FROM base
+
+ARG EXPLORER_VERSION=""
+LABEL org.opencontainers.image.version=${EXPLORER_VERSION}
 
 # Add login-script for UID/GID-remapping.
 COPY --chown=root:root --link docker/files/remap-user.sh /usr/local/bin/remap-user.sh

--- a/Makefile
+++ b/Makefile
@@ -70,25 +70,30 @@ clean:  ## Clean all working/temporary files
 
 # DOCKER STUFF
 up: ## Start server using Docker
-	docker compose up --quiet-pull
+	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	  docker compose up --quiet-pull
 
 up-d: ## Start server using Docker in background
-	docker compose up -d --wait --quiet-pull
+	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	  docker compose up -d --wait --quiet-pull
 
 build: ## Build the dev Docker image
-	docker compose build
+	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	  docker compose build
 
 docker-clean: ## Get rid of the local docker env and DB
 	docker compose down
 
 # These rules pass --file to avoid loading docker-compose.override.yml.
 build-prod: ## Build the prod Docker image
-	docker compose \
+	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	  docker compose \
 		--file docker-compose.yml \
 		build
 
 up-prod: ## Start using the prod Docker image
-	docker compose \
+	export EXPLORER_VERSION=$$(git describe --tag | sed 's#\-g#+g#') && \
+	  docker compose \
 		--file docker-compose.yml \
 		up -d --wait --quiet-pull
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         ENVIRONMENT: deployment
+        EXPLORER_VERSION: ${EXPLORER_VERSION}
     image: ghcr.io/opendatacube/explorer:tests
     ports:
       - "80:8080"


### PR DESCRIPTION
We were getting an unclean git repo inside of the Docker build which is where setuptools_scm determines the version number. This happend because our .dockerignore was excluding some directories that exist in the git repo but aren't required in the docker image.

That's reasonable, but it makes it impossible to determine the version number correctly inside of the docker build.

This change add a docker ARG, and determines the version number in the GitHub Actions workflow before building the image.

Closes #897

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1015.org.readthedocs.build/en/1015/

<!-- readthedocs-preview datacube-explorer end -->