### PR TITLE
Fix Docker image tags

### DIFF
--- a/.github/workflows/deployment_test.yaml
+++ b/.github/workflows/deployment_test.yaml
@@ -42,8 +42,10 @@ jobs:
       - name: Get and log unstable git tag
         run: |
           set -ex
-          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
+          UNSTABLE_TAG=$(git describe --tags)
           echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
+          EXPLORER_VERSION=$(git describe --tags | sed 's#\-g#+g#')
+          echo "EXPLORER_VERSION=$EXPLORER_VERSION" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
@@ -54,7 +56,7 @@ jobs:
           file: Dockerfile
           context: .
           build-args: |
-            EXPLORER_VERSION=${{ env.UNSTABLE_TAG }}
+            EXPLORER_VERSION=${{ env.EXPLORER_VERSION }}
           tags: ${{ env.DOCKER_IMAGE }}
           load: true
           cache-from: type=gha

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,8 +62,10 @@ jobs:
         if: github.event_name != 'release'
         run: |
           set -ex
-          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
+          UNSTABLE_TAG=$(git describe --tags)
           echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
+          EXPLORER_VERSION=$(git describe --tags | sed 's#\-g#+g#')
+          echo "EXPLORER_VERSION=$EXPLORER_VERSION" >> $GITHUB_ENV
 
       - name: Build and Push unstable + latest Docker image tag
         if: github.event_name != 'release'
@@ -75,7 +77,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             ENVIRONMENT=deployment
-            EXPLORER_VERSION=${{ env.UNSTABLE_TAG }}
+            EXPLORER_VERSION=${{ env.EXPLORER_VERSION }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
@@ -103,7 +105,7 @@ jobs:
             ENVIRONMENT=deployment
             EXPLORER_VERSION=${{ env.RELEASE_VERSION }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE_VERSION }}
         env:
           SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -31,8 +31,10 @@ jobs:
       - name: Get and log unstable git tag
         run: |
           set -ex
-          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
+          UNSTABLE_TAG=$(git describe --tags)
           echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
+          EXPLORER_VERSION=$(git describe --tags | sed 's#\-g#+g#')
+          echo "EXPLORER_VERSION=$EXPLORER_VERSION" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
@@ -48,7 +50,7 @@ jobs:
           file: Dockerfile
           context: .
           build-args: |
-            EXPLORER_VERSION=${{ env.UNSTABLE_TAG }}
+            EXPLORER_VERSION=${{ env.EXPLORER_VERSION }}
           tags: ${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}
           load: true
           cache-from: type=gha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,8 +63,10 @@ jobs:
         run: |
           TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock cubedash)
           echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
-          UNSTABLE_TAG=$(git describe --tags | sed 's#\-g#+g#')
+          UNSTABLE_TAG=$(git describe --tags)
           echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
+          EXPLORER_VERSION=$(git describe --tags | sed 's#\-g#+g#')
+          echo "EXPLORER_VERSION=$EXPLORER_VERSION" >> $GITHUB_ENV
 
       - name: Build Docker
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -73,7 +75,7 @@ jobs:
           context: .
           build-args: |
             ENVIRONMENT=test
-            EXPLORER_VERSION=${{ env.UNSTABLE_TAG }}
+            EXPLORER_VERSION=${{ env.EXPLORER_VERSION }}
           tags: ${{ env.DOCKER_IMAGE }}
           load: true
           cache-from: type=gha


### PR DESCRIPTION
The requirements for Docker tags
and Python versions are different,
so use two separate variables for
them.

Put in both variable definitions
in all workflows, but only use
the UNSTABLE_TAG variable in
the workflow that tags the image.
Will update the workflows to use
the variable later this week
after the release.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1018.org.readthedocs.build/en/1018/

<!-- readthedocs-preview datacube-explorer end -->