### PR TITLE
Ensure safe_transform function created with admin ownership.

### DIFF
--- a/cubedash/index/postgis/_schema.py
+++ b/cubedash/index/postgis/_schema.py
@@ -1,4 +1,5 @@
 from datacube.drivers.common_psql import (
+    as_role,
     grant_role,
     has_roles,
     transfer_ownership,
@@ -331,7 +332,8 @@ def create_after_schema(conn: Connection, epsg_code: int) -> None:
         unique=True,
     )
 
-    create_safe_transform_func(conn)
+    with as_role(conn, "odc_admin") as conn:
+        create_safe_transform_func(conn)
 
 
 def grant_permissions(conn: Connection) -> None:

--- a/cubedash/index/postgres/_schema.py
+++ b/cubedash/index/postgres/_schema.py
@@ -348,7 +348,8 @@ def create_after_schema(conn: Connection, epsg_code: int) -> None:
         unique=True,
     )
 
-    create_safe_transform_func(conn)
+    with as_role(conn, "agdc_admin") as conn:
+        create_safe_transform_func(conn)
 
 
 def update_schema(conn: Connection) -> set[PleaseRefresh]:


### PR DESCRIPTION
Create safe_transform function as admin.

Would need to ensure as for other objects if a release had gone out, but as 3.1.3 never hit PyPI, this should be fine.

(Also the new Core common ownership functions don't support functions yet.)