### PR TITLE
Remove direct click dependency for PyPI upload.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,18 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
 
+      # We need a patched version of click to run tests, but direct dependencies can't
+      # be uploaded to PyPI.
+      #
+      # Therefore we removed the direct click dependency, and simply depend on click.
+      #
+      # Version dependency can be inherited from datacube-core.
+      #
+      # This step should be removed once a click release fixes the CliRunner issue that breaks tests.
+      - name: Remove patched click dependency
+        run: |
+          perl -pi -e 's# \@ git\+https://github\.com/pjonsson/click\.git\@one-close-only##' pyproject.toml
+
       - name: Build Packages
         run: |
           uv build


### PR DESCRIPTION
We need a patched version of click to run tests, but direct dependencies can't be uploaded to PyPI.

This PR removes the direct click dependency in the PyPI upload workflow to simply depend on "click". (Version dependency can be inherited from datacube-core.)

The workflow step added by this PR should be removed once a click release fixes the CliRunner issue that is breaking tests.

(The Click issue is with CliRunner, and therefore only affects tests).

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1026.org.readthedocs.build/en/1026/

<!-- readthedocs-preview datacube-explorer end -->