### PR TITLE
Second attempt at removing click direct dependency for PyPI upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,18 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
 
+      # We need a patched version of click to run tests, but direct dependencies can't
+      # be uploaded to PyPI.
+      #
+      # Therefore we removed the direct click dependency, and simply depend on click.
+      #
+      # Version dependency can be inherited from datacube-core.
+      #
+      # This step should be removed once a click release fixes the CliRunner issue that breaks tests.
+      - name: Remove patched click dependency
+        run: |
+          perl -pi -e 's# \@ git\+https://github\.com/pjonsson/click\.git\@one-close-only##' pyproject.toml
+
       - name: Build Packages
         run: |
           uv build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,7 @@ jobs:
       # be uploaded to PyPI.
       #
       # Therefore we removed the direct click dependency, and simply depend on click.
+      # (and use $SETUPTOOLS_SCM_PRETEND_VERSION to force a clean version number.)
       #
       # Version dependency can be inherited from datacube-core.
       #
@@ -133,6 +134,7 @@ jobs:
 
       - name: Build Packages
         run: |
+          export SETUPTOOLS_SCM_PRETEND_VERSION=`git describe --abbrev=0 --tags`
           uv build
           uv tool run twine check --strict dist/*
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,8 @@ jobs:
       #
       # Version dependency can be inherited from datacube-core.
       #
-      # This step should be removed once a click release fixes the CliRunner issue that breaks tests.
+      # This step (and the export of SETUPTOOLS_SCM_PRETEND_VERSION below) should be
+      # removed once a click release fixes the CliRunner issue that breaks tests.
       - name: Remove patched click dependency
         run: |
           perl -pi -e 's# \@ git\+https://github\.com/pjonsson/click\.git\@one-close-only##' pyproject.toml

--- a/README.md
+++ b/README.md
@@ -292,26 +292,4 @@ The `filter` extension supports both `cql2-text` and `cql2-json` for both GET an
 
 ## Release process
 
-Normally simply use the Github release interface.
-
-Currently the automated release process fails to push to PyPI because of the direct
-dependency on a unoffical patched version of Click.  This patch is only required
-for running the integration tests, therefore it is safe to remove for the version that
-goes to PyPI.
-
-The process for a manual release to PyPI is:
-
-1. Create a release through the Github release interface.  This will trigger
-   a github workflow job that will handle the push of the docker image to GHCR,
-   but the push to PyPI will fail.
-2. Checkout the release tag (`git checkout x.y.z`)
-3. Manually remove the direct dependency on the patched click version from `pyproject.toml`.
-   (Simply depend on an unpinned click.)
-4. Override SCM versioning (`export SETUPTOOLS_SCM_PRETEND_VERSION=x.y.z`)
-5. Cleanup any previous builds and rebuild (`rm -rf dist; python -m build`)
-6. Manually push to PyPI (`python -m twine upload --repository datacube-explorer dist/*`)
-   (Note that this requires an appropropriately authorised PyPI access token to be stored
-   in `~/.pypirc` - refer to the PyPI documentation for details.)
-
-Once the issue affecting tests is fixed in a Click release, we can revert to using
-the Github release interface and workflow automation.
+Create a release using the Github release interface.


### PR DESCRIPTION
See #1026 and #1028

This should force the version number to be the most recent tag, bypassing the problem the stopped #1026 from working.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1032.org.readthedocs.build/en/1032/

<!-- readthedocs-preview datacube-explorer end -->