### PR TITLE
Disallow bot access to `/api`

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -43,6 +43,7 @@ Disallow: /products/
 Disallow: /product/
 Disallow: /stac/
 Disallow: /dataset/
+Disallow: /api/
 """
 
 


### PR DESCRIPTION
All the `/api` links are for downloading the product geojson summaries, which we probably don't want bots doing so add it to `robots.txt`

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1041.org.readthedocs.build/en/1041/

<!-- readthedocs-preview datacube-explorer end -->