### PR TITLE
pages: error on no footprint

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -409,6 +409,8 @@ def region_geojson(
         abort(404, f"Product {product_name!r} has no {region_code!r} region.")
 
     geojson = region_summary.footprint_geojson
+    if geojson is None:
+        abort(404, f"Product {product_name!r} has no footprint.")
     geojson["properties"].update(
         {"product_name": product_name, "year_month_day_filter": [year, month, day]}
     )

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -5,7 +5,7 @@ from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from datetime import date, datetime
 from pathlib import Path
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 import fiona
 import structlog
@@ -352,7 +352,7 @@ class RegionSummary:
     footprint_wgs84: Geometry
 
     @property
-    def footprint_geojson(self):
+    def footprint_geojson(self) -> dict[str, Any] | None:
         extent = self.footprint_wgs84
         if not extent:
             return None


### PR DESCRIPTION
The return type can be None, so
detect that and return an error.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1047.org.readthedocs.build/en/1047/

<!-- readthedocs-preview datacube-explorer end -->