### PR TITLE
Dockerfile: increase UV_HTTP_RETRIES

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         python3-dev
 
 ENV UV_COMPILE_BYTECODE=0 \
+    UV_HTTP_RETRIES=10 \
     UV_LINK_MODE=copy \
     UV_PROJECT_ENVIRONMENT=/app \
     UV_PYTHON_DOWNLOADS=never \


### PR DESCRIPTION
This reduces the risk of intermittent
failures causing the build to fail.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1050.org.readthedocs.build/en/1050/

<!-- readthedocs-preview datacube-explorer end -->