### PR TITLE
Use more specific type annotations

### DIFF
--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -68,7 +68,9 @@ import structlog
 from click import secho as click_secho
 from click import style
 from datacube.cfg import ODCConfig, ODCEnvironment
-from datacube.index import Index, index_connect
+from datacube.index import index_connect
+from datacube.index.postgis.index import Index as PostgisIndex
+from datacube.index.postgres.index import Index as PostgresIndex
 from datacube.model import Product
 from datacube.ui.click import environment_option, pass_config
 from typing_extensions import override
@@ -150,11 +152,14 @@ def generate_report(
         store.close()
 
 
-def _get_index(config: ODCEnvironment, variant: str) -> Index:
+def _get_index(config: ODCEnvironment, variant: str) -> PostgisIndex | PostgresIndex:
     # Avoid long names as they will print warnings all the time.
     prefix = "gen."
     name = f"{prefix}{variant.replace('_', '')[: 64 - len(prefix)]}"
-    return index_connect(config, application_name=name, validate_connection=False)
+    ix = index_connect(config, application_name=name, validate_connection=False)
+    if isinstance(ix, (PostgisIndex, PostgresIndex)):
+        return ix
+    raise ValueError(f"Cannot run explorer with index {ix.name}")
 
 
 def run_generation(

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -15,7 +15,7 @@ from datacube.drivers.postgis._schema import (  # isort: skip
     Dataset as ODC_DATASET,  # noqa: N814
     Product as ODC_PRODUCT,  # noqa: N814
 )
-from datacube.index import Index
+from datacube.index.postgis.index import Index
 from datacube.model import Dataset, Field, MetadataType, Product, Range
 from geoalchemy2 import Geometry
 from geoalchemy2.shape import from_shape
@@ -70,6 +70,8 @@ _LOG = structlog.stdlib.get_logger()
 
 
 class ExplorerIndex(ExplorerAbstractIndex):
+    index: Index
+
     def __init__(self, index: Index) -> None:
         super().__init__("pgis_index", index)
         self.db_api = PostgisDbAPI

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -17,7 +17,7 @@ from datacube.drivers.postgres._schema import (  # isort: skip
     DATASET_SOURCE,
     PRODUCT as ODC_PRODUCT,
 )
-from datacube.index import Index
+from datacube.index.postgres.index import Index
 from datacube.model import Dataset, Field, MetadataType, Product, Range
 from geoalchemy2 import Geometry
 from geoalchemy2.shape import from_shape
@@ -67,6 +67,8 @@ _LOG = structlog.stdlib.get_logger()
 
 
 class ExplorerIndex(ExplorerAbstractIndex):
+    index: Index
+
     def __init__(self, index: Index) -> None:
         super().__init__("postgres", index)
         self.db_api = PostgresDbAPI

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -34,6 +34,8 @@ try:
 except ModuleNotFoundError:
     explorer_version = "ci-test-pipeline"
 from datacube.index import Index
+from datacube.index.postgis.index import Index as PostgisIndex
+from datacube.index.postgres.index import Index as PostgresIndex
 from datacube.model import Dataset, Field, MetadataType, Product, Range
 from odc.geo.geom import Geometry
 
@@ -60,10 +62,10 @@ DEFAULT_EPSG = 6933
 default_timezone = ZoneInfo(DEFAULT_TIMEZONE)
 
 
-def explorer_index(index: Index) -> ExplorerIndex:
-    if index.name == "pg_index":
+def explorer_index(index: PostgisIndex | PostgresIndex) -> ExplorerIndex:
+    if isinstance(index, PostgresIndex):
         return ExplorerPgIndex(index)
-    if index.name == "pgis_index":
+    if isinstance(index, PostgisIndex):
         return ExplorerPgisIndex(index)
     # should we permit memory? default to postgres? other handling?
     raise ValueError(f"Cannot run explorer with index {index.name}")
@@ -308,6 +310,8 @@ class SummaryStore:
     def create(
         cls, index: Index, log=_LOG, grouping_time_zone: str = DEFAULT_TIMEZONE
     ) -> "SummaryStore":
+        if not isinstance(index, (PostgisIndex, PostgresIndex)):
+            raise ValueError(f"Cannot run explorer with index {index.name}")
         e_index = explorer_index(index)
         return cls(
             e_index, Summariser(e_index, grouping_time_zone=grouping_time_zone), log=log

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -15,6 +15,8 @@ import structlog
 from click import echo, secho
 from datacube.cfg import ODCEnvironment
 from datacube.index import index_connect
+from datacube.index.postgis.index import Index as PostgisIndex
+from datacube.index.postgres.index import Index as PostgresIndex
 from datacube.ui.click import environment_option, pass_config
 
 from cubedash._filters import sizeof_fmt
@@ -28,7 +30,9 @@ def _get_store(cfg_env: ODCEnvironment, variant: str, log=_LOG) -> SummaryStore:
     index = index_connect(
         cfg_env, application_name=f"cubedash.show.{variant}", validate_connection=False
     )
-    return SummaryStore.create(index, log=log)
+    if isinstance(index, (PostgisIndex, PostgresIndex)):
+        return SummaryStore.create(index, log=log)
+    raise ValueError(f"Cannot run explorer with index {index.name}")
 
 
 @click.command(help=__doc__)


### PR DESCRIPTION
Be explicit with that we are passing
around an index that is from a database.
This brings the number of type errors
reported by MyPy from 90 down to 28.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1059.org.readthedocs.build/en/1059/

<!-- readthedocs-preview datacube-explorer end -->