### PR TITLE
stac: use datacube's ds2stac

### DIFF
--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -9,9 +9,9 @@ from typing import Any, TypeAlias
 import flask
 import pystac
 import structlog
+from datacube.metadata import ds2stac
 from datacube.model import Range
 from datacube.utils import DocReader, parse_time
-from eodatasets3 import serialise
 from eodatasets3 import stac as eo3stac
 from eodatasets3.model import AccessoryDoc, DatasetDoc, MeasurementDoc, ProductDoc
 from eodatasets3.properties import Eo3Dict
@@ -174,34 +174,15 @@ def as_stac_item(dataset: DatasetItem) -> pystac.Item:
     Get a dict corresponding to a stac item
     """
     ds = dataset.odc_dataset
-
+    base_url = url_for("pages.default_redirect")
+    self_url = url_for(
+        ".item", collection=dataset.product_name, dataset_id=dataset.dataset_id
+    )
+    ds_yaml_url = url_for("dataset.raw_doc", id_=dataset.dataset_id)
     if ds is not None and is_doc_eo3(ds.metadata_doc):
-        dataset_doc = serialise.from_doc(ds.metadata_doc, skip_validation=True)
-        dataset_doc.locations = None if ds.uri is None else [ds.uri]
-
-        # Geometry is optional in eo3, and needs to be calculated from grids if missing.
-        # We can use ODC's own calculation that happens on index.
-        if dataset_doc.geometry is None:
-            fallback_extent = ds.extent
-            if fallback_extent is not None:
-                dataset_doc.geometry = fallback_extent.geom
-                dataset_doc.crs = str(ds.crs)
-
-        if ds.sources:
-            dataset_doc.lineage = {
-                classifier: [d.id] for classifier, d in ds.sources.items()
-            }
-        # Does ODC still put legacy lineage into indexed documents?
-        elif ("source_datasets" in dataset_doc.lineage) and len(
-            dataset_doc.lineage
-        ) == 1:
-            # From old to new lineage type.
-            # FIXME: remove type ignores and fix the issues.
-            dataset_doc.lineage = {  # type: ignore[misc]
-                classifier: [dataset["id"]]  # type: ignore[has-type]
-                for classifier, dataset in dataset_doc.lineage["source_datasets"]
-            }
-
+        item = ds2stac(
+            ds, base_url=base_url, self_url=self_url, ds_yaml_url=ds_yaml_url
+        )
     else:
         # eo1 to eo3
 
@@ -235,17 +216,15 @@ def as_stac_item(dataset: DatasetItem) -> pystac.Item:
             lineage={},
         )
 
-    if dataset_doc.label is None and ds is not None:
-        dataset_doc.label = _utils.dataset_label(ds)
+        if dataset_doc.label is None and ds is not None:
+            dataset_doc.label = _utils.dataset_label(ds)
 
-    item = eo3stac.to_pystac_item(
-        dataset=dataset_doc,
-        stac_item_destination_url=url_for(
-            ".item", collection=dataset.product_name, dataset_id=dataset.dataset_id
-        ),
-        odc_dataset_metadata_url=url_for("dataset.raw_doc", id_=dataset.dataset_id),
-        explorer_base_url=url_for("pages.default_redirect"),
-    )
+        item = eo3stac.to_pystac_item(
+            dataset=dataset_doc,
+            stac_item_destination_url=self_url,
+            odc_dataset_metadata_url=ds_yaml_url,
+            explorer_base_url=base_url,
+        )
 
     # Add the region code that Explorer inferred.
     # (Explorer's region codes predate ODC's and support

--- a/integration_tests/schemas/stac-extensions.github.io/raster/v1.1.0/schema.json
+++ b/integration_tests/schemas/stac-extensions.github.io/raster/v1.1.0/schema.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stac-extensions.github.io/raster/v1.1.0/schema.json#",
+  "title": "raster Extension",
+  "description": "STAC Raster Extension for STAC Items.",
+  "oneOf": [
+    {
+      "$comment": "This is the schema for STAC extension raster in Items.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "assets"
+          ],
+          "properties": {
+            "type": {
+              "const": "Feature"
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/assetfields"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ]
+    },
+    {
+      "$comment": "This is the schema for STAC Collections.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "Collection"
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/assetfields"
+              }
+            },
+            "item_assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/assetfields"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+          }
+        }
+      }
+    },
+    "assetfields": {
+      "type": "object",
+      "properties": {
+        "raster:bands": {
+          "$ref": "#/definitions/bands"
+        }
+      },
+      "patternProperties": {
+        "^(?!raster:)": {
+          "$comment": "Above, change `template` to the prefix of this extension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "bands": {
+      "title": "Bands",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Band",
+        "type": "object",
+        "minProperties": 1,
+        "additionalProperties": true,
+        "properties": {
+          "data_type": {
+            "title": "Data type of the band",
+            "type": "string",
+            "enum": [
+              "int8",
+              "int16",
+              "int32",
+              "int64",
+              "uint8",
+              "uint16",
+              "uint32",
+              "uint64",
+              "float16",
+              "float32",
+              "float64",
+              "cint16",
+              "cint32",
+              "cfloat32",
+              "cfloat64",
+              "other"
+            ]
+          },
+          "unit": {
+            "title": "Unit denomination of the pixel value",
+            "type": "string"
+          },
+          "bits_per_sample": {
+            "title": "The actual number of bits used for this band",
+            "type": "integer"
+          },
+          "sampling": {
+            "title": "Pixel sampling in the band",
+            "type": "string",
+            "enum": [
+              "area",
+              "point"
+            ]
+          },
+          "nodata": {
+            "title": "No data pixel value",
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "nan",
+                  "inf",
+                  "-inf"
+                ]
+              }
+            ]
+          },
+          "scale": {
+            "title": "multiplicator factor of the pixel value to transform into the value",
+            "type": "number"
+          },
+          "offset": {
+            "title": "number to be added to the pixel value to transform into the value",
+            "type": "number"
+          },
+          "spatial_resolution": {
+            "title": "Average spatial resolution (in meters) of the pixels in the band",
+            "type": "number"
+          },
+          "statistics": {
+            "title": "Statistics",
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": false,
+            "properties": {
+              "mean": {
+                "title": "Mean value of all the pixels in the band",
+                "type": "number"
+              },
+              "minimum": {
+                "title": "Minimum value of all the pixels in the band",
+                "type": "number"
+              },
+              "maximum": {
+                "title": "Maximum value of all the pixels in the band",
+                "type": "number"
+              },
+              "stddev": {
+                "title": "Standard deviation value of all the pixels in the band",
+                "type": "number"
+              },
+              "valid_percent": {
+                "title": "Percentage of valid (not nodata) pixel",
+                "type": "number"
+              }
+            }
+          },
+          "histogram": {
+            "title": "Histogram",
+            "type": "object",
+            "additionalItems": false,
+            "required": [
+              "count",
+              "min",
+              "max",
+              "buckets"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "count": {
+                "title": "number of buckets",
+                "type": "number"
+              },
+              "min": {
+                "title": "Minimum value of the buckets",
+                "type": "number"
+              },
+              "max": {
+                "title": "Maximum value of the buckets",
+                "type": "number"
+              },
+              "buckets": {
+                "title": "distribution buckets",
+                "type": "array",
+                "minItems": 3,
+                "items": {
+                  "title": "number of pixels in the bucket",
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/integration_tests/schemas/update.sh
+++ b/integration_tests/schemas/update.sh
@@ -6,6 +6,18 @@ set -eu
 stac_tag='v1.1.0'
 stac_api_tag='v1.0.0'
 
+exts=( \
+  "eo" \
+  "projection" \
+  "raster" \
+  "view" \
+)
+
+declare -A ext_versions=(["eo"]="v1.1.0" \
+  ["projection"]="v2.0.0" \
+  ["raster"]="v1.1.0" \
+  ["view"]="v1.0.0" \
+)
 
 function get() {
     echo "$1"
@@ -21,8 +33,6 @@ get 'https://geojson.org/schema/Feature.json'
 stac_version="${stac_tag#v}"
 stac_api_version="${stac_api_tag#v}"
 subfolder="stac-spec-${stac_version}"
-
-set -x
 
 # Clean before updating.
 rm -rf schemas.stacspec.org
@@ -48,6 +58,19 @@ ln -s "../schemas.stacspec.org/${stac_api_version}" "stac-api/"
 cd "stac/${stac_version}/item-spec/json-schema"
 wget https://raw.githubusercontent.com/radiantearth/stac-spec/568a04821935cc92de7b4b05ea6fa9f6bf8a0592/item-spec/json-schema/itemcollection.json
 perl -pi -e 's#"const": "0.9.0"#"const": "1.1.0"#g' itemcollection.json
+cd -
+
+# Download STAC extensions.
+rm -rf stac-extensions.github.io
+for ext in "${exts[@]}"; do
+  ext_version=${ext_versions[$ext]}
+  ext_tgz=$ext-$ext_version.tar.gz
+  wget https://github.com/stac-extensions/$ext/archive/$ext_version.tar.gz -O $ext_tgz
+  ext_dst=stac-extensions.github.io/$ext/$ext_version
+  mkdir -p $ext_dst
+  tar xf $ext_tgz --strip-components=2 -C $ext_dst $ext-${ext_version//v/}/json-schema/schema.json
+  rm $ext_tgz
+done
 
 echo "Success"
 echo "If git status shows any changes, rerun tests, and commit them"


### PR DESCRIPTION
Replace the old EO3->STAC conversion
code with a call into datacube instead.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1062.org.readthedocs.build/en/1062/

<!-- readthedocs-preview datacube-explorer end -->