### PR TITLE
tests: update STAC schemas

### DIFF
--- a/integration_tests/schemas/stac-extensions.github.io/raster/v1.1.0/schema.json
+++ b/integration_tests/schemas/stac-extensions.github.io/raster/v1.1.0/schema.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stac-extensions.github.io/raster/v1.1.0/schema.json#",
+  "title": "raster Extension",
+  "description": "STAC Raster Extension for STAC Items.",
+  "oneOf": [
+    {
+      "$comment": "This is the schema for STAC extension raster in Items.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "assets"
+          ],
+          "properties": {
+            "type": {
+              "const": "Feature"
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/assetfields"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ]
+    },
+    {
+      "$comment": "This is the schema for STAC Collections.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "Collection"
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/assetfields"
+              }
+            },
+            "item_assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/assetfields"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+          }
+        }
+      }
+    },
+    "assetfields": {
+      "type": "object",
+      "properties": {
+        "raster:bands": {
+          "$ref": "#/definitions/bands"
+        }
+      },
+      "patternProperties": {
+        "^(?!raster:)": {
+          "$comment": "Above, change `template` to the prefix of this extension"
+        }
+      },
+      "additionalProperties": false
+    },
+    "bands": {
+      "title": "Bands",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Band",
+        "type": "object",
+        "minProperties": 1,
+        "additionalProperties": true,
+        "properties": {
+          "data_type": {
+            "title": "Data type of the band",
+            "type": "string",
+            "enum": [
+              "int8",
+              "int16",
+              "int32",
+              "int64",
+              "uint8",
+              "uint16",
+              "uint32",
+              "uint64",
+              "float16",
+              "float32",
+              "float64",
+              "cint16",
+              "cint32",
+              "cfloat32",
+              "cfloat64",
+              "other"
+            ]
+          },
+          "unit": {
+            "title": "Unit denomination of the pixel value",
+            "type": "string"
+          },
+          "bits_per_sample": {
+            "title": "The actual number of bits used for this band",
+            "type": "integer"
+          },
+          "sampling": {
+            "title": "Pixel sampling in the band",
+            "type": "string",
+            "enum": [
+              "area",
+              "point"
+            ]
+          },
+          "nodata": {
+            "title": "No data pixel value",
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "nan",
+                  "inf",
+                  "-inf"
+                ]
+              }
+            ]
+          },
+          "scale": {
+            "title": "multiplicator factor of the pixel value to transform into the value",
+            "type": "number"
+          },
+          "offset": {
+            "title": "number to be added to the pixel value to transform into the value",
+            "type": "number"
+          },
+          "spatial_resolution": {
+            "title": "Average spatial resolution (in meters) of the pixels in the band",
+            "type": "number"
+          },
+          "statistics": {
+            "title": "Statistics",
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": false,
+            "properties": {
+              "mean": {
+                "title": "Mean value of all the pixels in the band",
+                "type": "number"
+              },
+              "minimum": {
+                "title": "Minimum value of all the pixels in the band",
+                "type": "number"
+              },
+              "maximum": {
+                "title": "Maximum value of all the pixels in the band",
+                "type": "number"
+              },
+              "stddev": {
+                "title": "Standard deviation value of all the pixels in the band",
+                "type": "number"
+              },
+              "valid_percent": {
+                "title": "Percentage of valid (not nodata) pixel",
+                "type": "number"
+              }
+            }
+          },
+          "histogram": {
+            "title": "Histogram",
+            "type": "object",
+            "additionalItems": false,
+            "required": [
+              "count",
+              "min",
+              "max",
+              "buckets"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "count": {
+                "title": "number of buckets",
+                "type": "number"
+              },
+              "min": {
+                "title": "Minimum value of the buckets",
+                "type": "number"
+              },
+              "max": {
+                "title": "Maximum value of the buckets",
+                "type": "number"
+              },
+              "buckets": {
+                "title": "distribution buckets",
+                "type": "array",
+                "minItems": 3,
+                "items": {
+                  "title": "number of pixels in the bucket",
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/integration_tests/schemas/update.sh
+++ b/integration_tests/schemas/update.sh
@@ -6,6 +6,11 @@ set -eu
 stac_tag='v1.1.0'
 stac_api_tag='v1.0.0'
 
+declare -A exts=(["eo"]="v1.1.0" \
+  ["projection"]="v2.0.0" \
+  ["raster"]="v1.1.0" \
+  ["view"]="v1.0.0" \
+)
 
 function get() {
     echo "$1"
@@ -21,8 +26,6 @@ get 'https://geojson.org/schema/Feature.json'
 stac_version="${stac_tag#v}"
 stac_api_version="${stac_api_tag#v}"
 subfolder="stac-spec-${stac_version}"
-
-set -x
 
 # Clean before updating.
 rm -rf schemas.stacspec.org
@@ -48,6 +51,19 @@ ln -s "../schemas.stacspec.org/${stac_api_version}" "stac-api/"
 cd "stac/${stac_version}/item-spec/json-schema"
 wget https://raw.githubusercontent.com/radiantearth/stac-spec/568a04821935cc92de7b4b05ea6fa9f6bf8a0592/item-spec/json-schema/itemcollection.json
 perl -pi -e 's#"const": "0.9.0"#"const": "1.1.0"#g' itemcollection.json
+cd -
+
+# Download STAC extensions.
+rm -rf stac-extensions.github.io
+for ext in "${!exts[@]}"; do
+  ext_version=${exts[$ext]}
+  ext_tgz=$ext-$ext_version.tar.gz
+  wget https://github.com/stac-extensions/$ext/archive/$ext_version.tar.gz -O $ext_tgz
+  ext_dst=stac-extensions.github.io/$ext/$ext_version
+  mkdir -p $ext_dst
+  tar xf $ext_tgz --strip-components=2 -C $ext_dst $ext-${ext_version#v}/json-schema/schema.json
+  rm $ext_tgz
+done
 
 echo "Success"
 echo "If git status shows any changes, rerun tests, and commit them"


### PR DESCRIPTION
The STAC organization have reorganized,
so download the extensions from
the new place.

Also add some new extensions that
will be required when using stac2ds
from datacube-core in the future.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1063.org.readthedocs.build/en/1063/

<!-- readthedocs-preview datacube-explorer end -->