### PR TITLE
index: change return type

### DIFF
--- a/cubedash/index/api.py
+++ b/cubedash/index/api.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections.abc import Generator, Iterable, Sequence
+from collections.abc import Generator, Iterable, Mapping, Sequence
 from datetime import date, datetime, timedelta
 from typing import Any
 from uuid import UUID
@@ -67,7 +67,13 @@ class ExplorerAbstractIndex(ABC):
     @abstractmethod
     def get_mutable_dataset_search_fields(
         self, md: MetadataType
-    ) -> dict[str, Field]: ...
+    ) -> Mapping[str, Field]: ...
+
+    """
+        Get a copy of a metadata type's fields that we can mutate.
+
+        (the ones returned by the Index are cached and so may be shared among callers)
+    """
 
     @abstractmethod
     def get_datasets_derived(

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator, Iterable, Sequence
+from collections.abc import Generator, Iterable, Mapping, Sequence
 from datetime import date, datetime, timedelta
 from typing import Any
 from uuid import UUID
@@ -77,12 +77,9 @@ class ExplorerIndex(ExplorerAbstractIndex):
         self.db_api = PostgisDbAPI
 
     @override
-    def get_mutable_dataset_search_fields(self, md: MetadataType) -> dict[str, Field]:
-        """
-        Get a copy of a metadata type's fields that we can mutate.
-
-        (the ones returned by the Index are cached and so may be shared among callers)
-        """
+    def get_mutable_dataset_search_fields(
+        self, md: MetadataType
+    ) -> Mapping[str, Field]:
         # why not do md.dataset_fields?
         return self.index._db.get_dataset_fields(md.definition)
 

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator, Iterable, Sequence
+from collections.abc import Generator, Iterable, Mapping, Sequence
 from datetime import date, datetime, timedelta
 from typing import Any
 from uuid import UUID
@@ -74,12 +74,9 @@ class ExplorerIndex(ExplorerAbstractIndex):
         self.db_api = PostgresDbAPI
 
     @override
-    def get_mutable_dataset_search_fields(self, md: MetadataType) -> dict[str, Field]:
-        """
-        Get a copy of a metadata type's fields that we can mutate.
-
-        (the ones returned by the Index are cached and so may be shared among callers)
-        """
+    def get_mutable_dataset_search_fields(
+        self, md: MetadataType
+    ) -> Mapping[str, Field]:
         # why not do md.dataset_fields?
         return self.index._db.get_dataset_fields(md.definition)
 


### PR DESCRIPTION
Explorer does not mutate the returned
dictionary, so switch to a Mapping
to fix a type error.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1071.org.readthedocs.build/en/1071/

<!-- readthedocs-preview datacube-explorer end -->