### PR TITLE
Include fixed boolean fields

### DIFF
--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -527,7 +527,14 @@ class SummaryStore:
             iter(self.index.datasets.search(product=product.name, limit=1))
         ).metadata.fields
 
-        simple_field_types = {"string", "numeric", "double", "integer", "datetime"}
+        simple_field_types = {
+            "string",
+            "numeric",
+            "double",
+            "integer",
+            "datetime",
+            "boolean",
+        }
 
         candidate_fields: list[tuple[str, Field]] = [
             (name, field)


### PR DESCRIPTION
Add "boolean" to list of simple field types when finding product fixed metadata.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1073.org.readthedocs.build/en/1073/

<!-- readthedocs-preview datacube-explorer end -->