### PR TITLE
generate: exit(1) on error

### DIFF
--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -510,7 +510,9 @@ def cli(
         )
         if updated > 0 and refresh_stats:
             user_message("Refreshing statistics...", nl=False)
-            store.refresh_stats(concurrently=force_concurrently)
+            if not store.refresh_stats(concurrently=force_concurrently):
+                user_message("Failed to refresh statistics, aborting.")
+                sys.exit(1)
             user_message("done", fg="green")
             _LOG.info("stats.refresh")
     finally:

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -332,10 +332,10 @@ class SummaryStore:
         self.index.close()
         self.e_index.engine.dispose()
 
-    def refresh_all_product_extents(self) -> None:
+    def refresh_all_product_extents(self) -> bool:
         for product in self.all_products():
             self.refresh_product_extent(product.name)
-        self.refresh_stats()
+        return self.refresh_stats()
 
     def find_months_needing_update(
         self, product_name: str, only_those_newer_than: datetime
@@ -504,13 +504,18 @@ class SummaryStore:
         self._persist_product_extent(new_summary)
         return change_count, new_summary
 
-    def refresh_stats(self, concurrently: bool = False) -> None:
+    def refresh_stats(self, concurrently: bool = False) -> bool:
         """
         Refresh general statistics tables that cover all products.
 
         This is ideally done once after all needed products have been refreshed.
         """
-        self.e_index.refresh_stats(concurrently)
+        try:
+            self.e_index.refresh_stats(concurrently)
+        except ProgrammingError as e:
+            _LOG.error(str(e))
+            return False
+        return True
 
     def _find_product_fixed_metadata(
         self, product: Product, sample_datasets_size: int

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -114,7 +114,8 @@ def unpopulated_client(
     empty_client: FlaskClient, summary_store: SummaryStore
 ) -> FlaskClient:
     with disable_logging():
-        _model.STORE.refresh_all_product_extents()
+        success = _model.STORE.refresh_all_product_extents()
+    assert success is True
     return empty_client
 
 

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -406,8 +406,8 @@ def test_generate_empty_time(run_generate, summary_store: SummaryStore) -> None:
 
 
 def test_calc_empty(summary_store: SummaryStore) -> None:
-    summary_store.refresh_all_product_extents()
-
+    result = summary_store.refresh_all_product_extents()
+    assert result is True
     # Should not exist.
     summary = summary_store.get("ls8_fake_product", year=2006, month=None, day=None)
     assert summary is None
@@ -616,8 +616,8 @@ def test_computed_regions_match_those_summarised(summary_store: SummaryStore) ->
     The region code for all datasets should be computed identically when
     done in both SQL and Python.
     """
-    summary_store.refresh_all_product_extents()
-
+    result = summary_store.refresh_all_product_extents()
+    assert result is True
     # Loop through all datasets in the test data to check that the the DB and Python
     # functions give identical region codes.
     for product in summary_store.index.products.get_all():


### PR DESCRIPTION
Catch permission issues and exit
with an exit code instead of
giving the user a backtrace.
Doesn't fix the permission problem,
but makes it less hostile to
the user.

Refs #1079

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1080.org.readthedocs.build/en/1080/

<!-- readthedocs-preview datacube-explorer end -->