### PR TITLE
index: align return type

### DIFF
--- a/cubedash/index/api.py
+++ b/cubedash/index/api.py
@@ -156,7 +156,7 @@ class ExplorerAbstractIndex(ABC):
         bbox: tuple[float, float, float, float] | None,
         time: tuple[datetime, datetime] | None,
         q: Sequence[str] | None,
-    ) -> Result: ...
+    ) -> list[Row]: ...
 
     @abstractmethod
     def upsert_product_record(

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -410,7 +410,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         bbox: tuple[float, float, float, float] | None,
         time: tuple[datetime, datetime] | None,
         q: Sequence[str] | None,
-    ) -> Result:
+    ) -> list[Row]:
         # STAC Collections only hold a bounding box in EPSG:4326, no polygons
         # Calculate the bounding box on the server, it's far more efficient.
 


### PR DESCRIPTION
The queries were changed in commit
98010828 for both postgres and postgis,
but the return type was only updated
for postgis. Align the two other types
with the postgis type.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1083.org.readthedocs.build/en/1083/

<!-- readthedocs-preview datacube-explorer end -->