### PR TITLE
generate: propagate return values

### DIFF
--- a/cubedash/index/api.py
+++ b/cubedash/index/api.py
@@ -237,8 +237,8 @@ class ExplorerAbstractIndex(ABC):
             drop_schema(conn, CUBEDASH_SCHEMA)
 
     @abstractmethod
-    def init_schema(self, grouping_epsg_code: int) -> bool:
-        """Returns true if product information needs to be refreshed."""
+    def init_schema(self, grouping_epsg_code: int) -> bool | None:
+        """Returns None on failure, true if product information needs to be refreshed."""
 
     @abstractmethod
     def refresh_stats(self, concurrently: bool) -> None: ...

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -873,7 +873,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         return True
 
     @override
-    def init_schema(self, grouping_epsg_code: int) -> bool:
+    def init_schema(self, grouping_epsg_code: int) -> bool | None:
         with self.engine.connect() as conn:
             return init_elements(conn, grouping_epsg_code)
 

--- a/cubedash/index/postgis/_schema.py
+++ b/cubedash/index/postgis/_schema.py
@@ -30,6 +30,7 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.orm import registry
 
 from cubedash.summary._schema import (
+    _LOG,
     CUBEDASH_SCHEMA,
     METADATA,
     REF_TABLE_METADATA,
@@ -285,7 +286,7 @@ def create_after_schema(conn: Connection, epsg_code: int) -> None:
         "srid",
         unique=True,
     )
-    # For case insensitive auth name/code lookups.
+    # For case-insensitive auth name/code lookups.
     # (Postgis doesn't add one by default, but we're going to do a lot of lookups)
     pg_create_index(
         conn,
@@ -354,7 +355,7 @@ def grant_permissions(conn: Connection) -> None:
         grant_role(conn, UserRole.ADMIN, ["explorer_owner"])
 
 
-def ensure_owners(conn: Connection) -> None:
+def ensure_owners(conn: Connection) -> bool:
     transfers = transfers_required(
         conn,
         "odc_admin",
@@ -367,9 +368,13 @@ def ensure_owners(conn: Connection) -> None:
             "region",
         ],
     )
+    rv = True
     for table, current_owner in transfers:
-        transfer_ownership(
-            conn, CUBEDASH_SCHEMA, table, current_owner, "odc_admin", "tables"
+        rv = (
+            transfer_ownership(
+                conn, CUBEDASH_SCHEMA, table, current_owner, "odc_admin", "tables"
+            )
+            and rv
         )
 
     transfers = transfers_required(
@@ -383,14 +388,18 @@ def ensure_owners(conn: Connection) -> None:
         ],
     )
     for mv, current_owner in transfers:
-        transfer_ownership(
-            conn, CUBEDASH_SCHEMA, mv, current_owner, "odc_manage", "matviews"
+        rv = (
+            transfer_ownership(
+                conn, CUBEDASH_SCHEMA, mv, current_owner, "odc_manage", "matviews"
+            )
+            and rv
         )
 
     conn.commit()
+    return rv
 
 
-def init_elements(conn: Connection, grouping_epsg_code: int) -> bool:
+def init_elements(conn: Connection, grouping_epsg_code: int) -> bool | None:
     """
     Initialise any schema elements that don't exist.
 
@@ -426,7 +435,12 @@ def init_elements(conn: Connection, grouping_epsg_code: int) -> bool:
             (Warning: Resummarising all of your products may take a long time!)
             """
         )
-    ensure_owners(conn)
+    if not ensure_owners(conn):
+        _LOG.error(
+            "Failed to transfer ownerships in database. Please re-run the "
+            "command as the database administrator user."
+        )
+        return None
     grant_permissions(conn)
 
     # no need to add potentially missing columns because we know postgis will have them

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -947,7 +947,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
         return True
 
     @override
-    def init_schema(self, grouping_epsg_code: int) -> bool:
+    def init_schema(self, grouping_epsg_code: int) -> bool | None:
         with self.engine.connect() as conn:
             return init_elements(conn, grouping_epsg_code)
 

--- a/cubedash/index/postgres/_schema.py
+++ b/cubedash/index/postgres/_schema.py
@@ -308,7 +308,7 @@ def create_after_schema(conn: Connection, epsg_code: int) -> None:
         "srid",
         unique=True,
     )
-    # For case insensitive auth name/code lookups.
+    # For case-insensitive auth name/code lookups.
     # (Postgis doesn't add one by default, but we're going to do a lot of lookups)
     pg_create_index(
         conn,
@@ -472,7 +472,7 @@ def grant_permissions(conn: Connection) -> None:
         grant_role(conn, UserRole.ADMIN, ["explorer_owner"])
 
 
-def ensure_owners(conn: Connection) -> None:
+def ensure_owners(conn: Connection) -> bool:
     transfers = transfers_required(
         conn,
         "agdc_admin",
@@ -485,9 +485,13 @@ def ensure_owners(conn: Connection) -> None:
             "region",
         ],
     )
+    rv = True
     for table, current_owner in transfers:
-        transfer_ownership(
-            conn, CUBEDASH_SCHEMA, table, current_owner, "agdc_admin", "tables"
+        rv = (
+            transfer_ownership(
+                conn, CUBEDASH_SCHEMA, table, current_owner, "agdc_admin", "tables"
+            )
+            and rv
         )
 
     transfers = transfers_required(
@@ -501,14 +505,18 @@ def ensure_owners(conn: Connection) -> None:
         ],
     )
     for mv, current_owner in transfers:
-        transfer_ownership(
-            conn, CUBEDASH_SCHEMA, mv, current_owner, "agdc_manage", "matviews"
+        rv = (
+            transfer_ownership(
+                conn, CUBEDASH_SCHEMA, mv, current_owner, "agdc_manage", "matviews"
+            )
+            and rv
         )
 
     conn.commit()
+    return rv
 
 
-def init_elements(conn: Connection, grouping_epsg_code: int) -> bool:
+def init_elements(conn: Connection, grouping_epsg_code: int) -> bool | None:
     """
     Initialise any schema elements that don't exist.
 
@@ -544,6 +552,11 @@ def init_elements(conn: Connection, grouping_epsg_code: int) -> bool:
             (Warning: Resummarising all of your products may take a long time!)
             """
         )
-    ensure_owners(conn)
+    if not ensure_owners(conn):
+        _LOG.error(
+            "Failed to transfer ownerships in database. Please re-run the "
+            "command as the database administrator user."
+        )
+        return None
     grant_permissions(conn)
     return update_schema(conn)

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -302,7 +302,7 @@ class SummaryStore:
                 _LOG.info("data.refreshing_extents", product=name)
                 self.refresh_product_extent(name, scan_for_deleted=True)
             _LOG.info("data.refreshing_extents.complete")
-        return True
+        return rv is not None
 
     @classmethod
     def create(


### PR DESCRIPTION
Check the results when running
cubedash-gen --init, and bail out
if we detect a failure. This will
at least signal things did not
work as intended, but without
crashing.

Fixes #1079

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1087.org.readthedocs.build/en/1087/

<!-- readthedocs-preview datacube-explorer end -->