### PR TITLE
Update to Click 8.3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,23 +119,10 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
-      # We need a patched version of click to run tests, but direct dependencies can't
-      # be uploaded to PyPI.
-      #
-      # Therefore we removed the direct click dependency, and simply depend on click.
-      # (and use $SETUPTOOLS_SCM_PRETEND_VERSION to force a clean version number.)
-      #
-      # Version dependency can be inherited from datacube-core.
-      #
-      # This step (and the export of SETUPTOOLS_SCM_PRETEND_VERSION below) should be
-      # removed once a click release fixes the CliRunner issue that breaks tests.
-      - name: Remove patched click dependency
-        run: |
-          perl -pi -e 's# \@ git\+https://github\.com/pjonsson/click\.git\@one-close-only##' pyproject.toml
-
       - name: Build Packages
         run: |
-          export SETUPTOOLS_SCM_PRETEND_VERSION=`git describe --abbrev=0 --tags`
+          SETUPTOOLS_SCM_PRETEND_VERSION=$(git describe --abbrev=0 --tags)
+          export SETUPTOOLS_SCM_PRETEND_VERSION
           uv build
           uv tool run twine check --strict dist/*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,10 +65,7 @@ dev = [
 
 [project.optional-dependencies]
 deployment = [
-    # Performance.
-    "bottleneck",
-    "ciso8601",
-    # The default run.sh and docs use gunicorn+meinheld
+    "datacube[performance]",
     "gunicorn[gevent,setproctitle]>=22.0.0",
     "sentry-sdk[flask]",
     # Monitoring.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,7 @@ authors = [
 dependencies = [
     "Flask-Caching",
     "cachetools",
-    # Tests fail with "ValueError: I/O operation on closed file" with Click
-    # 8.2.0 and later.
-    "click @ git+https://github.com/pjonsson/click.git@one-close-only",
+    "click>=8.3.2", # Tests require 8.3.2 to work.
     "datacube[postgres]>=1.9.17,<1.10.0",
     "eodatasets3>=1.9",
     "fiona>=1.10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -545,10 +545,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
-source = { git = "https://github.com/pjonsson/click.git?rev=one-close-only#17680224aa471016d7e53d00c8f17562b386993a" }
+version = "8.3.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
 ]
 
 [[package]]
@@ -940,7 +944,7 @@ requires-dist = [
     { name = "bottleneck", marker = "extra == 'deployment'" },
     { name = "cachetools" },
     { name = "ciso8601", marker = "extra == 'deployment'" },
-    { name = "click", git = "https://github.com/pjonsson/click.git?rev=one-close-only" },
+    { name = "click", specifier = ">=8.3.2" },
     { name = "datacube", extras = ["postgres"], specifier = ">=1.9.17,<1.10.0" },
     { name = "datacube-explorer", extras = ["deployment"], marker = "extra == 'test'" },
     { name = "deepdiff", marker = "extra == 'test'" },

--- a/uv.lock
+++ b/uv.lock
@@ -845,6 +845,10 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+performance = [
+    { name = "bottleneck" },
+    { name = "ciso8601" },
+]
 postgres = [
     { name = "psycopg2" },
 ]
@@ -880,16 +884,14 @@ dependencies = [
 [package.optional-dependencies]
 deployment = [
     { name = "blinker" },
-    { name = "bottleneck" },
-    { name = "ciso8601" },
+    { name = "datacube", extra = ["performance"] },
     { name = "gunicorn", extra = ["gevent", "setproctitle"] },
     { name = "prometheus-flask-exporter" },
     { name = "sentry-sdk", extra = ["flask"] },
 ]
 test = [
     { name = "blinker" },
-    { name = "bottleneck" },
-    { name = "ciso8601" },
+    { name = "datacube", extra = ["performance"] },
     { name = "deepdiff" },
     { name = "docker" },
     { name = "docutils" },
@@ -941,10 +943,9 @@ doc = [
 [package.metadata]
 requires-dist = [
     { name = "blinker", marker = "extra == 'deployment'" },
-    { name = "bottleneck", marker = "extra == 'deployment'" },
     { name = "cachetools" },
-    { name = "ciso8601", marker = "extra == 'deployment'" },
     { name = "click", specifier = ">=8.3.2" },
+    { name = "datacube", extras = ["performance"], marker = "extra == 'deployment'" },
     { name = "datacube", extras = ["postgres"], specifier = ">=1.9.17,<1.10.0" },
     { name = "datacube-explorer", extras = ["deployment"], marker = "extra == 'test'" },
     { name = "deepdiff", marker = "extra == 'test'" },


### PR DESCRIPTION
This release contains the fix
to only close things once.

Also add a commit that uses
the datacube optional for
performance to ensure
datacube gets the performance
packages it needs.


<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1096.org.readthedocs.build/en/1096/

<!-- readthedocs-preview datacube-explorer end -->