### PR TITLE
filters: fix license detection

### DIFF
--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -226,7 +226,7 @@ def _product_license(product: Product):
     if license_ is None:
         return "-"
 
-    if license_ in ("various", "proprietry"):
+    if license_ in ("various", "proprietary"):
         return license_
 
     return Markup(


### PR DESCRIPTION
Fix spelling of "proprietary".

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1104.org.readthedocs.build/en/1104/

<!-- readthedocs-preview datacube-explorer end -->