### PR TITLE
Move create_app to startup_utils

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
         python-version: ["3.10"]
         lintcommand:
           - "ruff check --output-format=github"
-          - "mypy --follow-imports=silent cubedash/*.py cubedash/index/*.py cubedash/summary cubedash/testutils"
+          - "mypy --follow-imports=silent cubedash/*.py cubedash/index/*.py cubedash/startup_utils cubedash/summary cubedash/testutils"
     name: Linting
     steps:
       - name: checkout git

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,4 +126,4 @@ CMD ["gunicorn", \
      "90", \
      "--config", \
      "python:cubedash.gunicorn_config", \
-     "cubedash:create_app()"]
+     "cubedash.startup_utils:create_app()"]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A `cubedash-run` command is available to run Explorer locally:
 But Explorer can be run using any typical Python WSGI server, for example [gunicorn](https://gunicorn.org/):
 
     pip install gunicorn
-    gunicorn -b '127.0.0.1:8080' -w 4 cubedash:create_app()
+    gunicorn -b '127.0.0.1:8080' -w 4 cubedash.startup_utils:create_app()
 
 Products will begin appearing one-by-one as the summaries are generated in the
 background.  If impatient, you can manually navigate to a product using

--- a/cubedash/__init__.py
+++ b/cubedash/__init__.py
@@ -3,6 +3,4 @@ try:
 except ImportError:
     __version__ = "Unknown/Not Installed"
 
-from ._model import create_app
-
-__all__ = ["__version__", "create_app"]
+__all__ = ["__version__"]

--- a/cubedash/run.py
+++ b/cubedash/run.py
@@ -76,8 +76,8 @@ def cli(
     event_log_file: str,
     verbose: int,
 ) -> None:
-    from cubedash import create_app
     from cubedash.logs import init_logging
+    from cubedash.startup_utils import create_app
 
     init_logging(
         open(event_log_file, "ab") if event_log_file else None, verbosity=verbose

--- a/cubedash/startup_utils/__init__.py
+++ b/cubedash/startup_utils/__init__.py
@@ -1,0 +1,3 @@
+from .._model import create_app
+
+__all__ = ["create_app"]

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -45,7 +45,7 @@ But Explorer can be run using any typical python wsgi server, for example gunico
 .. code-block:: text
 
     pip install gunicorn
-    gunicorn -b '127.0.0.1:8080' -w 4 cubedash:create_app()
+    gunicorn -b '127.0.0.1:8080' -w 4 cubedash.startup_utils:create_app()
 
 Products will begin appearing one-by-one as the summaries are generated in the
 background.  If impatient, you can manually navigate to a product using

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -12,7 +12,8 @@ from datacube import Datacube
 from flask.testing import FlaskClient
 from structlog import DropEvent
 
-from cubedash import _model, create_app, generate, logs
+from cubedash import _model, generate, logs
+from cubedash.startup_utils import create_app
 from cubedash.summary import SummaryStore
 from cubedash.summary._schema import METADATA as CUBEDASH_METADATA
 from cubedash.warmup import find_examples_of_all_public_urls


### PR DESCRIPTION
Split out from #1102.

Mirror the structure of OWS
so cubedash-gen does not have
to import _model.py on startup.

Refs #1100

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1108.org.readthedocs.build/en/1108/

<!-- readthedocs-preview datacube-explorer end -->