### PR TITLE
tests: test non-initialized store

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,6 +11,6 @@ services:
       - ./:/code
       - ./.docker/.datacube_integration.conf:/root/.datacube_integration.conf
       - ./.docker/settings_docker.py:/code/settings.env.py
-    command: flask run --host 0.0.0.0
+    command: flask --app 'cubedash.startup_utils:create_app()' run --host 0.0.0.0
     ports:
       - "5000:5000"

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -611,6 +611,11 @@ def test_cubedash_gen_refresh(
         "Product sequence was incremented without any new products being added."
     )
 
+    # Refresh with non-initialized store.
+    run_generate("--drop-database")
+    run_generate("--all", expect_success=False)
+    run_generate("--init")
+
 
 def test_computed_regions_match_those_summarised(summary_store: SummaryStore) -> None:
     """


### PR DESCRIPTION
Add a test that runs cubedash-gen
on a non-initialized store.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1112.org.readthedocs.build/en/1112/

<!-- readthedocs-preview datacube-explorer end -->