### PR TITLE
pages: remove current_time

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -487,7 +487,6 @@ def inject_globals():
             "CUBEDASH_HIDE_PRODUCTS_BY_NAME_LIST", []
         ),
         "datacube_metadata_types": list(_model.STORE.all_metadata_types()),
-        "current_time": datetime.now(timezone.utc),
         "datacube_version": datacube.__version__,
         "app_version": cubedash.__version__,
         "grouping_timezone": ZoneInfo(_model.DEFAULT_GROUPING_TIMEZONE),


### PR DESCRIPTION
The current_time isn't used by any
templates, so stop calling now()
on every page request.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1118.org.readthedocs.build/en/1118/

<!-- readthedocs-preview datacube-explorer end -->