### PR TITLE
stores: double default TTL

### DIFF
--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -50,7 +50,7 @@ from cubedash.summary._extents import (
 )
 from cubedash.summary._summarise import DEFAULT_TIMEZONE, Summariser
 
-DEFAULT_TTL = 90
+DEFAULT_TTL = 180
 
 _DEFAULT_REFRESH_OLDER_THAN = timedelta(hours=23)
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -94,7 +94,7 @@ class GenerateResult(Enum):
     NO_CHANGES = 1
     # Exception was thrown
     ERROR = 4
-    # A unsupported product (eg. Unsupported CRS)
+    # An unsupported product (e.g. Unsupported CRS)
     UNSUPPORTED = 5
 
 


### PR DESCRIPTION
Double the TTL from 1.5 minutes
to 3 minutes. This reduces
the amount of database lookups.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1120.org.readthedocs.build/en/1120/

<!-- readthedocs-preview datacube-explorer end -->