### PR TITLE
Use TYPE_CHECKING block for Explorer

### DIFF
--- a/cubedash/_audit.py
+++ b/cubedash/_audit.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import time
-from collections.abc import Generator
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import flask
 import structlog
@@ -10,6 +11,11 @@ from flask import Blueprint, Response, redirect, url_for
 
 from . import _model
 from . import _utils as utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from datetime import datetime
 
 _LOG = structlog.stdlib.get_logger()
 bp = Blueprint("audit", __name__)

--- a/cubedash/_dataset.py
+++ b/cubedash/_dataset.py
@@ -1,4 +1,4 @@
-from uuid import UUID
+from __future__ import annotations
 
 import flask
 import structlog
@@ -6,6 +6,10 @@ from flask import Blueprint, abort, current_app, url_for
 
 from . import _model
 from . import _utils as utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from uuid import UUID
 
 _LOG = structlog.stdlib.get_logger()
 bp = Blueprint("dataset", __name__)

--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -2,22 +2,29 @@
 Common global filters for templates.
 """
 
+from __future__ import annotations
+
 import calendar
-from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
 import flask
 import structlog
-from datacube.index.fields import Field
-from datacube.model import Dataset, Product, Range
+from datacube.model import Range
 from flask import Blueprint
 from markupsafe import Markup
 from rapidjson import DM_ISO8601, UM_CANONICAL, dumps
-from shapely.geometry import MultiPolygon
 
 from . import _model, _utils
 from . import _utils as utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    from datacube.index.fields import Field
+    from datacube.model import Dataset, Product
+    from shapely.geometry import MultiPolygon
 
 # How far to step the number when the user hits up/down.
 NUMERIC_STEP_SIZE = {

--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 import json
 import os
 import time
-from collections import Counter
-from collections.abc import Sequence
 from pathlib import Path
 from typing import TypeAlias
 
@@ -10,23 +10,29 @@ import flask
 import structlog
 from datacube.index import index_connect
 from datacube.model import Product
-from flask.typing import ResponseValue
 from flask_caching import Cache
 from flask_cors import CORS
 from flask_themer import Themer
-
-# pylint: disable=import-error
-from shapely.geometry.base import BaseGeometry
 from werkzeug.exceptions import HTTPException
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from cubedash import _monitoring
-from cubedash.summary import SummaryStore, TimePeriodOverview
-from cubedash.summary._extents import RegionInfo
+from cubedash.summary import SummaryStore
 from cubedash.summary._stores import ProductSummary
 from cubedash.summary._summarise import DEFAULT_TIMEZONE
 
 from . import _utils as utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections import Counter
+    from collections.abc import Sequence
+
+    from flask.typing import ResponseValue
+    from shapely.geometry.base import BaseGeometry
+
+    from cubedash.summary import TimePeriodOverview
+    from cubedash.summary._extents import RegionInfo
 
 NAME = "cubedash"
 BASE_DIR = Path(__file__).parent.parent

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import decimal
 import re
 from datetime import datetime, timedelta, timezone
@@ -6,7 +8,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import datacube
 import flask
 import structlog
-from datacube.model import Product, Range
+from datacube.model import Range
 from datacube.scripts.dataset import build_dataset_info
 from flask import (
     Blueprint,
@@ -21,13 +23,18 @@ from sqlalchemy.exc import DataError, ProgrammingError
 from werkzeug.datastructures import MultiDict
 
 import cubedash
-from cubedash._model import ProductWithSummary
 from cubedash._utils import default_utc
-from cubedash.summary import TimePeriodOverview
-from cubedash.summary._stores import ProductSummary
 
 from . import _model, _stac
 from . import _utils as utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.model import Product
+
+    from cubedash._model import ProductWithSummary
+    from cubedash.summary import TimePeriodOverview
+    from cubedash.summary._stores import ProductSummary
 
 bp = Blueprint("pages", __name__)
 

--- a/cubedash/_product.py
+++ b/cubedash/_product.py
@@ -1,10 +1,14 @@
-from datetime import timedelta
+from __future__ import annotations
 
 import structlog
 from flask import Blueprint, Response, abort, redirect, url_for
 
 from cubedash import _model, _utils
 from cubedash import _utils as utils
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datetime import timedelta
 
 _LOG = structlog.stdlib.get_logger()
 bp = Blueprint("product", __name__)
@@ -203,6 +207,7 @@ def _iso8601_duration(tdelta: timedelta) -> str:
     """
     Format a timedelta as an iso8601 duration
 
+    >>> from datetime import timedelta
     >>> _iso8601_duration(timedelta(seconds=0))
     'PT0S'
     >>> _iso8601_duration(timedelta(seconds=1))

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import json
 import uuid
-from collections.abc import Callable, Sequence
 from datetime import datetime, timedelta, timezone
 from datetime import time as dt_time
 from functools import partial
@@ -12,17 +13,24 @@ import structlog
 from datacube.metadata import ds2stac
 from datacube.utils import parse_time
 from flask import abort, current_app, request
-from pystac import Catalog, Collection, Extent, Item, ItemCollection, Link, STACObject
+from pystac import Catalog, Collection, Extent, ItemCollection, Link, STACObject
 from shapely.geometry import shape
-from shapely.geometry.base import BaseGeometry
 from toolz import dicttoolz
-from werkzeug.datastructures import ImmutableMultiDict, TypeConversionDict
+from werkzeug.datastructures import TypeConversionDict
 from werkzeug.exceptions import BadRequest, HTTPException
-
-from cubedash.summary._stores import CollectionItem, DatasetItem
 
 from . import _model, _utils
 from .summary import ItemSort
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from pystac import Item
+    from shapely.geometry.base import BaseGeometry
+    from werkzeug.datastructures import ImmutableMultiDict
+
+    from cubedash.summary._stores import CollectionItem, DatasetItem
 
 _LOG = structlog.stdlib.get_logger()
 bp = flask.Blueprint("stac", __name__, url_prefix="/stac")

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -11,11 +11,9 @@ import io
 import itertools
 import re
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import datetime, timedelta, timezone
-from datetime import tzinfo as e_tzinfo
 from io import StringIO
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import eodatasets3.serialise
@@ -26,22 +24,29 @@ import structlog
 from affine import Affine
 from datacube import utils as dc_utils
 from datacube.index.eo3 import is_doc_eo3
-from datacube.index.fields import Field
-from datacube.model import Dataset, MetadataType, Product, Range
+from datacube.model import MetadataType, Range
 from datacube.utils import InvalidDocException, jsonify_document
 from eodatasets3 import serialise
 from flask_themer import render_template
-from odc.geo import Geometry, geom
+from odc.geo import geom
 from odc.geo.crs import CRS
 from pyproj import CRS as PJCRS
 from rapidjson import DM_ISO8601, UM_CANONICAL, dumps
 from ruamel.yaml.comments import CommentedMap
 from shapely.geometry import shape
-from shapely.geometry.base import BaseGeometry
 from sqlalchemy import TIMESTAMP, func
-from werkzeug.datastructures import MultiDict
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping, Sequence
+    from datetime import tzinfo as e_tzinfo
+
+    from datacube.index.fields import Field
+    from datacube.model import Dataset, Product
+    from odc.geo import Geometry
+    from shapely.geometry.base import BaseGeometry
+    from werkzeug.datastructures import MultiDict
+
     from cubedash._model import ProductWithSummary
 
 _TARGET_CRS = "EPSG:4326"

--- a/cubedash/conftest.py
+++ b/cubedash/conftest.py
@@ -2,7 +2,11 @@
 #
 # Copyright (c) 2015-2025 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
+from __future__ import annotations
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 # The only thing tested under this directory is doctests, so only collect

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -53,11 +53,12 @@ Drop all of Explorer’s additions to the database:
 
 """
 
+from __future__ import annotations
+
 import collections
 import multiprocessing
 import re
 import sys
-from collections.abc import Generator, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import partial
@@ -67,23 +68,26 @@ import click
 import structlog
 from click import secho as click_secho
 from click import style
-from datacube.cfg import ODCConfig, ODCEnvironment
+from datacube.cfg import ODCConfig
 from datacube.index import index_connect
 from datacube.index.postgis.index import Index as PostgisIndex
 from datacube.index.postgres.index import Index as PostgresIndex
-from datacube.model import Product
 from datacube.ui.click import environment_option, pass_config
 from typing_extensions import override
 
 from cubedash.logs import init_logging
-from cubedash.summary import (
-    GenerateResult,
-    SummaryStore,
-    TimePeriodOverview,
-    UnsupportedWKTProductCRSError,
-)
+from cubedash.summary import GenerateResult, SummaryStore, UnsupportedWKTProductCRSError
 from cubedash.summary._stores import DEFAULT_EPSG
 from cubedash.summary._summarise import DEFAULT_TIMEZONE
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Sequence
+
+    from datacube.cfg import ODCEnvironment
+    from datacube.model import Product
+
+    from cubedash.summary import TimePeriodOverview
 
 # Machine (json) logging.
 _LOG = structlog.stdlib.get_logger()

--- a/cubedash/index/api.py
+++ b/cubedash/index/api.py
@@ -1,23 +1,25 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Generator, Iterable, Mapping, Sequence
-from datetime import date, datetime, timedelta
 from typing import Any
-from uuid import UUID
 
 from datacube.drivers.common_psql import drop_schema, has_schema
-from datacube.index import Index
-from datacube.model import Dataset, MetadataType, Product, Range
-from datacube.model.fields import Field
-from sqlalchemy import CursorResult, Result, Row, Select
-from sqlalchemy.sql import ColumnElement
-from sqlalchemy.sql.elements import ClauseElement, Label
 
 from cubedash.summary._schema import CUBEDASH_SCHEMA
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Mapping, Sequence
+    from datetime import date, datetime, timedelta
+    from uuid import UUID
+
+    from datacube.index import Index
+    from datacube.model import Dataset, MetadataType, Product, Range
+    from datacube.model.fields import Field
+    from sqlalchemy import CursorResult, Result, Row, Select
+    from sqlalchemy.sql import ColumnElement
+    from sqlalchemy.sql.elements import ClauseElement, Label
+
     from cubedash.summary._extents import PgDocField
 
 

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator, Iterable, Mapping, Sequence
-from datetime import date, datetime, timedelta
 from typing import Any
-from uuid import UUID
 
 import shapely.ops
 import structlog
@@ -17,18 +14,10 @@ from datacube.drivers.postgis._schema import (  # isort: skip
     Dataset as ODC_DATASET,  # noqa: N814
     Product as ODC_PRODUCT,  # noqa: N814
 )
-from datacube.index.postgis.index import Index
-from datacube.model import Dataset, Field, MetadataType, Product, Range
 from geoalchemy2 import Geometry
 from geoalchemy2.shape import from_shape
 from sqlalchemy import (
-    ClauseElement,
-    CursorResult,
     Integer,
-    Label,
-    Result,
-    Row,
-    Select,
     SmallInteger,
     String,
     and_,
@@ -48,7 +37,6 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import TSTZRANGE, array, insert
 from sqlalchemy.orm import Session, aliased
-from sqlalchemy.sql import ColumnElement
 from sqlalchemy.types import TIMESTAMP
 
 import cubedash.summary._schema as _schema
@@ -70,6 +58,15 @@ from ._schema import (  # isort: skip
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Mapping, Sequence
+    from datetime import date, datetime, timedelta
+    from uuid import UUID
+
+    from datacube.index.postgis.index import Index
+    from datacube.model import Dataset, Field, MetadataType, Product, Range
+    from sqlalchemy import ClauseElement, CursorResult, Label, Result, Row, Select
+    from sqlalchemy.sql import ColumnElement
+
     from cubedash.summary._extents import PgDocField
 
 

--- a/cubedash/index/postgis/_schema.py
+++ b/cubedash/index/postgis/_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datacube.drivers.common_psql import (
     grant_role,
     has_roles,
@@ -26,7 +28,6 @@ from sqlalchemy import (
 )
 from sqlalchemy import Enum as SqlEnum
 from sqlalchemy.dialects import postgresql as postgres
-from sqlalchemy.engine import Connection
 from sqlalchemy.orm import registry
 
 from cubedash.summary._schema import (
@@ -38,6 +39,10 @@ from cubedash.summary._schema import (
     epsg_to_srid,
     pg_create_index,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection
 
 orm_registry = registry()
 

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator, Iterable, Mapping, Sequence
-from datetime import date, datetime, timedelta
 from typing import Any
-from uuid import UUID
 
 import shapely.ops
 import structlog
@@ -19,18 +16,10 @@ from datacube.drivers.postgres._schema import (  # isort: skip
     DATASET_SOURCE,
     PRODUCT as ODC_PRODUCT,
 )
-from datacube.index.postgres.index import Index
-from datacube.model import Dataset, Field, MetadataType, Product, Range
 from geoalchemy2 import Geometry
 from geoalchemy2.shape import from_shape
 from sqlalchemy import (
-    ClauseElement,
-    CursorResult,
     Integer,
-    Label,
-    Result,
-    Row,
-    Select,
     SmallInteger,
     String,
     and_,
@@ -46,7 +35,6 @@ from sqlalchemy import (
     union_all,
 )
 from sqlalchemy.dialects.postgresql import TSTZRANGE, array, insert
-from sqlalchemy.sql import ColumnElement
 
 import cubedash.summary._schema as _schema
 from cubedash._utils import datetime_expression, default_utc
@@ -67,6 +55,15 @@ from ._schema import get_srid_name as srid_name
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Mapping, Sequence
+    from datetime import date, datetime, timedelta
+    from uuid import UUID
+
+    from datacube.index.postgres.index import Index
+    from datacube.model import Dataset, Field, MetadataType, Product, Range
+    from sqlalchemy import ClauseElement, CursorResult, Label, Result, Row, Select
+    from sqlalchemy.sql import ColumnElement
+
     from cubedash.summary._extents import PgDocField
 
 _LOG = structlog.stdlib.get_logger()

--- a/cubedash/index/postgres/_schema.py
+++ b/cubedash/index/postgres/_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from textwrap import dedent
 
@@ -33,7 +35,6 @@ from sqlalchemy import (
 )
 from sqlalchemy import Enum as SqlEnum
 from sqlalchemy.dialects import postgresql as postgres
-from sqlalchemy.engine import Connection
 from sqlalchemy.exc import ProgrammingError
 
 from cubedash.summary._schema import (
@@ -48,6 +49,10 @@ from cubedash.summary._schema import (
     pg_column_exists,
     pg_create_index,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection
 
 DATASET_SPATIAL = Table(
     "dataset_spatial",

--- a/cubedash/logs.py
+++ b/cubedash/logs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import pathlib
 import sys
@@ -6,8 +8,11 @@ from typing import BinaryIO
 
 import structlog
 from rapidjson import DM_ISO8601, UM_CANONICAL, dumps
-from structlog.types import EventDict, WrappedLogger
 from typing_extensions import override
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from structlog.types import EventDict, WrappedLogger
 
 
 def init_logging(

--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import functools
 import json
 import uuid
-from collections.abc import Generator, Iterable
+from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Any, TypeAlias
 
@@ -17,14 +17,11 @@ from datacube.drivers.postgis._fields import RangeDocField as PgisRangeDocField
 from datacube.drivers.postgres._fields import NativeField as PgresNativeField
 from datacube.drivers.postgres._fields import PgDocField as PgresDocField
 from datacube.drivers.postgres._fields import RangeDocField as PgresRangeDocField
-from datacube.model import Dataset, MetadataType, Product
 from geoalchemy2 import Geometry, WKBElement
 from geoalchemy2.shape import to_shape
 from shapely.geometry import shape
-from shapely.geometry.base import BaseGeometry
 from sqlalchemy import BigInteger, String, case, cast, func, null
 from sqlalchemy.dialects import postgresql as postgres
-from sqlalchemy.sql.elements import Label
 from sqlalchemy.types import TIMESTAMP
 from typing_extensions import override
 
@@ -34,7 +31,17 @@ from cubedash._utils import (
     infer_crs,
     jsonb_doc_expression,
 )
-from cubedash.index import ExplorerIndex
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from datetime import date
+
+    from datacube.model import Dataset, MetadataType, Product
+    from shapely.geometry.base import BaseGeometry
+    from sqlalchemy.sql.elements import Label
+
+    from cubedash.index import ExplorerIndex
 
 _LOG = structlog.stdlib.get_logger()
 

--- a/cubedash/summary/_model.py
+++ b/cubedash/summary/_model.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import warnings
 from collections import Counter
-from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
 
@@ -12,8 +11,13 @@ import structlog
 from datacube.model import Range
 from odc.geo.geom import Geometry
 from shapely.geometry import MultiPolygon
-from shapely.geometry.base import BaseGeometry
 from typing_extensions import override
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from shapely.geometry.base import BaseGeometry
 
 _LOG = structlog.stdlib.get_logger()
 

--- a/cubedash/summary/_schema.py
+++ b/cubedash/summary/_schema.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import structlog
 from geoalchemy2 import Geometry
 from sqlalchemy import MetaData, func, select, text
-from sqlalchemy.engine import Connection
 from sqlalchemy.sql.functions import GenericFunction
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection
 
 _LOG = structlog.stdlib.get_logger()
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -1,54 +1,61 @@
+from __future__ import annotations
+
 import math
 import re
 from collections import Counter
-from collections.abc import Generator, Iterable, Sequence
 from copy import copy
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta, tzinfo
+from datetime import date, datetime, timedelta
 from enum import Enum, auto
 from itertools import groupby
 from typing import Any, Literal, Protocol
-from uuid import UUID
 from zoneinfo import ZoneInfo
 
 import structlog
 from cachetools.func import ttl_cache
-from geoalchemy2 import WKBElement
 from geoalchemy2 import shape as geo_shape
 from geoalchemy2.shape import from_shape, to_shape
-from odc.geo import BoundingBox, MaybeCRS
 from pygeofilter.backends.sqlalchemy import to_filter
 from pygeofilter.parsers.cql2_json import parse as parse_cql2_json
 from pygeofilter.parsers.cql2_text import parse as parse_cql2_text
-from shapely.geometry.base import BaseGeometry
-from sqlalchemy import RowMapping, func, select
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import TSTZRANGE
 from sqlalchemy.exc import ProgrammingError
-from sqlalchemy.sql import Select
 
 try:
     from cubedash._version import version as explorer_version
 except ModuleNotFoundError:
     explorer_version = "ci-test-pipeline"
-from datacube.index import Index
 from datacube.index.postgis.index import Index as PostgisIndex
 from datacube.index.postgres.index import Index as PostgresIndex
 from datacube.metadata._utils import EO3_TO_STAC_RENAMES
-from datacube.model import Dataset, Field, MetadataType, Product, Range
+from datacube.model import Range
 from odc.geo.geom import Geometry
 
 from cubedash import _utils
-from cubedash.index import EmptyDbError, ExplorerIndex
+from cubedash.index import EmptyDbError
 from cubedash.index.postgis import ExplorerPgisIndex
 from cubedash.index.postgres import ExplorerPgIndex
 from cubedash.summary import RegionInfo, TimePeriodOverview, _extents
-from cubedash.summary._extents import (
-    GridRegionInfo,
-    ProductArrival,
-    RegionSummary,
-    SceneRegionInfo,
-)
+from cubedash.summary._extents import ProductArrival, RegionSummary
 from cubedash.summary._summarise import DEFAULT_TIMEZONE, Summariser
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Sequence
+    from datetime import tzinfo
+    from uuid import UUID
+
+    from datacube.index import Index
+    from datacube.model import Dataset, Field, MetadataType, Product
+    from geoalchemy2 import WKBElement
+    from odc.geo import BoundingBox, MaybeCRS
+    from shapely.geometry.base import BaseGeometry
+    from sqlalchemy import RowMapping
+    from sqlalchemy.sql import Select
+
+    from cubedash.index import ExplorerIndex
+    from cubedash.summary._extents import GridRegionInfo, SceneRegionInfo
 
 DEFAULT_TTL = 180
 
@@ -305,7 +312,7 @@ class SummaryStore:
     @classmethod
     def create(
         cls, index: Index, log=_LOG, grouping_time_zone: str = DEFAULT_TIMEZONE
-    ) -> "SummaryStore":
+    ) -> SummaryStore:
         if not isinstance(index, (PostgisIndex, PostgresIndex)):
             raise ValueError(f"Cannot run explorer with index {index.name}")
         e_index = explorer_index(index)

--- a/cubedash/summary/_summarise.py
+++ b/cubedash/summary/_summarise.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import os
 from collections import Counter
-from datetime import datetime
 from zoneinfo import ZoneInfo
 
 import pandas as pd
@@ -8,8 +9,13 @@ import structlog
 from geoalchemy2 import shape as geo_shape
 
 from cubedash import _utils
-from cubedash.index import ExplorerIndex
 from cubedash.summary import TimePeriodOverview
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from cubedash.index import ExplorerIndex
 
 _LOG = structlog.stdlib.get_logger()
 

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -6,6 +6,8 @@ Useful for testing Explorer-generated summaries from
 scripts and the command-line.
 """
 
+from __future__ import annotations
+
 import sys
 import time
 from textwrap import dedent
@@ -13,7 +15,6 @@ from textwrap import dedent
 import click
 import structlog
 from click import echo, secho
-from datacube.cfg import ODCEnvironment
 from datacube.index import index_connect
 from datacube.index.postgis.index import Index as PostgisIndex
 from datacube.index.postgres.index import Index as PostgresIndex
@@ -22,6 +23,10 @@ from datacube.ui.click import environment_option, pass_config
 from cubedash._filters import sizeof_fmt
 from cubedash.logs import init_logging
 from cubedash.summary import SummaryStore
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.cfg import ODCEnvironment
 
 _LOG = structlog.stdlib.get_logger()
 

--- a/cubedash/testutils/database.py
+++ b/cubedash/testutils/database.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import configparser
 import os
 import time
@@ -7,11 +9,12 @@ from pathlib import Path
 # There is a docker directory in the root, skip sorting that import until
 # this repository uses a src layout.
 import docker  # isort: skip
+
 import psycopg2
 import psycopg2.extensions
 import pytest
 from datacube import Datacube
-from datacube.cfg import ODCConfig, ODCEnvironment
+from datacube.cfg import ODCConfig
 from datacube.drivers.common_psql import drop_schema
 from datacube.drivers.postgis import _core as pgis_core
 from datacube.drivers.postgres import _core as pgres_core
@@ -21,6 +24,10 @@ from datacube.model import MetadataType
 from datacube.utils import read_documents
 from datacube.utils.documents import InvalidDocException, UnknownMetadataType
 from sqlalchemy import text
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.cfg import ODCEnvironment
 
 GET_DB_FROM_ENV = "get-the-db-from-the-environment-variable"
 

--- a/cubedash/warmup.py
+++ b/cubedash/warmup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import time
 import urllib.request
@@ -7,10 +9,13 @@ from urllib.parse import urljoin
 
 import click
 from click import echo, secho, style
-from datacube.index import Index
 from datacube.ui.click import config_option, environment_option, pass_index
 
 from cubedash.summary import RegionInfo
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.index import Index
 
 
 def find_examples_of_all_public_urls(index: Index):

--- a/integration_tests/asserts.py
+++ b/integration_tests/asserts.py
@@ -1,24 +1,33 @@
+from __future__ import annotations
+
 import json
 import re
-from datetime import datetime, timezone
+from datetime import timezone
 from pathlib import Path
 from pprint import pformat, pprint
 from textwrap import indent
-from types import TracebackType
 
 import jsonschema
 import pytest
-from datacube.model import Range
 from datacube.utils import InvalidDocException, validate_document
 from deepdiff import DeepDiff
-from flask.testing import FlaskClient
-from selectolax.lexbor import LexborHTMLParser, LexborNode
+from selectolax.lexbor import LexborHTMLParser
 from shapely.geometry import shape
-from shapely.geometry.base import BaseGeometry
-from werkzeug.test import TestResponse
 
 from cubedash._utils import default_utc
-from cubedash.summary import TimePeriodOverview
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datetime import datetime
+    from types import TracebackType
+
+    from datacube.model import Range
+    from flask.testing import FlaskClient
+    from selectolax.lexbor import LexborNode
+    from shapely.geometry.base import BaseGeometry
+    from werkzeug.test import TestResponse
+
+    from cubedash.summary import TimePeriodOverview
 
 # GeoJSON schema from https://geojson.org/schema/FeatureCollection.json
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import time
 from contextlib import contextmanager
@@ -8,8 +10,6 @@ import pytest
 import sqlalchemy
 import structlog
 from click.testing import CliRunner
-from datacube import Datacube
-from flask.testing import FlaskClient
 from structlog import DropEvent
 
 from cubedash import _model, generate, logs
@@ -24,6 +24,11 @@ from cubedash.warmup import find_examples_of_all_public_urls
 #          default index/dea_index fixtures, as they'll override data from
 #          the same db.
 from .asserts import format_doc_diffs
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube import Datacube
+    from flask.testing import FlaskClient
 
 ######################################################
 # Prepare DB for integration test

--- a/integration_tests/dumpdatasets.py
+++ b/integration_tests/dumpdatasets.py
@@ -2,6 +2,8 @@
 Util script to dump datasets from a datacube for use as test data.
 """
 
+from __future__ import annotations
+
 import gzip
 import random
 from datetime import datetime
@@ -11,7 +13,11 @@ from typing import Any
 import click
 import yaml
 from datacube import Datacube
-from datacube.model import Dataset, Range
+from datacube.model import Range
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube.model import Dataset
 
 
 def _sample(iterable, sample_count):

--- a/integration_tests/test_archival_handling.py
+++ b/integration_tests/test_archival_handling.py
@@ -5,10 +5,15 @@ while the other dataset has datetime outside of
 end_datetime and start_datetime range (deliberate test setup sample)
 """
 
+from __future__ import annotations
+
 import pytest
-from flask.testing import FlaskClient
 
 from integration_tests.asserts import check_dataset_count, get_html
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
 
 METADATA_TYPES = ["metadata/eo3_landsat_ard.odc-type.yaml"]
 PRODUCTS = ["products/ga_ls7e_ard_3.odc-product.yaml"]

--- a/integration_tests/test_center_datetime_logic.py
+++ b/integration_tests/test_center_datetime_logic.py
@@ -5,14 +5,19 @@ while the other dataset has datetime outside of
 end_datetime and start_datetime range (deliberate test setup sample)
 """
 
+from __future__ import annotations
+
 import pytest
-from flask.testing import FlaskClient
 
 from integration_tests.asserts import (
     check_dataset_count,
     check_datesets_page_datestring,
     get_html,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
 
 METADATA_TYPES = ["metadata/eo3_metadata.yaml"]
 PRODUCTS = ["products/rainfall_chirps_daily.odc-product.yaml"]

--- a/integration_tests/test_configurable_page_elements.py
+++ b/integration_tests/test_configurable_page_elements.py
@@ -1,8 +1,14 @@
-import pytest
-from flask.testing import FlaskClient
+from __future__ import annotations
 
-from cubedash.summary import SummaryStore
+import pytest
+
 from integration_tests.asserts import get_html
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
+
+    from cubedash.summary import SummaryStore
 
 METADATA_TYPES = [
     "metadata/eo3_metadata.yaml",

--- a/integration_tests/test_dataset_listing.py
+++ b/integration_tests/test_dataset_listing.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 import pytest
-from datacube import Datacube
-from datacube.index import Index
 from datacube.model import Range
 from werkzeug.datastructures import MultiDict
 
 from cubedash._utils import query_to_search
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube import Datacube
+    from datacube.index import Index
 
 DEFAULT_PLATFORM_END_DATE = {
     "LANDSAT_5": datetime(2011, 11, 30),

--- a/integration_tests/test_dataset_maturity.py
+++ b/integration_tests/test_dataset_maturity.py
@@ -4,11 +4,15 @@ Indexes 20 datasets for ga_ls8c_ard_3,
 - 16 datasets have maturity level: final
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest
 
-from cubedash.summary import SummaryStore
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from cubedash.summary import SummaryStore
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
@@ -5,10 +7,7 @@ from textwrap import dedent
 from uuid import UUID
 
 import pytest
-from datacube import Datacube
-from datacube.index import Index
 from datacube.utils import parse_time
-from flask.testing import FlaskClient
 from geoalchemy2.shape import to_shape
 from ruamel.yaml import YAML
 
@@ -19,6 +18,12 @@ from cubedash.warmup import find_examples_of_all_public_urls
 from integration_tests.asserts import assert_matching_eo3
 from integration_tests.test_pages_render import assert_all_urls_render
 from integration_tests.test_stac import get_item, get_items
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube import Datacube
+    from datacube.index import Index
+    from flask.testing import FlaskClient
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 

--- a/integration_tests/test_model.py
+++ b/integration_tests/test_model.py
@@ -8,7 +8,7 @@ from datetime import date, datetime
 from datacube.model import Range
 from shapely.geometry import shape
 
-from cubedash._model import TimePeriodOverview
+from cubedash.summary._model import TimePeriodOverview
 from integration_tests.asserts import assert_shapes_mostly_equal
 
 ANTIMERIDIAN_POLY = shape(

--- a/integration_tests/test_page_loads.py
+++ b/integration_tests/test_page_loads.py
@@ -2,17 +2,18 @@
 Tests that load pages and check the contained text.
 """
 
+from __future__ import annotations
+
 from datetime import datetime, timezone
 from io import StringIO
 from zoneinfo import ZoneInfo
 
 import flask
 import pytest
-from flask.testing import FlaskClient
 from ruamel.yaml import YAML, YAMLError
 
 from cubedash import _model
-from cubedash.summary import SummaryStore, _extents, show
+from cubedash.summary import _extents, show
 from cubedash.summary._stores import explorer_index
 from integration_tests.asserts import (
     assert_text_contains,
@@ -26,6 +27,12 @@ from integration_tests.asserts import (
     get_normalized_text,
     get_text_response,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
+
+    from cubedash.summary import SummaryStore
 
 DEFAULT_TZ = ZoneInfo("Australia/Darwin")
 

--- a/integration_tests/test_pages_render.py
+++ b/integration_tests/test_pages_render.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 from textwrap import indent
 
 import pytest
-from datacube import Datacube
-from flask.testing import FlaskClient
 from sqlalchemy import text
 
-from cubedash.summary import SummaryStore
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from datacube import Datacube
+    from flask.testing import FlaskClient
+
+    from cubedash.summary import SummaryStore
 
 METADATA_TYPES = [
     "metadata/eo3_metadata.yaml",

--- a/integration_tests/test_raw_yaml.py
+++ b/integration_tests/test_raw_yaml.py
@@ -5,12 +5,17 @@ Tests rendered raw yaml pages by passing the rendered content to datacube cli to
 - odc-metadata.yaml (cli command: datacube dataset)
 """
 
+from __future__ import annotations
+
 import tempfile
 
 import datacube.scripts.cli_app
 import pytest
 from click.testing import CliRunner
-from flask.testing import FlaskClient
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
 
 METADATA_TYPES = [
     "metadata/qga_eo.yaml",

--- a/integration_tests/test_region_tiles.py
+++ b/integration_tests/test_region_tiles.py
@@ -2,10 +2,15 @@
 Tests that indexes DEA C3 Summary products region tiles
 """
 
+from __future__ import annotations
+
 import pytest
-from flask.testing import FlaskClient
 
 from integration_tests.asserts import check_dataset_count, get_html
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
 
 METADATA_TYPES = [
     "metadata/eo3_metadata.yaml",

--- a/integration_tests/test_s2_l2a_footprint.py
+++ b/integration_tests/test_s2_l2a_footprint.py
@@ -2,15 +2,21 @@
 Tests that load pages and check the contained text.
 """
 
+from __future__ import annotations
+
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 from datacube.model import Range
-from flask.testing import FlaskClient
 
-from cubedash.summary import SummaryStore
 from integration_tests.asserts import check_dataset_count, expect_values, get_html
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
+
+    from cubedash.summary import SummaryStore
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 

--- a/integration_tests/test_stac.py
+++ b/integration_tests/test_stac.py
@@ -2,10 +2,11 @@
 Tests that hit the stac api
 """
 
+from __future__ import annotations
+
 import urllib.parse
 import warnings
 from collections import Counter
-from collections.abc import Generator, Iterable
 from functools import lru_cache
 from pathlib import Path
 from pprint import pformat
@@ -16,12 +17,10 @@ import jsonschema
 import pytest
 from datacube.migration import ODC2DeprecationWarning
 from datacube.utils import is_url, read_documents
-from flask.testing import FlaskClient
 from jsonschema import SchemaError
 from rapidjson import JSONDecodeError, dumps, loads
 from referencing import Registry, Resource
 from referencing.exceptions import NoSuchResource
-from referencing.typing import URI
 from shapely.geometry import shape as shapely_shape
 from shapely.validation import explain_validity
 
@@ -33,6 +32,13 @@ from integration_tests.asserts import (
     get_json,
     get_text_response,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
+
+    from flask.testing import FlaskClient
+    from referencing.typing import URI
 
 DEFAULT_TZ = ZoneInfo("Australia/Darwin")
 

--- a/integration_tests/test_stores.py
+++ b/integration_tests/test_stores.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import operator
 import time
 from collections import Counter
@@ -7,8 +9,12 @@ import pytest
 from datacube.model import Range
 from shapely import geometry as geo
 
-from cubedash.summary import SummaryStore, TimePeriodOverview
+from cubedash.summary import TimePeriodOverview
 from cubedash.summary._stores import GenerateResult, ProductSummary, default_timezone
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from cubedash.summary import SummaryStore
 
 METADATA_TYPES = ["metadata/eo3_landsat_l1.odc-type.yaml"]
 PRODUCTS = ["products/l1_ls8_ga.odc-product.yaml"]

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -4,21 +4,29 @@ Load a lot of real-world DEA datasets (very slow)
 And then check their statistics match expected.
 """
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
-from uuid import UUID
 from zoneinfo import ZoneInfo
 
 import pytest
-from datacube import Datacube
-from datacube.index import Index
-from datacube.model import Product, Range
+from datacube.model import Range
 from sqlalchemy import text
 
-from cubedash.summary import SummaryStore
 from cubedash.summary._extents import GridRegionInfo
 from cubedash.summary._schema import CUBEDASH_SCHEMA
 
 from .asserts import expect_values as _expect_values
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from datacube import Datacube
+    from datacube.index import Index
+    from datacube.model import Product
+
+    from cubedash.summary import SummaryStore
 
 DEFAULT_TZ = ZoneInfo("Australia/Darwin")
 

--- a/integration_tests/test_utc_tst.py
+++ b/integration_tests/test_utc_tst.py
@@ -2,17 +2,22 @@
 Tests that load pages and check the contained text.
 """
 
+from __future__ import annotations
+
 from datetime import datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pytest
 from datacube.model import Range
-from flask.testing import FlaskClient
 
 from cubedash._utils import datetime_from_metadata, default_utc
 from cubedash.summary import SummaryStore
 from integration_tests.asserts import check_dataset_count, get_html
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 

--- a/integration_tests/test_wagl_data.py
+++ b/integration_tests/test_wagl_data.py
@@ -2,14 +2,20 @@
 Tests that load pages and check the contained text.
 """
 
+from __future__ import annotations
+
 from datetime import datetime, timezone
 
 import pytest
 from datacube.model import Range
-from flask.testing import FlaskClient
 
-from cubedash.summary import SummaryStore
 from integration_tests.asserts import expect_values, get_html
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
+
+    from cubedash.summary import SummaryStore
 
 METADATA_TYPES = ["metadata/qga_eo.yaml"]
 PRODUCTS = ["products/ga_s2_ard.odc-product.yaml"]

--- a/integration_tests/test_zzz_timings.py
+++ b/integration_tests/test_zzz_timings.py
@@ -4,10 +4,15 @@ Tests that use the app monitoring.
 The timing decorator modifies global state, run these tests last.
 """
 
+from __future__ import annotations
+
 import pytest
-from flask.testing import FlaskClient
 
 from cubedash import _monitoring
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
 
 
 # this test fails in gh with the postgis driver for unknown reasons

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ filterwarnings = [
 target-version = "py310"
 
 [tool.ruff.lint]
+future-annotations = true
 select = [
     "A",  # Don't shadow built-ins
     "B",  # flake8-bugbear
@@ -182,6 +183,7 @@ select = [
     "S",  # flake8-bandit
     "SIM", # flake8-simplify
     "T10", # flake8-debugger
+    "TC",  # Import types in TYPE_CHECKING block
     "UP",  # pyupgrade
     "W",  # pycodestyle warnings
 ]


### PR DESCRIPTION
Reduce the dependencies required
for running cubedash-gen by
importing type signature symbols
in the TYPE_CHECKING block.

Refs #1100

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1123.org.readthedocs.build/en/1123/

<!-- readthedocs-preview datacube-explorer end -->