### PR TITLE
utils: fix type error

### DIFF
--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -43,18 +43,22 @@ bp = Blueprint("filters", __name__)
 
 
 @bp.app_template_filter("printable_time")
-def _format_datetime(date):
-    return date.strftime("%Y-%m-%d %H:%M:%S")
+def _format_datetime(date: datetime | None) -> str:
+    return "(unknown time)" if date is None else date.strftime("%Y-%m-%d %H:%M:%S")
 
 
 @bp.app_template_filter("metadata_center_time")
-def _get_metadata_center_time(dataset):
+def _get_metadata_center_time(dataset) -> datetime | None:
     return utils.datetime_from_metadata(dataset)
 
 
 @bp.app_template_filter("localised_metadata_center_time")
-def _get_localised_metadata_center_time(date):
-    return date.astimezone(ZoneInfo(_model.DEFAULT_GROUPING_TIMEZONE))
+def _get_localised_metadata_center_time(date: datetime | None) -> datetime | None:
+    return (
+        None
+        if date is None
+        else date.astimezone(ZoneInfo(_model.DEFAULT_GROUPING_TIMEZONE))
+    )
 
 
 @bp.app_template_filter("printable_dataset")

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -461,7 +461,7 @@ def dataset_created(dataset: Dataset) -> datetime | None:
     return None
 
 
-def datetime_from_metadata(dataset: Dataset) -> datetime:
+def datetime_from_metadata(dataset: Dataset) -> datetime | None:
     """
     This function shares similar logic to datetime_expression (above),
     but retrieves values for the flask template.
@@ -475,8 +475,7 @@ def datetime_from_metadata(dataset: Dataset) -> datetime:
         t = properties.get("datetime") or properties.get("dtr:start_datetime")
         return default_utc(dc_utils.parse_time(t))
     # stick with center time for EO datasets
-    # FIXME: dataset.center_time can be None.
-    return default_utc(dataset.center_time)  # type:ignore[arg-type]
+    return None if dataset.center_time is None else default_utc(dataset.center_time)
 
 
 def as_rich_json(o):

--- a/integration_tests/test_utc_tst.py
+++ b/integration_tests/test_utc_tst.py
@@ -158,6 +158,7 @@ def test_clirunner_generate_grouping_timezone(
 def test_dataset_day_link(summary_store) -> None:
     ds = summary_store.index.datasets.get("6293ac37-7f1d-430e-8d7e-ffdc1bfd556c")
     t = datetime_from_metadata(ds)
+    assert t is not None
     t = default_utc(t).astimezone(ZoneInfo("Australia/Darwin"))
     assert t.year == 2022
     assert t.month == 1


### PR DESCRIPTION
Make the second caller handle the None
case the same way as the first caller.

Fixes #1114

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1125.org.readthedocs.build/en/1125/

<!-- readthedocs-preview datacube-explorer end -->