### PR TITLE
Type check integration_tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
         python-version: ["3.10"]
         lintcommand:
           - "ruff check --output-format=github"
-          - "mypy --follow-imports=silent cubedash/*.py cubedash/index/*.py cubedash/startup_utils cubedash/summary cubedash/testutils"
+          - "mypy --follow-imports=silent cubedash/*.py cubedash/index/*.py cubedash/startup_utils cubedash/summary cubedash/testutils integration_tests"
     name: Linting
     steps:
       - name: checkout git

--- a/cubedash/generate.py
+++ b/cubedash/generate.py
@@ -70,14 +70,12 @@ from click import secho as click_secho
 from click import style
 from datacube.cfg import ODCConfig
 from datacube.index import index_connect
-from datacube.index.postgis.index import Index as PostgisIndex
-from datacube.index.postgres.index import Index as PostgresIndex
 from datacube.ui.click import environment_option, pass_config
 from typing_extensions import override
 
 from cubedash.logs import init_logging
 from cubedash.summary import GenerateResult, SummaryStore, UnsupportedWKTProductCRSError
-from cubedash.summary._stores import DEFAULT_EPSG
+from cubedash.summary._stores import DEFAULT_EPSG, DatacubeIndex
 from cubedash.summary._summarise import DEFAULT_TIMEZONE
 
 TYPE_CHECKING = False
@@ -156,12 +154,12 @@ def generate_report(
         store.close()
 
 
-def _get_index(config: ODCEnvironment, variant: str) -> PostgisIndex | PostgresIndex:
+def _get_index(config: ODCEnvironment, variant: str) -> DatacubeIndex:
     # Avoid long names as they will print warnings all the time.
     prefix = "gen."
     name = f"{prefix}{variant.replace('_', '')[: 64 - len(prefix)]}"
     ix = index_connect(config, application_name=name, validate_connection=False)
-    if isinstance(ix, (PostgisIndex, PostgresIndex)):
+    if isinstance(ix, DatacubeIndex):
         return ix
     raise ValueError(f"Cannot run explorer with index {ix.name}")
 

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from enum import Enum, auto
 from itertools import groupby
-from typing import Any, Literal, Protocol
+from typing import Any, Literal, Protocol, TypeAlias
 from zoneinfo import ZoneInfo
 
 import structlog
@@ -69,7 +69,10 @@ DEFAULT_EPSG = 6933
 default_timezone = ZoneInfo(DEFAULT_TIMEZONE)
 
 
-def explorer_index(index: PostgisIndex | PostgresIndex) -> ExplorerIndex:
+DatacubeIndex: TypeAlias = PostgresIndex | PostgisIndex
+
+
+def explorer_index(index: DatacubeIndex) -> ExplorerIndex:
     if isinstance(index, PostgresIndex):
         return ExplorerPgIndex(index)
     if isinstance(index, PostgisIndex):
@@ -313,7 +316,7 @@ class SummaryStore:
     def create(
         cls, index: Index, log=_LOG, grouping_time_zone: str = DEFAULT_TIMEZONE
     ) -> SummaryStore:
-        if not isinstance(index, (PostgisIndex, PostgresIndex)):
+        if not isinstance(index, DatacubeIndex):
             raise ValueError(f"Cannot run explorer with index {index.name}")
         e_index = explorer_index(index)
         return cls(

--- a/cubedash/summary/show.py
+++ b/cubedash/summary/show.py
@@ -16,13 +16,12 @@ import click
 import structlog
 from click import echo, secho
 from datacube.index import index_connect
-from datacube.index.postgis.index import Index as PostgisIndex
-from datacube.index.postgres.index import Index as PostgresIndex
 from datacube.ui.click import environment_option, pass_config
 
 from cubedash._filters import sizeof_fmt
 from cubedash.logs import init_logging
 from cubedash.summary import SummaryStore
+from cubedash.summary._stores import DatacubeIndex
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -35,7 +34,7 @@ def _get_store(cfg_env: ODCEnvironment, variant: str, log=_LOG) -> SummaryStore:
     index = index_connect(
         cfg_env, application_name=f"cubedash.show.{variant}", validate_connection=False
     )
-    if isinstance(index, (PostgisIndex, PostgresIndex)):
+    if isinstance(index, DatacubeIndex):
         return SummaryStore.create(index, log=log)
     raise ValueError(f"Cannot run explorer with index {index.name}")
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -209,6 +209,6 @@ def _make_all_tables_unlogged(index, metadata: sqlalchemy.MetaData) -> None:
         with index._active_connection() as conn:
             conn.execute(
                 sqlalchemy.text(
-                    f"""alter table {table.selectable.fullname} set unlogged;"""
+                    f"alter table {table.selectable.fullname} set unlogged;"  # type:ignore[attr-defined]
                 )
             )

--- a/integration_tests/dumpdatasets.py
+++ b/integration_tests/dumpdatasets.py
@@ -65,7 +65,7 @@ def dump_datasets(
         ) as progress,
         gzip.open(path, "w") as f,
     ):
-        yaml.safe_dump_all(
+        yaml.safe_dump_all(  # type:ignore[call-overload]
             (_get_dumpable_doc(dc, d, include_sources) for d in progress),
             stream=f,
             encoding="utf-8",

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -22,8 +22,9 @@ from integration_tests.test_stac import get_item, get_items
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from datacube import Datacube
-    from datacube.index import Index
     from flask.testing import FlaskClient
+
+    from cubedash.summary._stores import DatacubeIndex as Index
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 

--- a/integration_tests/test_pages_render.py
+++ b/integration_tests/test_pages_render.py
@@ -5,6 +5,8 @@ from textwrap import indent
 import pytest
 from sqlalchemy import text
 
+from cubedash.summary._stores import DatacubeIndex
+
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from datacube import Datacube
@@ -91,7 +93,8 @@ def test_allows_null_product_fixed_fields(
         "There's no summarised products to test"
     )
 
-    # AND there's some with null fixed_metadata (ie. pre-Explorer0-EO3-update)
+    assert isinstance(odc_test_db.index, DatacubeIndex)
+    # AND there's some with null fixed_metadata (i.e. pre-Explorer0-EO3-update)
     with odc_test_db.index._active_connection() as conn:
         update_count = conn.execute(
             text("update cubedash.product set fixed_metadata = null")

--- a/integration_tests/test_summarise_data.py
+++ b/integration_tests/test_summarise_data.py
@@ -15,6 +15,7 @@ from sqlalchemy import text
 
 from cubedash.summary._extents import GridRegionInfo
 from cubedash.summary._schema import CUBEDASH_SCHEMA
+from cubedash.summary._stores import DatacubeIndex as Index
 
 from .asserts import expect_values as _expect_values
 
@@ -23,7 +24,6 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from datacube import Datacube
-    from datacube.index import Index
     from datacube.model import Product
 
     from cubedash.summary import SummaryStore
@@ -156,6 +156,7 @@ def test_generate_incremental_archivals(
 ) -> None:
     run_generate("ga_ls9c_ard_3")
     index = summary_store.index
+    assert isinstance(index, Index)
 
     # When we have a summarised product...
     original_summary = summary_store.get("ga_ls9c_ard_3")
@@ -194,6 +195,7 @@ def test_generate_incremental_adds(run_generate, summary_store: SummaryStore) ->
     # the summary should be updated
     run_generate("ga_ls9c_ard_3")
     index = summary_store.index
+    assert isinstance(index, Index)
 
     original_summary = summary_store.get("ga_ls9c_ard_3")
     assert original_summary is not None
@@ -242,7 +244,7 @@ def test_dataset_changing_product(run_generate, summary_store: SummaryStore) -> 
     """
     run_generate("ga_ls9c_ard_3")
     index = summary_store.index
-
+    assert isinstance(index, Index)
     dataset_id = _one_dataset(index, "ga_ls9c_ard_3")
     our_product = summary_store.get_product("ga_ls9c_ard_3")
     other_product = summary_store.get_product("ga_ls8c_ard_3")
@@ -600,6 +602,7 @@ def test_cubedash_gen_refresh(
     """
 
     def _get_product_seq_value():
+        assert isinstance(odc_test_db.index, Index)
         with odc_test_db.index._active_connection() as conn:
             [new_val] = conn.execute(
                 text(f"select last_value from {CUBEDASH_SCHEMA}.product_id_seq;")


### PR DESCRIPTION
Add a type alias for the two different
indices that Explorer supports, and
use that in the tests. Besides two
complaints from MyPy, the rest of
the tests type check, so add two
type ignores and enable type checking
in the lint workflow.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1130.org.readthedocs.build/en/1130/

<!-- readthedocs-preview datacube-explorer end -->