### PR TITLE
extents: change warning to info

### DIFF
--- a/cubedash/summary/_extents.py
+++ b/cubedash/summary/_extents.py
@@ -221,7 +221,7 @@ def refresh_spatial_extents(
     }
 
     if assume_after_date is None:
-        log.warning("spatial_update.recreating_everything")
+        log.info("spatial_update.recreating_everything")
 
     # Update any changed datasets
     log.info("spatial_upsert", product_name=product.name, after_date=assume_after_date)


### PR DESCRIPTION
It's surprising to get a warning
after initializing the index
and running "cubedash-gen --all",
so log as info instead.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1153.org.readthedocs.build/en/1153/

<!-- readthedocs-preview datacube-explorer end -->