### PR TITLE
pages: avoid crash without summaries

### DIFF
--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -501,9 +501,15 @@ def inject_globals():
     except OperationalError as e:
         _LOG.error(str(e))
         abort(500, "Internal server error")
+    try:
+        grouped_products = _get_grouped_products()
+    except RuntimeError as e:
+        # Database is probably missing summarised products.
+        _LOG.error(str(e))
+        abort(500, "Internal server error")
     return {
         # Only the known, summarised products in groups.
-        "grouped_products": _get_grouped_products(),
+        "grouped_products": grouped_products,
         # All products in the datacube, summarised or not.
         "datacube_products": products,
         "hidden_product_list": current_app.config.get(


### PR DESCRIPTION
The log gets flooded with crashes
when there aren't any summaries
in the database, so catch the error
and return a 500 page instead.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1155.org.readthedocs.build/en/1155/

<!-- readthedocs-preview datacube-explorer end -->