### PR TITLE
Prevent inject_globals being called on 500 errors.

### DIFF
--- a/cubedash/_model.py
+++ b/cubedash/_model.py
@@ -119,7 +119,8 @@ def create_app(test_config=None) -> flask.Flask:
 
     @app.errorhandler(500)
     def internal_server_error(error):
-        return flask.render_template("500.html")
+        # Bypass inject_globals for rendering the 500 error page
+        return utils.render_without_context_processors(app, "500.html")
 
     @app.errorhandler(HTTPException)
     def handle_exception(e: HTTPException) -> tuple[ResponseValue, int]:

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
     from datacube.index.fields import Field
     from datacube.model import Dataset, Product
+    from flask import Flask
     from odc.geo import Geometry
     from shapely.geometry.base import BaseGeometry
     from werkzeug.datastructures import MultiDict
@@ -94,6 +95,12 @@ def infer_crs(crs_str: str) -> str | None:
 
 def render(template, **context):
     return render_template(template, **context)
+
+
+def render_without_context_processors(app: Flask, template, **context):
+    # When e.g. rendering error pages, we don't want to trigger the context processors
+    # Use native Jinja template rendering instead (bypassing flask)
+    return app.jinja_env.get_template(template).render(**context)
 
 
 def expects_eo3_metadata_type(md: MetadataType) -> bool:

--- a/cubedash/templates/500.html
+++ b/cubedash/templates/500.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="panel">
-    <h4>Internal error</h4>
+    <h4>{% if message %}{{ message }}{% else %}Internal error{% endif %}</h4>
 
     This has been logged.
 </div>


### PR DESCRIPTION
500 errors do not render the full template and do not need globals injected.

Add a util method to render directly with Jinja, bypassing Flask's context processors.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1161.org.readthedocs.build/en/1161/

<!-- readthedocs-preview datacube-explorer end -->