### PR TITLE
Remove recursive query from raw metadata.

### DIFF
--- a/cubedash/_dataset.py
+++ b/cubedash/_dataset.py
@@ -101,7 +101,8 @@ def dataset_full_page(product_name: str, id_: UUID):
 @bp.route("/dataset/<uuid:id_>.odc-metadata.yaml")
 def raw_doc(id_):
     index = _model.STORE.index
-    dataset = index.datasets.get(id_, include_sources=True)
+    dataset = index.datasets.get(id_, include_sources=False)
+    lineage = index.lineage.get_source_ids(id_)
 
     if dataset is None:
         abort(404, f"No dataset found with id {id_}")
@@ -109,6 +110,6 @@ def raw_doc(id_):
     # Format for readability
     return utils.as_yaml(
         utils.prepare_dataset_formatting(
-            dataset, include_source_url=True, include_locations=True
+            dataset, include_source_url=True, include_locations=True, lineage=lineage
         )
     )

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -815,13 +815,6 @@ EODATASETS_PROPERTY_ORDER = [
     "lineage",
     "product_flags",
 ]
-EODATASETS_LINEAGE_PROPERTY_ORDER = [
-    "algorithm",
-    "machine",
-    "ancillary_quality",
-    "ancillary",
-    "source_datasets",
-]
 
 
 def dataset_shape(ds: Dataset) -> tuple[BaseGeometry | None, bool]:

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
     from datacube.index.fields import Field
     from datacube.model import Dataset, Product
+    from datacube.model.lineage import Eo3LineageDict
     from flask import Flask
     from odc.geo import Geometry
     from shapely.geometry.base import BaseGeometry
@@ -658,7 +659,10 @@ def as_csv(
 
 
 def prepare_dataset_formatting(
-    dataset: Dataset, include_source_url=False, include_locations=False
+    dataset: Dataset,
+    include_source_url=False,
+    include_locations=False,
+    lineage: Eo3LineageDict | None = None,
 ) -> CommentedMap:
     """
     Try to format a raw Dataset document for readability.
@@ -669,6 +673,9 @@ def prepare_dataset_formatting(
 
     if include_locations:
         doc["location"] = dataset.uri
+
+    if lineage:
+        doc["lineage"] = lineage
 
     # If it's EO3, use eodatasets's formatting. It's better.
     if is_doc_eo3(doc):
@@ -721,25 +728,6 @@ def prepare_document_formatting(
         )
     )
 
-    # Order any embedded ones too.
-    if "lineage" in ordered_metadata:
-        ordered_metadata["lineage"] = dict(
-            sorted(
-                ordered_metadata["lineage"].items(),
-                key=functools.partial(
-                    get_property_priority, EODATASETS_LINEAGE_PROPERTY_ORDER
-                ),
-            )
-        )
-
-        if "source_datasets" in ordered_metadata["lineage"]:
-            for type_, source_dataset_doc in ordered_metadata["lineage"][
-                "source_datasets"
-            ].items():
-                ordered_metadata["lineage"]["source_datasets"][type_] = (
-                    prepare_document_formatting(source_dataset_doc)
-                )
-
     # Products have an embedded metadata doc (subset of dataset metadata)
     if "metadata" in ordered_metadata:
         ordered_metadata["metadata"] = prepare_document_formatting(
@@ -783,18 +771,7 @@ def undo_eo3_compatibility(doc) -> None:
     if "extent" in doc:
         del doc["extent"]
 
-    lineage = doc.get("lineage", {})
-    # If old EO1-style lineage was built (as it is on dataset.get(include_sources=True),
-    # flatten to EO3-style ID lists.
-
-    # TODO: It's incredibly inefficient that the whole source-dataset tree has been loaded by ODC
-    #       and we're now throwing it all away except the top-level ids.
-
-    if "source_datasets" in lineage:
-        new_lineage: dict = {}
-        for classifier, dataset_doc in lineage["source_datasets"].items():
-            new_lineage.setdefault(classifier, []).append(dataset_doc["id"])
-        doc["lineage"] = new_lineage
+    # Lineage is already handled by core
 
 
 EODATASETS_PROPERTY_ORDER = [

--- a/integration_tests/test_eo3_support.py
+++ b/integration_tests/test_eo3_support.py
@@ -190,10 +190,12 @@ def test_undo_eo3_doc_compatibility(eo3_index: Index) -> None:
 
     # Get our EO3 ARD document that was indexed.
     indexed_dataset = eo3_index.datasets.get(
-        UUID("5b2f2c50-e618-4bef-ba1f-3d436d9aed14"), include_sources=True
+        UUID("5b2f2c50-e618-4bef-ba1f-3d436d9aed14"),
     )
     assert indexed_dataset is not None
     indexed_doc = with_parsed_datetimes(indexed_dataset.metadata_doc)
+    indexed_lineage = eo3_index.lineage.get_source_ids(indexed_dataset.id)
+    indexed_doc["lineage"] = indexed_lineage
 
     # Undo the changes.
     _utils.undo_eo3_compatibility(indexed_doc)


### PR DESCRIPTION
- don't call get with include_sources
- use new core methods to do simple shallow read of lineage for raw dataset metadata
- Always write EO3-style id-only lineage on EO-format datasets in raw dataset metadata

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1164.org.readthedocs.build/en/1164/

<!-- readthedocs-preview datacube-explorer end -->