### PR TITLE
Search by product ids

### DIFF
--- a/cubedash/index/api.py
+++ b/cubedash/index/api.py
@@ -74,13 +74,19 @@ class ExplorerAbstractIndex(ABC):
     @abstractmethod
     def get_mutable_dataset_search_fields(
         self, md: MetadataType
-    ) -> Mapping[str, Field]: ...
-
-    """
+    ) -> Mapping[str, Field]:
+        """
         Get a copy of a metadata type's fields that we can mutate.
-
         (the ones returned by the Index are cached and so may be shared among callers)
-    """
+        """
+        ...
+
+    @abstractmethod
+    def product_names_to_ids(self, names: list[str]) -> list[int]:
+        """
+        Convert a list of product names to a list of product ids.
+        """
+        ...
 
     @abstractmethod
     def get_datasets_derived(

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -93,6 +93,16 @@ class ExplorerIndex(ExplorerAbstractIndex):
         return self.index._db.get_dataset_fields(md.definition)
 
     @override
+    def product_names_to_ids(self, names: list[str]) -> list[int]:
+        with self.index._active_connection() as conn:
+            return [
+                row.id
+                for row in conn.run_query(
+                    select(ODC_PRODUCT.id).where(ODC_PRODUCT.name.in_(names))
+                )
+            ]
+
+    @override
     def ds_added_expr(self):
         return ODC_DATASET.added
 

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -802,6 +802,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     def dataset_spatial_field_exprs(self) -> dict[str, ColumnElement]:
         geom = func.ST_Transform(DatasetSpatial.footprint, 4326)
         return {
+            "collection_id": DatasetSpatial.product_ref,
             "collection": (
                 select(ODC_PRODUCT.name)
                 .where(ODC_PRODUCT.id == DatasetSpatial.product_ref)

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -89,6 +89,16 @@ class ExplorerIndex(ExplorerAbstractIndex):
         return self.index._db.get_dataset_fields(md.definition)
 
     @override
+    def product_names_to_ids(self, names: list[str]) -> list[int]:
+        with self.index._active_connection() as conn:
+            return [
+                row.id
+                for row in conn.run_query(
+                    select(ODC_PRODUCT.c.id).where(ODC_PRODUCT.c.name.in_(names))
+                )
+            ]
+
+    @override
     def ds_added_expr(self):
         # what's the best approach with this one?
         return ODC_DATASET.c.added

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -877,6 +877,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
     def dataset_spatial_field_exprs(self) -> dict[str, ColumnElement]:
         geom = func.ST_Transform(DATASET_SPATIAL.c.footprint, 4326)
         return {
+            "collection_id": DATASET_SPATIAL.c.dataset_type_ref,
             "collection": (
                 select(ODC_PRODUCT.c.name)
                 .where(ODC_PRODUCT.c.id == DATASET_SPATIAL.c.dataset_type_ref)

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -951,7 +951,8 @@ class SummaryStore:
                 field_exprs["geometry"].intersects(from_shape(intersects))
             )
         if product_names:
-            query = query.where(field_exprs["collection"].in_(product_names))
+            product_ids = self.e_index.product_names_to_ids(product_names)
+            query = query.where(field_exprs["collection_id"].in_(product_ids))
 
         return query
 


### PR DESCRIPTION
Search queries are searching by product by comparing a subquery to a list of product names, which causes a table scan of the DatasetSpatial table to happen.

This PR adds a method to the index layer to convert product name lists to product id lists, and then searches by them, allowing an index scan to be used. 

This speeds up many common queries by multiple orders of magnitude for large indexes.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1175.org.readthedocs.build/en/1175/

<!-- readthedocs-preview datacube-explorer end -->