### PR TITLE
CI: add attestation permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,6 +36,7 @@ jobs:
       contents: read    # This is required for actions/checkout
       packages: write  # This is required for pushing to ghcr
       attestations: write # This is required for pushing the attestation
+      artifact-metadata: write # This is required for creating the storage record
 
     steps:
       - name: Checkout git


### PR DESCRIPTION
This is some new permission from
early 2026 that is required for
creating the storage record.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1179.org.readthedocs.build/en/1179/

<!-- readthedocs-preview datacube-explorer end -->