### PR TITLE
Use time zone functions from core

### DIFF
--- a/cubedash/_filters.py
+++ b/cubedash/_filters.py
@@ -11,6 +11,7 @@ from zoneinfo import ZoneInfo
 import flask
 import structlog
 from datacube.model import Range
+from datacube.utils.dates import tz_aware
 from flask import Blueprint
 from markupsafe import Markup
 from rapidjson import DM_ISO8601, UM_CANONICAL, dumps
@@ -154,7 +155,7 @@ def _dataset_day_link(dataset: Dataset, timezone=None):
     if t is None:
         return "(unknown time)"
     if timezone:
-        t = utils.default_utc(t).astimezone(timezone)
+        t = tz_aware(t).astimezone(timezone)
     url = flask.url_for(
         "pages.product_page",
         product_name=dataset.product.name,
@@ -299,7 +300,7 @@ def timesince(dt, default="just now"):
         return "an unrecorded time ago"
 
     now = datetime.now(UTC)
-    diff = now - utils.default_utc(dt)
+    diff = now - tz_aware(dt)
 
     periods = (
         (diff.days // 365, "year", "years"),

--- a/cubedash/_pages.py
+++ b/cubedash/_pages.py
@@ -10,6 +10,7 @@ import flask
 import structlog
 from datacube.model import Range
 from datacube.scripts.dataset import build_dataset_info
+from datacube.utils.dates import tz_aware
 from flask import (
     Blueprint,
     abort,
@@ -23,7 +24,6 @@ from sqlalchemy.exc import DataError, OperationalError, ProgrammingError
 from werkzeug.datastructures import MultiDict
 
 import cubedash
-from cubedash._utils import default_utc
 
 from . import _model, _stac
 from . import _utils as utils
@@ -236,7 +236,7 @@ def search_page(
     try:
         datasets = sorted(
             index.datasets.search(**query, limit=hard_search_limit + 1),
-            key=lambda d: default_utc(d.center_time),
+            key=lambda d: tz_aware(d.center_time),
         )
     except (DataError, ProgrammingError):
         abort(400, "Invalid field value provided in query")

--- a/cubedash/_stac.py
+++ b/cubedash/_stac.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from datetime import time as dt_time
 from functools import partial
 from typing import Any, TypeAlias
@@ -12,6 +12,7 @@ import pystac
 import structlog
 from datacube.metadata import ds2stac
 from datacube.utils import parse_time
+from datacube.utils.dates import tz_as_utc
 from flask import abort, current_app, request
 from pystac import Catalog, Collection, Extent, ItemCollection, Link, STACObject
 from shapely.geometry import shape
@@ -82,12 +83,6 @@ def dissoc_in(d: dict, key: str):
 
 
 # Time-related
-
-
-def utc(d: datetime):
-    if d.tzinfo is None:
-        return d.replace(tzinfo=UTC)
-    return d.astimezone(UTC)
 
 
 def _parse_time_range(time: str) -> tuple[datetime, datetime] | None:
@@ -180,12 +175,12 @@ def as_stac_item(dataset: DatasetItem) -> pystac.Item:
             geometry=dataset.geom_geojson,
             bbox=list(dataset.bbox) if dataset.bbox is not None else None,
             properties={
-                "created": utc(dataset.creation_time),
+                "created": tz_as_utc(dataset.creation_time),
                 "proj:code": str(dataset.geometry.crs)
                 if dataset.geometry is not None
                 else None,
             },
-            datetime=utc(dataset.center_time),
+            datetime=tz_as_utc(dataset.center_time),
             collection=dataset.product_name,
             href=self_url,
         )
@@ -276,8 +271,8 @@ def as_stac_collection(res: CollectionItem) -> pystac.Collection:
             temporal=pystac.TemporalExtent(
                 intervals=[
                     [
-                        utc(res.time_earliest) if res.time_earliest else None,
-                        utc(res.time_latest) if res.time_latest else None,
+                        tz_as_utc(res.time_earliest) if res.time_earliest else None,
+                        tz_as_utc(res.time_latest) if res.time_latest else None,
                     ]
                 ]
             ),

--- a/cubedash/_utils.py
+++ b/cubedash/_utils.py
@@ -26,6 +26,7 @@ from datacube import utils as dc_utils
 from datacube.index.eo3 import is_doc_eo3
 from datacube.model import MetadataType, Range
 from datacube.utils import InvalidDocException, jsonify_document
+from datacube.utils.dates import tz_aware
 from eodatasets3 import serialise
 from flask_themer import render_template
 from odc.geo import geom
@@ -440,14 +441,8 @@ def _unchanged_value(a):
     return a
 
 
-def default_utc(d: datetime) -> datetime:
-    if d.tzinfo is None:
-        return d.replace(tzinfo=UTC)
-    return d
-
-
 def now_utc() -> datetime:
-    return default_utc(datetime.now(UTC))
+    return tz_aware(datetime.now(UTC))
 
 
 def dataset_created(dataset: Dataset) -> datetime | None:
@@ -457,7 +452,7 @@ def dataset_created(dataset: Dataset) -> datetime | None:
     value = dataset.metadata.creation_dt
     if value:
         try:
-            return default_utc(dc_utils.parse_time(value))
+            return tz_aware(dc_utils.parse_time(value))
         except ValueError:
             _LOG.warning(
                 "invalid_dataset.creation_dt", dataset_id=dataset.id, value=value
@@ -465,7 +460,7 @@ def dataset_created(dataset: Dataset) -> datetime | None:
     # like in _dataset_creation_expression, if there's no creation time
     # then we fall back to indexed time (if it exists)
     if dataset.indexed_time:
-        return default_utc(dc_utils.parse_time(dataset.indexed_time))
+        return tz_aware(dc_utils.parse_time(dataset.indexed_time))
     return None
 
 
@@ -481,9 +476,9 @@ def datetime_from_metadata(dataset: Dataset) -> datetime | None:
         # prefer using datetime or start_datetime directly
         properties = dataset.metadata_doc["properties"]
         t = properties.get("datetime") or properties.get("dtr:start_datetime")
-        return default_utc(dc_utils.parse_time(t))
+        return tz_aware(dc_utils.parse_time(t))
     # stick with center time for EO datasets
-    return None if dataset.center_time is None else default_utc(dataset.center_time)
+    return None if dataset.center_time is None else tz_aware(dataset.center_time)
 
 
 def as_rich_json(o):

--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -18,6 +18,7 @@ from datacube.drivers.postgis._schema import (  # isort: skip
     Dataset as ODC_DATASET,  # noqa: N814
     Product as ODC_PRODUCT,  # noqa: N814
 )
+from datacube.utils.dates import tz_aware
 from geoalchemy2 import Geometry
 from geoalchemy2.shape import from_shape
 from sqlalchemy import (
@@ -44,7 +45,7 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.types import TIMESTAMP
 
 import cubedash.summary._schema as _schema
-from cubedash._utils import datetime_expression, default_utc
+from cubedash._utils import datetime_expression
 from cubedash.index.api import EmptyDbError, ExplorerAbstractIndex
 
 from ._schema import (  # isort: skip
@@ -429,8 +430,8 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
         if time:
             query = query.where(
-                default_utc(time[0]) <= ProductSpatial.time_latest,
-                ProductSpatial.time_earliest <= default_utc(time[1]),
+                tz_aware(time[0]) <= ProductSpatial.time_latest,
+                ProductSpatial.time_earliest <= tz_aware(time[1]),
             )
 
         if q:

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -20,6 +20,7 @@ from datacube.drivers.postgres._schema import (  # isort: skip
     DATASET_SOURCE,
     PRODUCT as ODC_PRODUCT,
 )
+from datacube.utils.dates import tz_aware
 from geoalchemy2 import Geometry
 from geoalchemy2.shape import from_shape
 from sqlalchemy import (
@@ -41,7 +42,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import TSTZRANGE, array, insert
 
 import cubedash.summary._schema as _schema
-from cubedash._utils import datetime_expression, default_utc
+from cubedash._utils import datetime_expression
 from cubedash.index.api import EmptyDbError, ExplorerAbstractIndex
 
 from ._schema import (
@@ -487,8 +488,8 @@ class ExplorerIndex(ExplorerAbstractIndex):
 
         if time:
             query = query.where(
-                default_utc(time[0]) <= PRODUCT.c.time_latest,
-                PRODUCT.c.time_earliest <= default_utc(time[1]),
+                tz_aware(time[0]) <= PRODUCT.c.time_latest,
+                PRODUCT.c.time_earliest <= tz_aware(time[1]),
             )
 
         if q:

--- a/cubedash/summary/_stores.py
+++ b/cubedash/summary/_stores.py
@@ -30,6 +30,7 @@ from datacube.index.postgis.index import Index as PostgisIndex
 from datacube.index.postgres.index import Index as PostgresIndex
 from datacube.metadata._utils import EO3_TO_STAC_RENAMES
 from datacube.model import Range
+from datacube.utils.dates import tz_aware
 from odc.geo.geom import Geometry
 
 from cubedash import _utils
@@ -935,10 +936,7 @@ class SummaryStore:
         if time:
             query = query.where(
                 func.tstzrange(
-                    _utils.default_utc(time[0]),
-                    _utils.default_utc(time[1]),
-                    "[]",
-                    type_=TSTZRANGE,
+                    tz_aware(time[0]), tz_aware(time[1]), "[]", type_=TSTZRANGE
                 ).contains(field_exprs["datetime"])
             )
 

--- a/integration_tests/asserts.py
+++ b/integration_tests/asserts.py
@@ -10,11 +10,10 @@ from textwrap import indent
 import jsonschema
 import pytest
 from datacube.utils import InvalidDocException, validate_document
+from datacube.utils.dates import tz_aware
 from deepdiff import DeepDiff
 from selectolax.lexbor import LexborHTMLParser
 from shapely.geometry import shape
-
-from cubedash._utils import default_utc
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -225,7 +224,7 @@ def expect_values(
             assert s.footprint_geometry.area > 0, "Empty footprint"
 
         assert s.time_range == time_range, "wrong dataset time range"
-        assert s.newest_dataset_creation_time == default_utc(newest_creation_time), (
+        assert s.newest_dataset_creation_time == tz_aware(newest_creation_time), (
             "wrong newest dataset creation"
         )
         assert s.timeline_period == timeline_period, (

--- a/integration_tests/test_utc_tst.py
+++ b/integration_tests/test_utc_tst.py
@@ -10,8 +10,9 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from datacube.model import Range
+from datacube.utils.dates import tz_aware
 
-from cubedash._utils import datetime_from_metadata, default_utc
+from cubedash._utils import datetime_from_metadata
 from cubedash.summary import SummaryStore
 from integration_tests.asserts import check_dataset_count, get_html
 
@@ -159,12 +160,12 @@ def test_dataset_day_link(summary_store) -> None:
     ds = summary_store.index.datasets.get("6293ac37-7f1d-430e-8d7e-ffdc1bfd556c")
     t = datetime_from_metadata(ds)
     assert t is not None
-    t = default_utc(t).astimezone(ZoneInfo("Australia/Darwin"))
+    t = tz_aware(t).astimezone(ZoneInfo("Australia/Darwin"))
     assert t.year == 2022
     assert t.month == 1
     assert t.day == 1
 
-    t = default_utc(t).astimezone(ZoneInfo("America/Chicago"))
+    t = tz_aware(t).astimezone(ZoneInfo("America/Chicago"))
     assert t.year == 2021
     assert t.month == 12
     assert t.day == 31


### PR DESCRIPTION
Remove the two copies of the
utc function from this code
base and use the functions
defined in core instead.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1188.org.readthedocs.build/en/1188/

<!-- readthedocs-preview datacube-explorer end -->