### PR TITLE
Require setputools 83.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ cubedash-run = "cubedash.run:cli"
 cubedash-view = "cubedash.summary.show:cli"
 
 [build-system]
-requires = ["setuptools>=69", "setuptools_scm[toml]>=8"]
+requires = ["setuptools>=83.0.0", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This fixes CVE-2026-59890.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1209.org.readthedocs.build/en/1209/

<!-- readthedocs-preview datacube-explorer end -->