### PR TITLE
Revert "build(deps): bump osgeo/gdal from ubuntu-small-3.13.2 to ubuntu-small-3.13.3"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.13.3@sha256:64250faf833c06d4b21afce4c27190039ba7ab58d70f0eebc87cf77d929c0b40 AS base
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.13.2@sha256:49b1b7a9779340ad66e7f87ea78ea632e923867df24e68c6d17f0079220e16b3 AS base
 
 LABEL org.opencontainers.image.source=https://github.com/opendatacube/datacube-explorer
 LABEL org.opencontainers.image.description="Datacube Explorer"


### PR DESCRIPTION
This causes test_stac.py::test_stac_collection to fail because of rounding differences.

Reverts opendatacube/datacube-explorer#1226

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1229.org.readthedocs.build/en/1229/

<!-- readthedocs-preview datacube-explorer end -->