### PR TITLE
[docker/gha] arm64+amd64, `:latest` = release, simplify CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,74 +1,42 @@
-# Files that are only used by docker/docker compose.
-docker-compose.yaml
-docker-compose.*.yaml
-docker-compose.yml
-docker-compose.*.yml
-.docker
-.dockerignore
+# .dockerignore
+#
+# With BuildKit (this repo uses `# syntax=docker/dockerfile:1`), the build
+# context is transferred incrementally and only the files referenced by the
+# Dockerfile are sent, so an exhaustive ignore list is no longer needed for
+# efficiency. This keeps only the exclusions that genuinely matter:
+#
+#   - VCS metadata: large, and the image build deliberately avoids needing git
+#     (it uses SETUPTOOLS_SCM_PRETEND_VERSION), so `.git` must never be copied.
+#   - Local virtualenvs and caches: potentially huge and host-specific.
+#   - Local secrets / environment-specific files: must never leak into an image.
+#   - OS/editor cruft.
 
-# Byte-compiled / optimized / DLL files
-**/__pycache__
-**/*.py[cod]
-
-#Git/VCS
+# VCS
 .git
 .jj
 
-# CI / distribution / packaging
-**/*.egg-info
-.github
-.gitignore
-.mergify.yml
-.pre-commit-config.yaml
-.readthedocs.yaml
-.stylelintrc
-.venv
-.yamllint
-build
-dist
-Makefile
-pylintrc
+# Docker's own files (not needed inside the image)
+.dockerignore
 
-# Test and coverage reports
-**/htmlcov
+# Local virtualenvs and tool caches
+.venv
+**/__pycache__
+**/*.py[cod]
+**/.cache
+**/.mypy_cache
+**/.pytest_cache
+**/.ruff_cache
 **/.tox
+**/.hypothesis
 **/.coverage
 **/.coverage.*
-**/.cache
-**/nosetests.xml
-**/coverage.xml
-**/*.cover
-**/.hypothesis
-.mypy_cache
-.pytest_cache
-.ruff_cache
-conftest.py
-integration_tests
-tests
 
-# Django stuff:
-**/*.log
-
-# Documentation
-*.md
-*.png
-*.rst
-docs
-LICENSE
-
-# PyBuilder
-**/target
-
-# iPython Notebook
-**/.ipynb_checkpoints
-
-# Mac OS X
-**/.DS_Store
-
-# Environment-specific templates
+# Local secrets / environment-specific files
+**/*.env.py
 **/*.env.html
 **/settings.env.py
 
-# IDE settings
+# OS / editor cruft
+**/.DS_Store
 .idea
 .vscode

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - develop
-    paths:
-      - "**"
 
   release:
     types: [published]
@@ -26,18 +24,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docker:
-    timeout-minutes: 35
+  # Compute the git-describe based version/tags and reproducible-build epoch.
+  prepare:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop' || github.event_name == 'release'
-
     permissions:
-      id-token: write   # This is required for requesting the JWT
-      contents: read    # This is required for actions/checkout
-      packages: write  # This is required for pushing to ghcr
-      attestations: write # This is required for pushing the attestation
-      artifact-metadata: write # This is required for creating the storage record
-
+      contents: read
+    outputs:
+      # setuptools_scm-compatible version string passed as EXPLORER_VERSION build-arg.
+      version: ${{ steps.meta.outputs.version }}
+      meta-tags: ${{ steps.meta.outputs.meta-tags }}
+      # Base image name (registry/repo, no tag) consumed as meta-images.
+      meta-images: ${{ steps.meta.outputs.meta-images }}
+      # Unix timestamp for reproducible builds (SOURCE_DATE_EPOCH build-arg).
+      source-date-epoch: ${{ steps.meta.outputs.source-date-epoch }}
     steps:
       - name: Checkout git
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -45,76 +44,73 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Log in to GHCR
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.REGISTRY }}
+      - name: Compute version, tags and build epoch
+        id: meta
+        run: |
+          set -euo pipefail
+          echo "meta-images=${REGISTRY}/${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+
+          # Reproducible-build epoch: timestamp of the last commit that touched
+          # files which affect the built image.
+          SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct -- pyproject.toml uv.lock cubedash)
+          echo "source-date-epoch=${SOURCE_DATE_EPOCH}" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # Released image: vN.N.N AND :latest
+            RELEASE_VERSION=$(git describe --abbrev=0 --tags)
+            VERSION="${RELEASE_VERSION}"
+            META_TAGS=$(printf '%s\n%s' \
+              "type=raw,value=${RELEASE_VERSION}" \
+              "type=raw,value=latest")
+          else
+            # Unstable (develop) build: full git describe tag only
+            UNSTABLE_TAG=$(git describe --tags)
+            # setuptools_scm compatible version string (replace -g with +g).
+            VERSION="${UNSTABLE_TAG/-g/+g}"
+            META_TAGS="type=raw,value=${UNSTABLE_TAG}"
+          fi
+          {
+            echo "version=${VERSION}"
+            echo "meta-tags<<EOF"
+            echo "${META_TAGS}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  # Build (and push) a combined linux/amd64 + linux/arm64
+  # See https://docs.docker.com/build/ci/github-actions/github-builder/build/
+  # for documentation on this docker maintained workflow.
+  build:
+    needs: prepare
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read      # fetch the repository content
+      id-token: write     # sign attestations and cache entries via OIDC
+      packages: write     # push to GHCR
+      attestations: write # write the attestation storage record
+    with:
+      output: image
+      push: true
+      platforms: linux/amd64,linux/arm64
+      cache: true
+      cache-mode: max
+      meta-images: ${{ needs.prepare.outputs.meta-images }}
+      meta-tags: ${{ needs.prepare.outputs.meta-tags }}
+      set-meta-labels: true
+      meta-labels: |
+        org.opencontainers.image.title=Datacube Explorer
+        org.opencontainers.image.description=Web-based exploration of Open Data Cube collections
+        org.opencontainers.image.vendor=Open Data Cube
+        org.opencontainers.image.licenses=Apache-2.0
+        org.opencontainers.image.source=https://github.com/opendatacube/datacube-explorer
+        org.opencontainers.image.url=https://github.com/opendatacube/datacube-explorer
+        org.opencontainers.image.documentation=https://datacube-explorer.readthedocs.io
+        org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
+      build-args: |
+        ENVIRONMENT=deployment
+        EXPLORER_VERSION=${{ needs.prepare.outputs.version }}
+        SOURCE_DATE_EPOCH=${{ needs.prepare.outputs.source-date-epoch }}
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-
-      - name: Get Git commit timestamps
-        run: |
-          TIMESTAMP=$(git log -1 --pretty=%ct pyproject.toml uv.lock cubedash)
-          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
-
-      - name: Get and log unstable git tag
-        if: github.event_name != 'release'
-        run: |
-          set -ex
-          UNSTABLE_TAG=$(git describe --tags)
-          echo "UNSTABLE_TAG=$UNSTABLE_TAG" >> $GITHUB_ENV
-          EXPLORER_VERSION=$(git describe --tags | sed 's#\-g#+g#')
-          echo "EXPLORER_VERSION=$EXPLORER_VERSION" >> $GITHUB_ENV
-
-      - name: Build and Push unstable + latest Docker image tag
-        if: github.event_name != 'release'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            ENVIRONMENT=deployment
-            EXPLORER_VERSION=${{ env.EXPLORER_VERSION }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-        env:
-          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
-
-      # This section is for releases
-      - name: Get and log tag for this build if it exists
-        if: github.event_name == 'release'
-        run: |
-          set -ex
-          RELEASE_VERSION=$(git describe --abbrev=0 --tags)
-          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
-
-      - name: Build and Push release if we have a tag
-        if: github.event_name == 'release'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        id: push
-        with:
-          context: .
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            ENVIRONMENT=deployment
-            EXPLORER_VERSION=${{ env.RELEASE_VERSION }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE_VERSION }}
-        env:
-          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
-
-      - name: Attest Docker image
-        if: github.event_name == 'release'
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.13.3@sha256:64250faf833c06d4b21afce4c27190039ba7ab58d70f0eebc87cf77d929c0b40 AS base
 
-LABEL org.opencontainers.image.source=https://github.com/opendatacube/datacube-explorer
-LABEL org.opencontainers.image.description="Datacube Explorer"
-LABEL org.opencontainers.image.licences="Apache-2.0"
+# See https://reproducible-builds.org/docs/source-date-epoch/
+ARG SOURCE_DATE_EPOCH=1704067200
+
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.13.3@sha256:64250faf833c06d4b21afce4c27190039ba7ab58d70f0eebc87cf77d929c0b40 AS base
 
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \


### PR DESCRIPTION
This updates and replaces the docker image build workflow in GitHub Actions. It uses the Docker GitHub Builder [1] reusable workflow, which makes it much easier to build multi-platform images efficiently in GHA across multiple runner architectures and then merge them, as well as better use of cache.

I've also updated the tags and labels that get applied to the image.

It should be backwards compatible, and maintain the semantics/versioning done by  setuptools-scm.

The expected **incompatible** change is to the `:latest` tag, which will now be applied to **released** versions, instead of development versions. This is inline with OWS and is the most common practice broadly.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1238.org.readthedocs.build/en/1238/

<!-- readthedocs-preview datacube-explorer end -->