### PR TITLE
Create safe_transform function during postgres schema update.

### DIFF
--- a/cubedash/index/postgres/_schema.py
+++ b/cubedash/index/postgres/_schema.py
@@ -392,6 +392,12 @@ def update_schema(conn: Connection) -> bool:
             "timestamp with time zone null",
         )
 
+        # Ensure the safe_transform function exists. It's created during initial
+        # schema creation (create_all), but databases initialised by older Explorer
+        # versions won't have it, so (re)create it here on update. It's idempotent
+        # (create or replace).
+        create_safe_transform_func(admin_conn, "agdc_admin")
+
         check_or_update_odc_schema(admin_conn)
 
     return refresh


### PR DESCRIPTION
## Summary
  
The `/stac/collections` endpoint fails on databases that were initialised by older versions of Explorer, with:
  
```
psycopg2.errors.UndefinedFunction: function cubedash.safe_transform(geometry, integer) does not exist
```
  
The `cubedash.safe_transform` PL/pgSQL function was only created in the postgres driver's `create_all()` (fresh initialisation path), not in `update_schema()`. As a result, upgrading an existing database never installed the function, and any query calling `cubedash.safe_transform(...)` (such as the one backing `/stac/collections`) failed.
  
## Changes

- Add `create_safe_transform_func(admin_conn, "agdc_admin")` to `update_schema()` in `cubedash/index/postgres/_schema.py`, inside the existing `agdc_admin` role block. The call uses `create or replace`, so it is idempotent and safe to run repeatedly.
- No change needed for the postgis driver: it already (re)creates the function on every init/update via `init_elements()` → `create_after_schema()`.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1243.org.readthedocs.build/en/1243/

<!-- readthedocs-preview datacube-explorer end -->