### PR TITLE
[docker/ci] Docker Image Builds (simplify/attestation/metadata)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,11 +34,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Compute version, tags and build epoch
+      - name: Compute version, tags and build epoch (setuptools-scm)
         id: meta
         run: |
           set -euo pipefail
-          VERSION="$(pipx run setuptools-scm)"
+
+          VERSION="$(pipx run --spec setuptools-scm==10.2.3 setuptools-scm)"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
           # Reproducible-build epoch: timestamp of the last commit that touched

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -114,3 +114,28 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  # Also do GitHub-native attestations for the pushed image
+  attest:
+    if: github.event_name == 'release'
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # create an OIDC token to sign the attestation
+      packages: write # push the attestation alongside the image in GHCR
+      attestations: write # write the attestation to the GitHub store
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest image provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          # Fully-qualified image name no tag
+          subject-name: ghcr.io/${{ github.repository_owner }}/explorer
+          subject-digest: ${{ needs.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,10 +11,6 @@ on:
   release:
     types: [published]
 
-env:
-  IMAGE_NAME: opendatacube/explorer
-  REGISTRY: ghcr.io
-
 permissions: {}
 
 # When a PR is updated, cancel the jobs from the previous version. Merges
@@ -24,18 +20,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Compute the git-describe based version/tags and reproducible-build epoch.
   prepare:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
-      # setuptools_scm-compatible version string passed as EXPLORER_VERSION build-arg.
       version: ${{ steps.meta.outputs.version }}
-      meta-tags: ${{ steps.meta.outputs.meta-tags }}
-      # Base image name (registry/repo, no tag) consumed as meta-images.
-      meta-images: ${{ steps.meta.outputs.meta-images }}
-      # Unix timestamp for reproducible builds (SOURCE_DATE_EPOCH build-arg).
       source-date-epoch: ${{ steps.meta.outputs.source-date-epoch }}
     steps:
       - name: Checkout git
@@ -48,63 +38,45 @@ jobs:
         id: meta
         run: |
           set -euo pipefail
-          echo "meta-images=${REGISTRY}/${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+          VERSION="$(pipx run setuptools-scm)"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
           # Reproducible-build epoch: timestamp of the last commit that touched
           # files which affect the built image.
           SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct -- pyproject.toml uv.lock cubedash)
           echo "source-date-epoch=${SOURCE_DATE_EPOCH}" >> "$GITHUB_OUTPUT"
 
-          if [ "${{ github.event_name }}" = "release" ]; then
-            # Released image: vN.N.N AND :latest
-            RELEASE_VERSION=$(git describe --abbrev=0 --tags)
-            VERSION="${RELEASE_VERSION}"
-            META_TAGS=$(printf '%s\n%s' \
-              "type=raw,value=${RELEASE_VERSION}" \
-              "type=raw,value=latest")
-          else
-            # Unstable (develop) build: full git describe tag only
-            UNSTABLE_TAG=$(git describe --tags)
-            # setuptools_scm compatible version string (replace -g with +g).
-            VERSION="${UNSTABLE_TAG/-g/+g}"
-            META_TAGS="type=raw,value=${UNSTABLE_TAG}"
-          fi
-          {
-            echo "version=${VERSION}"
-            echo "meta-tags<<EOF"
-            echo "${META_TAGS}"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
   # Build (and push) a combined linux/amd64 + linux/arm64
   # See https://docs.docker.com/build/ci/github-actions/github-builder/build/
   # for documentation on this docker maintained workflow.
   build:
     needs: prepare
-    uses: docker/github-builder/.github/workflows/build.yml@v1
+    uses: docker/github-builder/.github/workflows/build.yml@58cb9f5b71b1836d6f690c1e95effdeb9b98cb8a # v1.17.0
     permissions:
-      contents: read      # fetch the repository content
-      id-token: write     # sign attestations and cache entries via OIDC
-      packages: write     # push to GHCR
-      attestations: write # write the attestation storage record
+      contents: read # fetch the repository content
+      id-token: write # sign attestations and cache entries via OIDC
+      packages: write # push to GHCR
     with:
       output: image
       push: true
       platforms: linux/amd64,linux/arm64
-      cache: true
-      cache-mode: max
-      meta-images: ${{ needs.prepare.outputs.meta-images }}
-      meta-tags: ${{ needs.prepare.outputs.meta-tags }}
-      set-meta-labels: true
-      meta-labels: |
+      sbom: true
+      meta-images: ghcr.io/${{ github.repository_owner }}/explorer
+      meta-tags: |
+        type=ref,event=tag
+        type=ref,event=branch
+        type=pep440,pattern={{version}}
+        type=raw,value=${{ needs.prepare.outputs.version }},priority=650
+      meta-annotations: |
+        org.opencontainers.image.documentation=https://datacube-explorer.readthedocs.io/
+        org.opencontainers.image.base.name=ghcr.io/osgeo/gdal:ubuntu-small
         org.opencontainers.image.title=Datacube Explorer
-        org.opencontainers.image.description=Web-based exploration of Open Data Cube collections
-        org.opencontainers.image.vendor=Open Data Cube
-        org.opencontainers.image.licenses=Apache-2.0
-        org.opencontainers.image.source=https://github.com/opendatacube/datacube-explorer
-        org.opencontainers.image.url=https://github.com/opendatacube/datacube-explorer
-        org.opencontainers.image.documentation=https://datacube-explorer.readthedocs.io
-        org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
+      meta-labels: |
+        org.opencontainers.image.documentation=https://datacube-explorer.readthedocs.io/
+        org.opencontainers.image.base.name=ghcr.io/osgeo/gdal:ubuntu-small
+        org.opencontainers.image.title=Datacube Explorer
+      set-meta-labels: true
+      set-meta-annotations: true
       build-args: |
         ENVIRONMENT=deployment
         EXPLORER_VERSION=${{ needs.prepare.outputs.version }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -60,7 +60,7 @@ jobs:
           SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 
       - name: Run vulnerability scanner
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: "${{ env.IMAGE_NAME }}:${{ env.UNSTABLE_TAG }}"
           format: 'sarif'
@@ -70,6 +70,6 @@ jobs:
           severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 ---
-name: Tests
+name: Test and Release
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ ARG SOURCE_DATE_EPOCH=1704067200
 
 FROM ghcr.io/osgeo/gdal:ubuntu-small-3.13.3@sha256:64250faf833c06d4b21afce4c27190039ba7ab58d70f0eebc87cf77d929c0b40 AS base
 
+LABEL org.opencontainers.image.source=https://github.com/opendatacube/datacube-explorer
+LABEL org.opencontainers.image.description="Datacube Explorer"
+LABEL org.opencontainers.image.licences="Apache-2.0"
+LABEL org.opencontainers.image.title="Datacube Explorer"
+
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -70,7 +75,7 @@ ARG EXPLORER_VERSION=""
 RUN --mount=type=cache,id=opendatacube-uv-cache,target=/root/.cache \
     EXTRAS=$( ([ "$ENVIRONMENT" = "deployment" ] && echo "--extra=deployment --no-dev") || \
                  echo "--extra=test") \
-    && export SETUPTOOLS_SCM_PRETEND_VERSION="${EXPLORER_VERSION}" \
+    && export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DATACUBE_EXPLORER="${EXPLORER_VERSION}" \
     && uv sync --frozen $EXTRAS --no-editable \
     && ([ "$ENVIRONMENT" != "deployment" ] || \
         (chmod 644 /usr/local/bin/uv* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # See https://reproducible-builds.org/docs/source-date-epoch/
-ARG SOURCE_DATE_EPOCH=1704067200
+ARG SOURCE_DATE_EPOCH
 
 FROM ghcr.io/osgeo/gdal:ubuntu-small-3.13.3@sha256:64250faf833c06d4b21afce4c27190039ba7ab58d70f0eebc87cf77d929c0b40 AS base
 


### PR DESCRIPTION
I rushed a bit with  #1238. This should tidy most things up.

- Attestations are working again, but via `gh attestation verify` and `cosign verify-attestation`.
- SBOMs are included in the images.
- The GHA workflow is shorter/simpler.
- Remove the attempt at reproducible builds with SOURCE_DATE_EPOCH

- Use setuptools-scm cli to get the version number before image building.
- Remove ugly shell script that was generating metadata and replace
  with the templated configuration available from `docker/metadata-action`
  accessed via docker/github-builder.
- Add a GitHub Attestation step after image publishing, so that
  `gh attestation verify oci://ghcr.io/opendatacube/explorer:<tag> -R opendatacube/datacube-explorer`
  works again, and attestations show up in the GitHub UI.
- Embed SBOMs with the published images.
- **Change** Published Image tags now match that produced by setuptools-scm,
  previously, it was close but not the same.
- **Fix**: Before #1238, the images we published were leaking through metadata from the
  osgeo/gdal images we use as a base.
- Replace `LABEL`s in the `Dockerfile`, and only specify labels and annotations
  which are different to the default in the GitHub Actions workflow.


```
$ cosign verify-attestation --type slsaprovenance1 --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp '^https://github.com/omad/datacube-explorer.*' ghcr.io/omad/explorer:3.2.2.dev2-g15b90a5c6 | jq '.payload | @base64d | fromjson'

Verification for ghcr.io/omad/explorer:3.2.2.dev2-g15b90a5c6 --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
```
```json
{
  "_type": "https://in-toto.io/Statement/v1",
  "subject": [
    {
      "name": "ghcr.io/omad/explorer",
      "digest": {
        "sha256": "3297cf3f29aec7a30fe2e72545ba0fd2a957fa16ab18dea4868fbe4e1e61f7dd"
      }
    }
  ],
  "predicateType": "https://slsa.dev/provenance/v1",
  "predicate": {
    "buildDefinition": {
      "buildType": "https://actions.github.io/buildtypes/workflow/v1",
      "externalParameters": {
        "workflow": {
          "ref": "refs/heads/develop",
          "repository": "https://github.com/omad/datacube-explorer",
          "path": ".github/workflows/docker.yml"
        }
      },
      "internalParameters": {
        "github": {
          "event_name": "push",
          "repository_id": "215386971",
          "repository_owner_id": "108979",
          "runner_environment": "github-hosted"
        }
      },
      "resolvedDependencies": [
        {
          "uri": "git+https://github.com/omad/datacube-explorer@refs/heads/develop",
          "digest": {
            "gitCommit": "15b90a5c6a7573ba9eb57ff8b91de462a01788a4"
          }
        }
      ]
    },
    "runDetails": {
      "builder": {
        "id": "https://github.com/omad/datacube-explorer/.github/workflows/docker.yml@refs/heads/develop"
      },
      "metadata": {
        "invocationId": "https://github.com/omad/datacube-explorer/actions/runs/33842781793/attempts/1"
      }
    }
  }
}
```

```
gh attestation verify oci://ghcr.io/omad/explorer:3.2.1 -R omad/datacube-explorer
Loaded digest sha256:de08d70694ecbcbcd06720157fddace839e5f02e06501e1dad0dd91cb86e657a for oci://ghcr.io/omad/explorer:3.2.1
Loaded 1 attestation from GitHub API

The following policy criteria will be enforced:
- Predicate type must match:................ https://slsa.dev/provenance/v1
- Source Repository Owner URI must match:... https://github.com/omad
- Source Repository URI must match:......... https://github.com/omad/datacube-explorer
- Subject Alternative Name must match regex: (?i)^https://github\.com/omad/datacube-explorer/
- OIDC Issuer must match:................... https://token.actions.githubusercontent.com

✓ Verification succeeded!

The following 1 attestation matched the policy criteria

- Attestation #1
  - Build repo:..... omad/datacube-explorer
  - Build workflow:. .github/workflows/docker.yml@refs/tags/3.2.1
  - Signer repo:.... omad/datacube-explorer
  - Signer workflow: .github/workflows/docker.yml@refs/tags/3.2.1

```

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1246.org.readthedocs.build/en/1246/

<!-- readthedocs-preview datacube-explorer end -->