### PR TITLE
Dockerfile: reduce gunicorn timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,8 +127,6 @@ CMD ["gunicorn", \
      "--threads=2", \
      "-k", \
      "gthread", \
-     "--timeout", \
-     "90", \
      "--config", \
      "python:cubedash.gunicorn_config", \
      "cubedash.startup_utils:create_app()"]


### PR DESCRIPTION
Remove the timeout argument to gunicorn
so workers get killed after the default
value of 30 seconds of silence.

The people who have so large databases
that they need a larger timeout
are most likely already deploying
Explorer in custom ways, so this
change shouldn't affect them.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1253.org.readthedocs.build/en/1253/

<!-- readthedocs-preview datacube-explorer end -->