### PR TITLE
index: use ST_MakeValid

### DIFF
--- a/cubedash/index/postgis/_api.py
+++ b/cubedash/index/postgis/_api.py
@@ -319,7 +319,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
                 select srid_groups.product_ref,
                     coalesce(srid_groups.region_code, '')                          as region_code,
                     ST_SimplifyPreserveTopology(
-                            ST_Union(ST_Buffer(srid_groups.footprint, 0)), 0.0001) as footprint,
+                            ST_Union(ST_MakeValid(srid_groups.footprint)), 0.0001) as footprint,
                     sum(srid_groups.count)                                         as count
                 from srid_groups
                 group by srid_groups.product_ref, srid_groups.region_code
@@ -974,7 +974,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
                     func.array_agg(select_by_srid.c.srid).label("srids"),
                     func.sum(select_by_srid.c.size_bytes).label("size_bytes"),
                     func.ST_Union(
-                        func.ST_Buffer(select_by_srid.c.footprint_geometry, 0),
+                        func.ST_MakeValid(select_by_srid.c.footprint_geometry),
                         type_=Geometry(),
                     ).label("footprint_geometry"),
                     func.max(select_by_srid.c.newest_dataset_creation_time).label(

--- a/cubedash/index/postgres/_api.py
+++ b/cubedash/index/postgres/_api.py
@@ -370,7 +370,7 @@ class ExplorerIndex(ExplorerAbstractIndex):
                 select srid_groups.dataset_type_ref,
                     coalesce(srid_groups.region_code, '')                          as region_code,
                     ST_SimplifyPreserveTopology(
-                            ST_Union(ST_Buffer(srid_groups.footprint, 0)), 0.0001) as footprint,
+                            ST_Union(ST_MakeValid(srid_groups.footprint)), 0.0001) as footprint,
                     sum(srid_groups.count)                                         as count
                 from srid_groups
                 group by srid_groups.dataset_type_ref, srid_groups.region_code


### PR DESCRIPTION
The ST_Buffer(..., 0) is likely
used to make valid geometries,
but use the function that does
exactly that instead of using
some other way to induce the same
functionality.

<!-- readthedocs-preview datacube-explorer start -->
----
📚 Documentation preview 📚: https://datacube-explorer--1255.org.readthedocs.build/en/1255/

<!-- readthedocs-preview datacube-explorer end -->